### PR TITLE
Updating Compliance onboarding page to populate Panther AWS Account ID

### DIFF
--- a/web/config/.env.development
+++ b/web/config/.env.development
@@ -1,11 +1,11 @@
 ##### This is the configuration for the development server ####
 
 NODE_ENV=production
-AWS_CLOUDFORMATION_S3_BUCKET=panther-dev-cloudformation-templates
-AWS_COGNITO_USER_POOL_ID=us-west-2_VCkN88uAA
-AWS_COGNITO_APP_CLIENT_ID=g7ked6h5q46hqpdb535lrbsqj
-AWS_CLOUDFORMATION_SERVICE_ROLE_NAME=PantherDevCFNServiceRole
-S3_BUCKET=dev.runpanther.info
-GRAPHQL_ENDPOINT=https://qakh2ks7efef5jm6npqhxrggiu.appsync-api.us-west-2.amazonaws.com/graphql
-AWS_REGION=us-west-2
-AWS_ACCOUNT_ID=770415837408
+AWS_CLOUDFORMATION_S3_BUCKET=
+AWS_COGNITO_USER_POOL_ID=
+AWS_COGNITO_APP_CLIENT_ID=
+AWS_CLOUDFORMATION_SERVICE_ROLE_NAME=
+S3_BUCKET=
+GRAPHQL_ENDPOINT=
+AWS_REGION=
+AWS_ACCOUNT_ID=

--- a/web/config/.env.local
+++ b/web/config/.env.local
@@ -1,8 +1,8 @@
 #### This is the configuration for local development ####
 
 NODE_ENV=development
-GRAPHQL_ENDPOINT=https://xxhovi4qlzai3ctjqwlvgdpzve.appsync-api.us-west-2.amazonaws.com/graphql
-AWS_REGION=us-west-2
-AWS_COGNITO_USER_POOL_ID=us-west-2_7JsQm1XNp
-AWS_COGNITO_APP_CLIENT_ID=7sp2nl4qto3lahbhqfo6lqighf
-AWS_ACCOUNT_ID=770415837408
+GRAPHQL_ENDPOINT=
+AWS_REGION=
+AWS_COGNITO_USER_POOL_ID=
+AWS_COGNITO_APP_CLIENT_ID=
+AWS_ACCOUNT_ID=

--- a/web/config/.env.production
+++ b/web/config/.env.production
@@ -1,14 +1,14 @@
 #### This is the configuration for the production server ####
 
-AWS_REGION=us-west-2
-NODE_ENV=production
-AWS_CLOUDFORMATION_S3_BUCKET=panther-prod-cloudformation-templates
-AWS_COGNITO_USER_POOL_ID=us-west-2_8IbrUHXlp
-AWS_COGNITO_APP_CLIENT_ID=3ptohhutp19gsa4mikfc8k56vo
-AWS_CLOUDFORMATION_SERVICE_ROLE_NAME=PantherProdCFNServiceRole
-GRAPHQL_ENDPOINT=https://nvhqfolanfb3rkstzqikhynr3u.appsync-api.us-west-2.amazonaws.com/graphql
-AWS_ACCOUNT_ID=891530560157
-S3_BUCKET=app.runpanther.io
-SENTRY_DSN=https://09a07ae9b7724f5aade2cacececb8212@sentry.io/1456280
-SENTRY_ORG=panther-labs
-SENTRY_PROJECT=prod-web-dashboard
+AWS_REGION=
+NODE_ENV=
+AWS_CLOUDFORMATION_S3_BUCKET=
+AWS_COGNITO_USER_POOL_ID=
+AWS_COGNITO_APP_CLIENT_ID=
+AWS_CLOUDFORMATION_SERVICE_ROLE_NAME=
+GRAPHQL_ENDPOINT=
+AWS_ACCOUNT_ID=
+S3_BUCKET=
+SENTRY_DSN=
+SENTRY_ORG=
+SENTRY_PROJECT=

--- a/web/config/.env.staging
+++ b/web/config/.env.staging
@@ -1,16 +1,16 @@
 #### This is the configuration for the staging server ####
 
-AWS_REGION=us-west-2
-AWS_REMEDIATION_MASTER_ACCOUNT=panther-aws-remediations-master-account
-AWS_REMEDIATION_SATELLITE_ACCOUNT=panther-aws-remediations-satellite-account
-NODE_ENV=production
-AWS_CLOUDFORMATION_S3_BUCKET=panther-stage-cloudformation-templates
-AWS_COGNITO_USER_POOL_ID=us-west-2_7JsQm1XNp
-AWS_COGNITO_APP_CLIENT_ID=7sp2nl4qto3lahbhqfo6lqighf
-AWS_CLOUDFORMATION_SERVICE_ROLE_NAME=PantherStageCFNServiceRole
-S3_BUCKET=staging.runpanther.xyz
-GRAPHQL_ENDPOINT=https://xxhovi4qlzai3ctjqwlvgdpzve.appsync-api.us-west-2.amazonaws.com/graphql
-AWS_ACCOUNT_ID=567780804328
-SENTRY_DSN=https://b8c06b145dc54aa58c0ba438c86538a2@sentry.io/1484175
-SENTRY_ORG=panther-labs
-SENTRY_PROJECT=staging-web-dashboard
+AWS_REGION=
+AWS_REMEDIATION_MASTER_ACCOUNT=
+AWS_REMEDIATION_SATELLITE_ACCOUNT=
+NODE_ENV=
+AWS_CLOUDFORMATION_S3_BUCKET=
+AWS_COGNITO_USER_POOL_ID=
+AWS_COGNITO_APP_CLIENT_ID=
+AWS_CLOUDFORMATION_SERVICE_ROLE_NAME=
+S3_BUCKET=
+GRAPHQL_ENDPOINT=
+AWS_ACCOUNT_ID=
+SENTRY_DSN=
+SENTRY_ORG=
+SENTRY_PROJECT=

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -103,8 +103,5 @@ export enum INTEGRATION_TYPES {
   AWS_INFRA = 'aws-scan',
 }
 
-export const PANTHER_AUDIT_ROLE = 'panther-compliance-iam';
-export const PANTHER_LOG_PROCESSING_ROLE = 'panther-log-processing-role';
-export const PANTHER_REAL_TIME = 'panther-cloudwatch-events';
 export const PANTHER_REMEDIATION_MASTER_ACCOUNT = 'panther-aws-remediations-master-account';
 export const PANTHER_REMEDIATION_SATELLITE_ACCOUNT = 'panther-aws-remediations-satellite-account';

--- a/web/src/pages/create-source/subcomponents/create-infra-source/subcomponents/resource-scanning-panel.tsx
+++ b/web/src/pages/create-source/subcomponents/create-infra-source/subcomponents/resource-scanning-panel.tsx
@@ -17,17 +17,14 @@
  */
 
 import { Button, Text, Flex, Box, Heading } from 'pouncejs';
-import { PANTHER_AUDIT_ROLE } from 'Source/constants';
 import React from 'react';
 
-// Super important for all these links to have no space or indents in each new line
-// The params for the cloudformation are passed in via query parameters using param_<Param_Name>
-export const scanningCloudformationLink = `https://${process.env.AWS_REGION}.console.aws.amazon.com/cloudformation/home?\
-region=${process.env.AWS_REGION}#/stacks/create/review?templateURL=https://s3-us-west-2.amazonaws.com/\
-panther-public-cloudformation-templates/${PANTHER_AUDIT_ROLE}/latest/template.yml&\
-stackName=${PANTHER_AUDIT_ROLE}`;
-
-const ResournceScanningPanel: React.FC = () => {
+const ResourceScanningPanel: React.FC = () => {
+  const cfnConsoleLink =
+    `https://${process.env.AWS_REGION}.console.aws.amazon.com/cloudformation/home?region=${process.env.AWS_REGION}#/stacks/create/review` +
+    `?templateURL=https://s3-us-west-2.amazonaws.com/panther-public-cloudformation-templates/panther-compliance-iam/latest/template.yml` +
+    `&stackName=panther-compliance-iam-roles` +
+    `&param_MasterAccountId=${process.env.AWS_ACCOUNT_ID}`;
   return (
     <Box>
       <Heading size="medium" m="auto" mb={10} color="grey400">
@@ -57,7 +54,7 @@ const ResournceScanningPanel: React.FC = () => {
           is="a"
           target="_blank"
           rel="noopener noreferrer"
-          href={scanningCloudformationLink}
+          href={cfnConsoleLink}
         >
           Launch Stack
         </Button>
@@ -66,4 +63,4 @@ const ResournceScanningPanel: React.FC = () => {
   );
 };
 
-export default ResournceScanningPanel;
+export default ResourceScanningPanel;


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

We now auto-populate Panther AWS Account ID in the Compliance CFN template

## Changes
> List your changes here in more detail
I have followed the style of the [log onboarding page](https://github.com/panther-labs/panther/blob/master/web/src/pages/create-source/subcomponents/create-log-source/subcomponents/cfn-launch-panel.tsx). 
* We now auto-populate Panther AWS Account ID in the Compliance IAM roles CFN template
* Removed unused constants
* Changed stack name to `panther-compliance-iam-roles`
* Small style changes - following style of log onboarding page
* Removing configuration values that should be no longer in the project

### Testing
Ran UI locally with `npm run dev`. 
Tried the Wizard and it automatically populated the Panther AWS Account ID

Once this is merged, I'm going to update the onboarding documentation