### PR TITLE
Properly emit glue table columns for composed Go structs 

### DIFF
--- a/tools/cfngen/gluecf/schema.go
+++ b/tools/cfngen/gluecf/schema.go
@@ -101,7 +101,7 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 	if fieldName == "" {
 		fieldName = sf.Name
 	}
-	
+
 	switch t.Kind() { // NOTE: not all possible nestings have been implemented
 	case reflect.Slice:
 

--- a/tools/cfngen/gluecf/schema.go
+++ b/tools/cfngen/gluecf/schema.go
@@ -49,14 +49,22 @@ func InferJSONColumns(obj interface{}, customMappings ...CustomMapping) (cols []
 		objType = objType.Elem()
 	}
 
-	for i := 0; i < objType.NumField(); i++ {
-		fieldName, jsonType, skip := inferStructFieldType(objType.Field(i), customMappingsTable)
-		if skip {
-			continue
-		}
-		cols = append(cols, Column{Name: fieldName, Type: jsonType})
-	}
+	return inferJSONColumns(objType, customMappingsTable)
+}
 
+func inferJSONColumns(t reflect.Type, customMappingsTable map[string]string) (cols []Column) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous { // if composing a struct, treat fields as part of this struct
+			cols = append(cols, inferJSONColumns(field.Type, customMappingsTable)...)
+		} else {
+			fieldName, jsonType, skip := inferStructFieldType(field, customMappingsTable)
+			if skip {
+				continue
+			}
+			cols = append(cols, Column{Name: fieldName, Type: jsonType})
+		}
+	}
 	return cols
 }
 
@@ -93,7 +101,7 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 	if fieldName == "" {
 		fieldName = sf.Name
 	}
-
+	
 	switch t.Kind() { // NOTE: not all possible nestings have been implemented
 	case reflect.Slice:
 
@@ -120,7 +128,12 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 			return
 		}
 
-		jsonType = fmt.Sprintf("struct<%s>", inferStruct(t, customMappingsTable))
+		if sf.Anonymous { // composed struct, fields part of enclosing struct
+			fieldName = ""
+			jsonType = inferStruct(t, customMappingsTable)
+		} else {
+			jsonType = fmt.Sprintf("struct<%s>", inferStruct(t, customMappingsTable))
+		}
 		return
 
 	default:
@@ -145,7 +158,10 @@ func inferStruct(structType reflect.Type, customMappingsTable map[string]string)
 		if subFieldSkip {
 			continue
 		}
-		keyPairs = append(keyPairs, subFieldName+":"+subFieldJSONType)
+		if subFieldName != "" {
+			subFieldName += ":"
+		}
+		keyPairs = append(keyPairs, subFieldName+subFieldJSONType)
 	}
 	return strings.Join(keyPairs, ",")
 }


### PR DESCRIPTION
Properly emit Glue table columns for composed Go structs (will be used for panther standard fields)

## Background
So we can define log events with Panther standard fields via composition.

Future PRs will include usage with log processing.

Looks like:
```
type VPCFlow struct {
	Version     *int               `json:"version,omitempty" validate:"required"`
	Account     *string            `json:"account,omitempty" validate:"omitempty,len=12,numeric"`
	InterfaceID *string            `json:"interfaceId,omitempty"`
	SourceAddr  *string            `json:"sourceAddr,omitempty"`
	DstAddr     *string            `json:"dstAddr,omitempty"`
	SrcPort     *int               `json:"srcPort,omitempty" validate:"omitempty,min=0,max=65535"`
	DstPort     *int               `json:"destPort,omitempty" validate:"omitempty,min=0,max=65535"`
	Protocol    *int               `json:"protocol,omitempty"`
	Packets     *int               `json:"packets,omitempty"`
	Bytes       *int               `json:"bytes,omitempty"`
	Start       *timestamp.RFC3339 `json:"start,omitempty" validate:"required"`
	End         *timestamp.RFC3339 `json:"end,omitempty" validate:"required"`
	Action      *string            `json:"action,omitempty" validate:"omitempty,oneof=ACCEPT REJECT"`
	LogStatus   *string            `json:"status,omitempty" validate:"oneof=OK NODATA SKIPDATA"`

	// NOTE: added to end of struct to allow expansion later
	common.PantherLog
}
```


## Testing
mage test:unit
deploy in dev account with pending changes for standard fields.
