### PR TITLE
Fixing email delivery

### DIFF
--- a/deployments/core/outputs.yml
+++ b/deployments/core/outputs.yml
@@ -81,30 +81,21 @@ Parameters:
     Default: 300  # 5 mins
     MinValue: 1
     MaxValue: 86400  # 1 day
-  MailFrom:
-    Type: String
-    Description: The email address that will appear in the 'MAIL FROM' field when Panther sends alert email to customers
-    Default: alerts@runpanther.io
   AlertSqsRetentionSec:
     Type: Number
     Description: Number of seconds SQS will retain a message in the alerts queue
     Default: 259200  # 3 days
     MinValue: 60
     MaxValue: 1209600
-  EmailVerificationTemplate:
-    Type: String
-    Description: The name of the SES template used for verifying emails
-    Default: EmailVerificationTemplate
-  SesConfigurationSet:
-    Type: String
-    Description: The name of the SES Configuration set that will be used when sending emails
-    Default: PantherConfigurationSet
   AppFqdn:
     Type: String
     Description: FQDN for the Panther web app (e.g. 1.2.3.4 or app.runpanther.io)
   SQSKeyId:
     Type: String
     Description: KMS key ID for SQS encryption
+  EmailAlertsFromAddress:
+    Type: String
+    Description: The email address that will appear in the 'MAIL FROM' field when Panther sends alert email to customers
 
 Conditions:
   AttachLayers: !Not [!Equals [!Join ['', !Ref LayerVersionArns], '']]
@@ -184,9 +175,7 @@ Resources:
           OUTPUTS_TABLE_NAME: !Ref OutputsTable
           OUTPUTS_DISPLAY_NAME_INDEX_NAME: displayName-index
           DEFAULTS_TABLE_NAME: !Ref DefaultOutputsTable
-          EMAIL_VERIFICATION_TEMPLATE: !Ref EmailVerificationTemplate
-          SES_CONFIGURATION_SET: !Ref SesConfigurationSet
-          USERS_API: panther-users-api
+          MAIL_FROM: !Ref EmailAlertsFromAddress
       FunctionName: panther-outputs-api
       Handler: main
       Layers: !If [AttachLayers, !Ref LayerVersionArns, !Ref 'AWS::NoValue']
@@ -235,14 +224,6 @@ Resources:
                 - ses:SendCustomVerificationEmail
                 - ses:VerifyEmailAddress
               Resource: '*'
-        -
-          Id: UsersAPI
-          Version: 2012-10-17
-          Statement:
-            -
-              Effect: Allow
-              Action: lambda:InvokeFunction
-              Resource: !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-users-api'
 
   ApiLogGroup:
     Type: AWS::Logs::LogGroup
@@ -269,13 +250,12 @@ Resources:
           ALERT_QUEUE_URL: !Ref AlertQueue
           ALERT_RETRY_DURATION_MINS: !Ref AlertRetryDurationMins
           ALERT_URL_PREFIX : !Sub https://${AppFqdn}/alerts/
-          MAIL_FROM: !Ref MailFrom
+          MAIL_FROM: !Ref EmailAlertsFromAddress
           MAX_RETRY_DELAY_SECS: !Ref MaxRetryDelaySecs
           MIN_RETRY_DELAY_SECS: !Ref MinRetryDelaySecs
           OUTPUTS_API: panther-outputs-api
           OUTPUTS_REFRESH_INTERVAL_MIN: '5'
           POLICY_URL_PREFIX: !Sub https://${AppFqdn}/policies/
-          SES_CONFIGURATION_SET : !Ref SesConfigurationSet
       Events:
         AlertQueue:
           Type: SQS
@@ -307,7 +287,7 @@ Resources:
               Resource: '*'
               Condition:
                 StringLike:
-                  'ses:FromAddress': !Ref MailFrom
+                  'ses:FromAddress': !Ref EmailAlertsFromAddress
         -
           Id: PublishSnsMessage
           Version: 2012-10-17

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -47,6 +47,13 @@ AppParameterValues:
   # PROVIDE A CERTIFICATE FOR PRODUCTION USE
   WebApplicationCertificateArn: ''
 
+
+  # Email address that will be used as the source for sending email alerts
+  #
+  # If not specified, the user will be prompted for the address during the first setup
+  # Specify only email addresses that you have verified through SES
+  EmailAlertsFromAddress: ''
+
   # XRay tracing mode for API Gateway and Lambda: '', 'Active', or 'PassThrough'
   TracingMode: ''
 

--- a/deployments/template.yml
+++ b/deployments/template.yml
@@ -57,6 +57,11 @@ Parameters:
     Type: String
     Description: The ARN of the TLS certificate that is going to be used by the web application
 
+  # Set automatically by "mage deploy" unless specified in panther_config
+  EmailAlertsFromAddress:
+    Type: String
+    Description: The email address that will be used as the source of email alerts
+
 Conditions:
   CreatePythonLayer: !Equals [!Ref PythonLayerVersionArn, '']
 
@@ -183,6 +188,7 @@ Resources:
 
         AppFqdn: !GetAtt WebApplicationLoadBalancer.Outputs.LoadBalancerUrl
         SQSKeyId: !Ref QueueEncryptionKey
+        EmailAlertsFromAddress: !Ref EmailAlertsFromAddress
       TemplateURL: core/outputs.yml
 
   AdminAPI:
@@ -390,3 +396,7 @@ Outputs:
   WebApplicationCertificateArn:
     Description: ARN of the certificate used by the web application
     Value: !Ref WebApplicationCertificateArn
+  EmailAlertsFromAddress:
+    Description: The email address that will be used as the source of email alerts
+    Value: !Ref EmailAlertsFromAddress
+

--- a/internal/core/alert_delivery/outputs/email.go
+++ b/internal/core/alert_delivery/outputs/email.go
@@ -20,7 +20,6 @@ package outputs
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -34,8 +33,6 @@ const emailTemplate = "<h2>Message</h2>%s<br>" +
 	"<h2>Severity</h2>%s<br>" +
 	"<h2>Runbook</h2>%s<br>" +
 	"<h2>Description</h2>%s"
-
-var sesConfigurationSet = os.Getenv("SES_CONFIGURATION_SET")
 
 func generateEmailContent(alert *alertmodels.Alert) *string {
 	messageField := fmt.Sprintf("<a href='%s'>%s</a>",
@@ -53,9 +50,8 @@ func generateEmailContent(alert *alertmodels.Alert) *string {
 // Email sends email to destination
 func (client *OutputClient) Email(alert *alertmodels.Alert, config *outputmodels.EmailConfig) *AlertDeliveryError {
 	emailInput := &ses.SendEmailInput{
-		ConfigurationSetName: aws.String(sesConfigurationSet),
-		Source:               client.mailFrom,
-		Destination:          &ses.Destination{ToAddresses: []*string{config.DestinationAddress}},
+		Source:      client.mailFrom,
+		Destination: &ses.Destination{ToAddresses: []*string{config.DestinationAddress}},
 		Message: &ses.Message{
 			Subject: &ses.Content{
 				Charset: aws.String("UTF-8"),

--- a/internal/core/alert_delivery/outputs/email_test.go
+++ b/internal/core/alert_delivery/outputs/email_test.go
@@ -58,7 +58,6 @@ func (m *mockSesClient) SendEmail(input *ses.SendEmailInput) (*ses.SendEmailOutp
 func init() {
 	policyURLPrefix = "https://panther.io/policies/"
 	alertURLPrefix = "https://panther.io/alerts/"
-	sesConfigurationSet = "sesConfigurationSet"
 }
 
 func TestSendEmail(t *testing.T) {
@@ -66,9 +65,8 @@ func TestSendEmail(t *testing.T) {
 	outputClient := &OutputClient{sesClient: client, mailFrom: aws.String("email@email.com")}
 
 	expectedEmailInput := &ses.SendEmailInput{
-		ConfigurationSetName: aws.String("sesConfigurationSet"),
-		Source:               aws.String("email@email.com"),
-		Destination:          &ses.Destination{ToAddresses: []*string{aws.String("destinationAddress")}},
+		Source:      aws.String("email@email.com"),
+		Destination: &ses.Destination{ToAddresses: []*string{aws.String("destinationAddress")}},
 		Message: &ses.Message{
 			Subject: &ses.Content{
 				Charset: aws.String("UTF-8"),
@@ -106,9 +104,8 @@ func TestSendEmailRule(t *testing.T) {
 	}
 
 	expectedEmailInput := &ses.SendEmailInput{
-		ConfigurationSetName: aws.String("sesConfigurationSet"),
-		Source:               aws.String("email@email.com"),
-		Destination:          &ses.Destination{ToAddresses: []*string{aws.String("destinationAddress")}},
+		Source:      aws.String("email@email.com"),
+		Destination: &ses.Destination{ToAddresses: []*string{aws.String("destinationAddress")}},
 		Message: &ses.Message{
 			Subject: &ses.Content{
 				Charset: aws.String("UTF-8"),

--- a/internal/core/outputs_api/verification/get_verification_status.go
+++ b/internal/core/outputs_api/verification/get_verification_status.go
@@ -19,17 +19,26 @@ package verification
  */
 
 import (
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
 
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
+	"github.com/panther-labs/panther/pkg/genericapi"
 )
+
+var emailFromAddress = os.Getenv("MAIL_FROM")
 
 // GetVerificationStatus returns the verification status of an email address
 func (verification *OutputVerification) GetVerificationStatus(input *models.AlertOutput) (*string, error) {
 	if *input.OutputType != "email" {
 		result := models.VerificationStatusSuccess
 		return &result, nil
+	}
+
+	if emailFromAddress == "" {
+		return nil, &genericapi.InvalidInputError{Message:"Cannot add email destination. You need to configure an email that will be used as source email"}
 	}
 
 	// Check SES to see if it has been verified already

--- a/internal/core/outputs_api/verification/verification.go
+++ b/internal/core/outputs_api/verification/verification.go
@@ -19,8 +19,6 @@ package verification
  */
 
 import (
-	"os"
-
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
@@ -30,11 +28,6 @@ import (
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
 )
 
-var (
-	emailVerificationTemplate = os.Getenv("EMAIL_VERIFICATION_TEMPLATE")
-	sesConfigurationSet       = os.Getenv("SES_CONFIGURATION_SET")
-	usersAPI                  = os.Getenv("USERS_API")
-)
 
 // OutputVerificationAPI defines the interface for the outputs table which can be used for mocking.
 type OutputVerificationAPI interface {

--- a/internal/core/outputs_api/verification/verify_output.go
+++ b/internal/core/outputs_api/verification/verify_output.go
@@ -19,26 +19,35 @@ package verification
  */
 
 import (
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
+	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
 // VerifyOutput performs verification on a AlertOutput
 // Note that in case the output is not an email, no action is performed.
 // In case it is an email, we use SES's email verification mechanism.
+
+var emailFromAddress = os.Getenv("MAIL_FROM")
+
 func (verification *OutputVerification) VerifyOutput(input *models.AlertOutput) (*models.AlertOutput, error) {
 	if *input.OutputType != "email" {
 		return input, nil
 	}
-	request := &ses.SendCustomVerificationEmailInput{
-		EmailAddress:         input.OutputConfig.Email.DestinationAddress,
-		ConfigurationSetName: aws.String(sesConfigurationSet),
-		TemplateName:         aws.String(emailVerificationTemplate),
+
+	if emailFromAddress == "" {
+		return nil, &genericapi.InvalidInputError{Message:"Cannot add email destination. You need to configure an email that will be used as source email"}
 	}
-	response, err := verification.sesClient.SendCustomVerificationEmail(request)
+
+	request := &ses.VerifyEmailIdentityInput{
+		EmailAddress: input.OutputConfig.Email.DestinationAddress,
+	}
+	response, err := verification.sesClient.VerifyEmailIdentity(request)
 
 	if err != nil {
 		return nil, err

--- a/internal/core/outputs_api/verification/verify_output.go
+++ b/internal/core/outputs_api/verification/verify_output.go
@@ -19,29 +19,22 @@ package verification
  */
 
 import (
-	"os"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
-	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
 // VerifyOutput performs verification on a AlertOutput
 // Note that in case the output is not an email, no action is performed.
 // In case it is an email, we use SES's email verification mechanism.
 
-var emailFromAddress = os.Getenv("MAIL_FROM")
+
 
 func (verification *OutputVerification) VerifyOutput(input *models.AlertOutput) (*models.AlertOutput, error) {
 	if *input.OutputType != "email" {
 		return input, nil
-	}
-
-	if emailFromAddress == "" {
-		return nil, &genericapi.InvalidInputError{Message:"Cannot add email destination. You need to configure an email that will be used as source email"}
 	}
 
 	request := &ses.VerifyEmailIdentityInput{

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -152,12 +152,20 @@ func getDeployParams(awsSession *session.Session, config *PantherConfig, bucket 
 		result["PythonLayerObjectVersion"] = version
 	}
 
-	if result["WebApplicationCertificateArn"] == "" {
+	if result[certificateOutputKey] == "" {
 		certificateArn, err := uploadLocalCertificate(awsSession)
 		if err != nil {
 			return nil, err
 		}
-		result["WebApplicationCertificateArn"] = certificateArn
+		result[certificateOutputKey] = certificateArn
+	}
+
+	if result[emailAlertsFromAddressOutputsKey] == "" {
+		emailAddress, err := getEmailAddress(awsSession)
+		if err != nil {
+			return nil, err
+		}
+		result[emailAlertsFromAddressOutputsKey] = emailAddress
 	}
 
 	return result, nil

--- a/tools/mage/deploy_email.go
+++ b/tools/mage/deploy_email.go
@@ -1,0 +1,87 @@
+package mage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+)
+
+const (
+	emailAlertsFromAddressOutputsKey = "EmailAlertsFromAddress"
+)
+
+func getEmailAddress(awsSession *session.Session) (string, error) {
+	// Check if certificate has already been uploaded
+	emailAddress, err := getExistingEmailAddress(awsSession)
+	if err != nil {
+		return "", err
+	}
+
+	if emailAddress != "" {
+		return emailAddress, nil
+	}
+
+
+	sesClient := ses.New(awsSession)
+
+	emailInput := promptUser("Enter email that will be used as alert source address. Empty string if you don't want to configure one: ", optionalEmailValidator)
+	if emailInput == "" {
+		return "", nil
+	}
+
+	isAlreadyVerified, err  := isAddressAlreadyVerified(sesClient, emailInput)
+
+	if !isAlreadyVerified {
+		_, err  = sesClient.VerifyEmailIdentity(&ses.VerifyEmailIdentityInput{EmailAddress: aws.String(emailInput)})
+		if err != nil {
+			return "", err
+		}
+	}
+
+	fmt.Printf("Check [%s] inbox to verify your email\n", emailInput)
+	return emailInput, nil
+}
+
+func isAddressAlreadyVerified(sesClient *ses.SES, email string) (bool, error) {
+	// Check SES to see if it has been verified already
+	request := &ses.GetIdentityVerificationAttributesInput{
+		Identities: aws.StringSlice([]string{email}),
+	}
+	response, err := sesClient.GetIdentityVerificationAttributes(request)
+	if err != nil {
+		return false, err
+	}
+	verificationStatusAttributes := response.VerificationAttributes[email]
+	if verificationStatusAttributes == nil {
+		return false, nil
+	}
+
+	return *verificationStatusAttributes.VerificationStatus == ses.VerificationStatusSuccess, nil
+}
+
+func optionalEmailValidator(input string) error {
+	if input == "" {
+		return nil
+	}
+	return emailValidator(input)
+}
+
+func getExistingEmailAddress(awsSession *session.Session) (string, error) {
+	outputs, err := getStackOutputs(awsSession, applicationStack)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() != "ValidationError" || !strings.HasSuffix(awsErr.Code(), "does not exist") {
+				return "", nil
+			}
+		}
+		return "", err
+	}
+	if arn, ok := outputs[emailAlertsFromAddressOutputsKey]; ok {
+		return arn, nil
+	}
+	return "", nil
+}

--- a/tools/mage/util.go
+++ b/tools/mage/util.go
@@ -19,6 +19,7 @@ package mage
  */
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -94,21 +95,19 @@ func uploadFileToS3(
 func promptUser(prompt string, validator func(string) error) string {
 	var result string
 
-	for {
-		fmt.Print(prompt)
-		if _, err := fmt.Scanln(&result); err != nil {
-			fmt.Println(err) // empty line, for example
-			continue
-		}
-
-		result = strings.TrimSpace(result)
+	fmt.Print(prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan(){
+		result = strings.TrimSpace(scanner.Text())
 		if err := validator(result); err != nil {
 			fmt.Println(err)
+			fmt.Print(prompt)
 			continue
 		}
-
 		return result
 	}
+
+	return result
 }
 
 // Ensure non-empty strings.


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Fixing email delivery

## Changes
> List your changes here in more detail

* During setup we ask now the user what email should be used as the source email for delivering alerts (the Mail-From header). The prompt looks like the following: 
```
 aws-vault exec dev-kostas-admin -- mage deploy
Enter token for arn:aws:iam::123456789012:mfa/kostas_papageorgiou: ******
deploy: panther-buckets: no changes needed
build:lambda: go build internal/*/main (21 binaries)
deploy: cloudformation package deployments/template.yml => out/deployments/package.template.yml
deploy: s3://panther-source-123456789012-eu-west-1/layers/python-analysis.zip exists and is up to date
deploy: ACM certificate already exists
Enter email that will be used as alert source address. Empty string if you don't want to configure one: kostas@runpanther.io
Check [kostas@runpanther.io] inbox to verify your email
deploy: panther-app: CreateChangeSet: CREATE_PENDING
deploy: panther-app: CreateChangeSet: CREATE_COMPLETE
deploy: panther-app: ExecuteChangeSet: UPDATE_IN_PROGRESS
deploy: panther-app: ExecuteChangeSet: UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
deploy: panther-app: ExecuteChangeSet: UPDATE_COMPLETE

Panther URL = https://web-1820136089.eu-west-1.elb.amazonaws.com
```
or for empty email
```
Enter token for arn:aws:iam::948584460855:mfa/kostas_papageorgiou: 212648
deploy: panther-buckets: no changes needed
build:lambda: go build internal/*/main (21 binaries)
deploy: cloudformation package deployments/template.yml => out/deployments/package.template.yml
deploy: s3://panther-source-415773754570-eu-west-1/layers/python-analysis.zip exists and is up to date
deploy: ACM certificate already exists
Enter email that will be used as alert source address. Empty string if you don't want to configure one: 
deploy: panther-app: CreateChangeSet: CREATE_PENDING
deploy: panther-app: CreateChangeSet: CREATE_IN_PROGRESS
deploy: panther-app: CreateChangeSet: CREATE_COMPLETE
deploy: panther-app: ExecuteChangeSet: UPDATE_IN_PROGRESS
...
```

* If user hasn't configured an email address that will be used for sending email alerts, adding an email alert will fail with an explanatory error. 

![Screen Shot 2020-01-21 at 8 01 14 PM](https://user-images.githubusercontent.com/2652630/72834316-d2ea2300-3c88-11ea-8482-5aa315bd16b1.png)



## Testing
> How did you test your change? 

* Deployed locally and verified above behavior
* Still need to make the code "pretty"