### PR TITLE
Fixing rules engine

### DIFF
--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -48,7 +48,7 @@ def lambda_handler(event: Dict[str, Any], unused_context) -> None:
     for log_type, data_streams in log_type_to_data.items():
         for data_stream in data_streams:
             for data in data_stream:
-                for matched_rule in rules_engine.analyze(log_type, data):
+                for matched_rule in rules_engine.analyze(log_type, json.loads(data)):
                     matched.append((matched_rule, data))
 
     if len(matched) > 0:


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

The rules expect that the events are Dict - we currently were passing the raw strings and the pre-canned rules were failing. 


## Changes
> List your changes here in more detail

* Parsing the string to Dict - Rules Engine input will always be JSON

## Testing
> How did you test your change? 

* Deployed and verified rules are actually running on data. 
