### PR TITLE
Handling CloudTral validation messages

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -69,3 +69,18 @@ func TestParseTestS3Notification(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(s3Objects))
 }
+
+func TestParseCloudTrailValidationMessage(t *testing.T) {
+	notification := "CloudTrail validation message."
+
+	s3Objects, err := ParseNotification(notification)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(s3Objects))
+}
+
+func TestParseUnknownMessage(t *testing.T) {
+	notification := "Unknown message"
+
+	_, err := ParseNotification(notification)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

When a user sets up CloudTrail SNS notifications, CloudTrail sends a message to the SNS topic to verify it has permissions to deliver notifications.
We need to be able to handle this gracefully

## Changes
> List your changes here in more detail

* If event is a CloudTrail validation message, we are now handling it gracefully
* More appropriate error handling when parsing notifications - we now try all scenarios when trying to parse a notification before returning an error 

## Testing
> How did you test your change? 

* Unit testing (uncovered the issue with parsing error handling)
* Deployed and verified it works. 
