### PR TITLE
Handling S3 Test events

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -37,6 +37,10 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/common"
 )
 
+const (
+	s3TestEvent = "s3:TestEvent"
+)
+
 // ReadSQSMessages reads incoming messages containing SNS notifications and returns a slice of DataStream items
 func ReadSQSMessages(messages []events.SQSMessage) (result []*common.DataStream, err error) {
 	zap.L().Debug("reading data for messages", zap.Int("numMessages", len(messages)))
@@ -187,7 +191,7 @@ func ParseNotification(message string) ([]*S3ObjectInfo, error) {
 		return nil, err
 	}
 
-	// If the input was not a CloudTrail notification, the result will be empty slice
+	// If the input was not a CloudTrail notification, s3Objects will be empty slice
 	if len(s3Objects) == 0 {
 		s3Objects, err = parseS3Event(message)
 		if err != nil {
@@ -195,7 +199,13 @@ func ParseNotification(message string) ([]*S3ObjectInfo, error) {
 		}
 	}
 
+	// If the input was not an S3 event notification, s3Objects will be empty slice
+
 	if len(s3Objects) == 0 {
+		// If it is an S3 test event, return an empty array. There are no S3 objects to process
+		if isTestS3Event(message) {
+			return []*S3ObjectInfo{}, nil
+		}
 		return nil, errors.New("notification is not of known type: " + message)
 	}
 	return s3Objects, nil
@@ -239,6 +249,16 @@ func parseS3Event(message string) (result []*S3ObjectInfo, err error) {
 		result = append(result, info)
 	}
 	return result, nil
+}
+
+// The method returns true if the received event is an S3 Test event
+func isTestS3Event(message string) bool {
+	notification := &events.S3TestEvent{}
+	err := jsoniter.UnmarshalFromString(message, notification)
+	if err != nil {
+		return false
+	}
+	return notification.Event == s3TestEvent
 }
 
 // cloudTrailNotification is the notification sent by CloudTrail whenever it delivers a new log file to S3

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -200,7 +200,6 @@ func ParseNotification(message string) ([]*S3ObjectInfo, error) {
 	}
 
 	// If the input was not an S3 event notification, s3Objects will be empty slice
-
 	if len(s3Objects) == 0 {
 		// If it is an S3 test event, return an empty array. There are no S3 objects to process
 		if isTestS3Event(message) {

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -59,3 +59,13 @@ func TestParseS3Notification(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, s3Objects)
 }
+
+func TestParseTestS3Notification(t *testing.T) {
+	//nolint:lll
+	notification := "{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\",\"Time\":\"2020-01-21T14:17:54.420Z\",\"Bucket\":\"test-bucket\"," +
+		"\"RequestId\":\"0D79B9C057838DEA\",\"HostId\":\"6HTLml3u1UbsYgjuzueCQApRHOfpRM5yJ+nTZCveOMejyM7iB4Pg8RESbVAU5nHjduW+QoeK+UA=\"}"
+
+	s3Objects, err := ParseNotification(notification)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(s3Objects))
+}


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

When a user sets up S3 Event notifications, S3 sends a test event to verify that it has permissions to send messages to the topic. 
I modified the log processor code to handle these events

## Changes
> List your changes here in more detail

* Updated code to handle S3 Test events

## Testing
> How did you test your change? 

* Unit test
* Deployed change and seen log processor handle the case gracefully.
