### PR TITLE
Restarting frontend on deploy

### DIFF
--- a/deployments/template.yml
+++ b/deployments/template.yml
@@ -390,3 +390,6 @@ Outputs:
   WebApplicationCertificateArn:
     Description: ARN of the certificate used by the web application
     Value: !Ref WebApplicationCertificateArn
+  WebApplicationClusterName:
+    Description: ARN of the certificate used by the web application
+    Value: !Ref WebApplicationCluster


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Modified deploy script so that it restarts frontend (stopping Fargate tasks and waiting for ones to start running)

## Changes
> List your changes here in more detail

* Mage deploy will not stop running Frontend Fargate tasks and wait until new tasks are up and running

## Testing
> How did you test your change? 

* Deployed to my account, seen expected behavior. Verified in ECS console that old tasks were stopped and replaced with new ones

```
deploy: panther-buckets: no changes needed
build:lambda: go build internal/*/main (21 binaries)
deploy: cloudformation package deployments/template.yml => out/deployments/package.template.yml
deploy: s3://panther-source-123456789012-eu-west-1/layers/python-analysis.zip exists and is up to date
deploy: ACM certificate already exists
deploy: panther-app: CreateChangeSet: CREATE_PENDING
deploy: panther-app: CreateChangeSet: CREATE_IN_PROGRESS
deploy: panther-app: CreateChangeSet: CREATE_COMPLETE
deploy: panther-app: ExecuteChangeSet: UPDATE_IN_PROGRESS
deploy: panther-app: ExecuteChangeSet: UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
deploy: panther-app: ExecuteChangeSet: UPDATE_COMPLETE
Restarting frontend server...
Waiting for frontend server to become active
Finished restarting frontend

Panther URL = https://web-1820136089.eu-west-1.elb.amazonaws.com

```
