### PR TITLE
Adding public templates

### DIFF
--- a/deployments/auxiliary/README.md
+++ b/deployments/auxiliary/README.md
@@ -1,0 +1,6 @@
+# Panther's Auxiliary Deployment Files
+A collection of files used to create auxiliary infrastructure in support of a panther deployment.
+
+## Formats
+  - CloudFormation: Deploy AWS Infrastructure with AWS CloudFormation templates
+  - Terraform: Deploy infrastructure with Hashicorp Terraform templates (coming soon!)

--- a/deployments/auxiliary/README.md
+++ b/deployments/auxiliary/README.md
@@ -3,4 +3,4 @@ A collection of files used to create auxiliary infrastructure in support of a pa
 
 ## Formats
   - CloudFormation: Deploy AWS Infrastructure with AWS CloudFormation templates
-  - Terraform: Deploy infrastructure with Hashicorp Terraform templates (coming soon!)
+  - Terraform: Deploy infrastructure with Terraform templates (coming soon!)

--- a/deployments/auxiliary/cloudformation/README.md
+++ b/deployments/auxiliary/cloudformation/README.md
@@ -1,5 +1,5 @@
 # Panther's CloudFormation Templates
-A collection of CloudFormation Templates to interact with Panther.
+A collection of CloudFormation templates to configure data collection and remediation with multiple satellite accounts.
 
 ## Templates
 

--- a/deployments/auxiliary/cloudformation/README.md
+++ b/deployments/auxiliary/cloudformation/README.md
@@ -1,0 +1,13 @@
+# Panther's CloudFormation Templates
+A collection of CloudFormation Templates to interact with Panther.
+
+## Templates
+
+* `panther-aws-compliance-iam`: The IAM Roles used in conjunction with the compliance features.
+* `panther-aws-remediations-master-account`: The Serverless Application and IAM Role used for Automatic Remediation deployed in the master account.
+* `panther-aws-remediations-satellite-account`: The Serverless Application and IAM Role used for Automatic Remediation in the satellite accounts.
+* `panther-cloudwatch-events`: Configures AWS CloudWatch Events to send to SNS/SQS.
+* `panther-stackset-iam-admin-role`: The IAM Role orchestrating the StackSet creation.
+* `panther-log-processing-iam`: The IAM Roles used in conjunction with the log processing features.
+* `panther-log-processing-infra`: A configuration for log processing in a satellite account.
+* `panther-log-processing-notifications` A minimal configuration for log processing in a satellite account.

--- a/deployments/auxiliary/cloudformation/panther-aws-remediations-master-account.yml
+++ b/deployments/auxiliary/cloudformation/panther-aws-remediations-master-account.yml
@@ -61,7 +61,7 @@ Resources:
         IsMasterAccount: 'true'
         CreateSSMDocument: 'false'
         LambdaLoggingLevel: 'INFO'
-        LambdaLogsRetentionDays: 365
+        LambdaLogsRetentionDays: '365'
 
 Outputs:
   LambdaArn:

--- a/deployments/auxiliary/cloudformation/panther-aws-remediations-master-account.yml
+++ b/deployments/auxiliary/cloudformation/panther-aws-remediations-master-account.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 Description: Deploys the latest Panther Remediation Lambda from SAR and creates the appropriate IAM role to allow invocation of Lambda from Panther

--- a/deployments/auxiliary/cloudformation/panther-aws-remediations-master-account.yml
+++ b/deployments/auxiliary/cloudformation/panther-aws-remediations-master-account.yml
@@ -1,0 +1,53 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Description: Deploys the latest Panther Remediation Lambda from SAR and creates the appropriate IAM role to allow invocation of Lambda from Panther
+Metadata:
+  Version: 1.1
+
+Parameters:
+  MasterAccountId:
+    Type: String
+    Description:  AWS account ID of the account running the Panther backend
+
+Resources:
+  PantherLambdaInvocationRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherLambdaInvocationRole
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              Bool:
+                aws:SecureTransport: true
+      Policies:
+        - PolicyName: AllowInvocation
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt PantherAWSRemediations.Outputs.LambdaArn
+
+  PantherAWSRemediations:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:349240696275:applications/aws-remediations
+        SemanticVersion: 0.1.2
+      Parameters:
+        IsMasterAccount: 'true'
+        CreateSSMDocument: 'false'
+        LambdaLoggingLevel: 'INFO'
+        LambdaLogsRetentionDays: 365
+
+Outputs:
+  LambdaArn:
+    Description: The ARN of the Lambda function that will perform the remediative actions.
+    Value: !GetAtt PantherAWSRemediations.Outputs.LambdaArn

--- a/deployments/auxiliary/cloudformation/panther-aws-remediations-satellite-account.yml
+++ b/deployments/auxiliary/cloudformation/panther-aws-remediations-satellite-account.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 Description: Deploys the latest Panther Remediation Roles from SAR

--- a/deployments/auxiliary/cloudformation/panther-aws-remediations-satellite-account.yml
+++ b/deployments/auxiliary/cloudformation/panther-aws-remediations-satellite-account.yml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Description: Deploys the latest Panther Remediation Roles from SAR
+Metadata:
+  Version: 1.0
+
+Parameters:
+  MasterAccountId:
+    Type: String
+    Description: The master account Id
+
+Resources:
+  PantherAWSRemediations:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:349240696275:applications/aws-remediations
+        SemanticVersion: 0.1.2
+      Parameters:
+        IsMasterAccount: 'false'
+        CreateSSMDocument: 'false'
+        MasterAccountId: !Ref MasterAccountId

--- a/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
@@ -1,0 +1,245 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  This stack configures Panther's real-time CloudWatch Event collection process.
+  It works by creating CloudWatch Event rules which feed to Panther's SQS Queue proxied by
+  a local SNS topic in each region.
+Metadata:
+  Version: v0.1.8
+
+Parameters:
+  MasterAccountId:
+    Type: String
+    Description: AWS account ID of the account running the Panther backend
+  QueueArn:
+    Type: String
+    Description: The Panther SQS Queue Arn to forward CloudWatch Events to via SNS.
+  CloudTrailEvents:
+    Type: String
+    Default: 'True'
+    Description: Collection of CloudTrail API events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  EC2Events:
+    Type: String
+    Default: 'True'
+    Description: Collection of CWE EC2 events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  ECSEvents:
+    Type: String
+    Default: 'False'
+    Description: Collection of CWE ECS events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  KMSEvents:
+    Type: String
+    Default: 'False'
+    Description: Collection of CWE KMS events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  OpsWorksEvents:
+    Type: String
+    Default: 'False'
+    Description: Collection of CWE OpsWorks events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  SecurityEvents:
+    Type: String
+    Default: 'True'
+    Description: Collection of CWE Security events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  SSMEvents:
+    Type: String
+    Default: 'False'
+    Description: Collection of CWE SSM events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+  ScheduledEvents:
+    Type: String
+    Default: 'False'
+    Description: Collection of CWE Scheduled events.
+    AllowedValues:
+      - 'True'
+      - 'False'
+
+Conditions:
+  CloudTrailEvents: !Equals [!Ref CloudTrailEvents, 'True']
+  EC2Events: !Equals [!Ref EC2Events, 'True']
+  ECSEvents: !Equals [!Ref ECSEvents, 'True']
+  KMSEvents: !Equals [!Ref KMSEvents, 'True']
+  OpsWorksEvents: !Equals [!Ref OpsWorksEvents, 'True']
+  ScheduledEvents: !Equals [!Ref ScheduledEvents, 'True']
+  SecurityEvents: !Equals [!Ref SecurityEvents, 'True']
+  SSMEvents: !Equals [!Ref SSMEvents, 'True']
+
+Resources:
+
+  # SNS Topic, Policy, and Subscription to SQS
+
+  PantherEventsTopic:
+    Type: AWS::SNS::Topic
+
+  TopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Sid: CloudWatchEventsPublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref PantherEventsTopic
+          -
+            Sid: CrossAccountSubscription
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sns:Subscribe
+            Resource: !Ref PantherEventsTopic
+      Topics:
+        - !Ref PantherEventsTopic
+
+  QueueSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Ref QueueArn
+      Protocol: sqs
+      RawMessageDelivery: true
+      TopicArn: !Ref PantherEventsTopic
+
+  # CloudWatch Event Rules
+
+  CloudTrailRule:
+    Type: AWS::Events::Rule
+    Condition: CloudTrailEvents
+    Properties:
+      Description: Collect CloudTrail API calls.
+      EventPattern:
+        detail-type:
+          - AWS API Call via CloudTrail
+      State: ENABLED
+      Targets:
+        -
+          Arn: !Ref PantherEventsTopic
+          Id: panther-collect-cloudtrail-events
+
+  SecurityRule:
+    Type: AWS::Events::Rule
+    Condition: SecurityEvents
+    Properties:
+      Description: Collect Security events into Panther.
+      EventPattern:
+        source:
+          - aws.config
+          - aws.guardduty
+          - aws.macie
+          - aws.trustedadvisor
+          - aws.health
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-security-events
+
+  EC2Rule:
+    Type: AWS::Events::Rule
+    Condition: EC2Events
+    Properties:
+      Description: Collect EBS and EC2 events into Panther.
+      EventPattern:
+        detail-type:
+          - EC2 Command Status-change Notification
+          - EC2 Command Invocation Status-change Notification
+          - EC2 Automation Step Status-change Notification
+          - EC2 Automation Execution Status-change Notification
+          - EC2 Instance State-change Notification
+          - EC2 State Manager Association State Change
+          - EC2 State Manager Instance Association State Change
+          - EC2 Spot Instance Interruption Warning
+          - EBS Snapshot Notification
+          - EBS Volume Notification
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-ec2-events
+
+  ECSRule:
+    Type: AWS::Events::Rule
+    Condition: ECSEvents
+    Properties:
+      Description: Collect ECS events into Panther.
+      EventPattern:
+        detail-type:
+          - ECS Container Instance State Change
+          - ECS Task State Change
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-ecs-events
+
+  OpsWorksRule:
+    Type: AWS::Events::Rule
+    Condition: OpsWorksEvents
+    Properties:
+      Description: Collect OpsWorks events into Panther.
+      EventPattern:
+        detail-type:
+          - OpsWorks Instance State Change
+          - OpsWorks Command State Change
+          - OpsWorks Deployment State Change
+          - OpsWorks Alert
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-opsworks-events
+
+  SSMRule:
+    Type: AWS::Events::Rule
+    Condition: SSMEvents
+    Properties:
+      Description: Collect SSM events into Panther.
+      EventPattern:
+        detail-type:
+          - Configuration Compliance State Change
+          - Parameter Store Change
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-ssm-events
+
+  KMSRule:
+    Type: AWS::Events::Rule
+    Condition: KMSEvents
+    Properties:
+      Description: Collect KMS events into Panther.
+      EventPattern:
+        detail-type:
+          - KMS CMK Rotation
+          - KMS CMK Deletion
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-kms-events
+
+  ScheduledEventsRule:
+    Type: AWS::Events::Rule
+    Condition: ScheduledEvents
+    Properties:
+      Description: Collect Scheduled CloudWatch events into Panther.
+      EventPattern:
+        detail-type:
+          - Scheduled Event
+      State: ENABLED
+      Targets:
+        - Arn: !Ref PantherEventsTopic
+          Id: panther-collect-scheduled-events

--- a/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
   This stack configures Panther's real-time CloudWatch Event collection process.

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: IAM roles for an account being scanned by Panther.
 

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -1,0 +1,206 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM roles for an account being scanned by Panther.
+
+Metadata:
+  Version: v1.0.1
+
+Parameters:
+  # Required parameters
+  MasterAccountId:
+    Type: String
+    Description: AWS account ID of the account running the Panther backend
+
+  # Deployment toggles
+  DeployAuditRole:
+    Type: String
+    Description: Creates the panther-audit-role required for compliance scanning.
+    Default: True 
+    AllowedValues: [true, false]
+  DeployCloudWatchEventSetup:
+    Type: String
+    Description: Creates a StackSet Execution Role to configure CloudWatch Events to send to Panther for compliance processing (optional).
+    Default: True 
+    AllowedValues: [true, false]
+  DeployRemediation:
+    Type: String
+    Description: Creates an IAM Role to perform remediation on non-compliant AWS resources (optional).
+    Default: false
+    AllowedValues: [true, false]
+
+Conditions:
+  AuditRole:       !Equals [true, !Ref DeployAuditRole]
+  CloudWatchEventSetup:     !Equals [true, !Ref DeployCloudWatchEventSetup]
+  AutoRemediation:  !Equals [true, !Ref DeployRemediation]
+
+Resources:
+  AuditRole:
+    Condition: AuditRole
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherAuditRole
+      Description: The Panther master account assumes this role for read-only security scanning
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              Bool:
+                aws:SecureTransport: true
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/SecurityAudit
+      Policies:
+        -
+          PolicyName: CloudFormationStackDriftDetection
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DetectStackDrift
+                  - cloudformation:DetectStackResourceDrift
+                Resource: '*'
+        -
+          PolicyName: GetWAFACLs
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetRule
+                  - waf:GetWebACL
+                  - waf-regional:GetRule
+                  - waf-regional:GetWebACL
+                  - waf-regional:GetWebACLForResource
+                Resource: '*'
+        -
+          PolicyName: GetTags
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:ListTagsOfResource
+                  - kms:ListResourceTags
+                  - waf:ListTagsForResource
+                  - waf-regional:ListTagsForResource
+                Resource: '*'
+        -
+          PolicyName: GetCertificates
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - acm:GetCertificate
+                Resource: '*'
+      Tags:
+        - Key: Application
+          Value: Panther
+
+  CloudFormationStackSetExecutionRole:
+    Condition: CloudWatchEventSetup
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherCloudFormationStackSetExecutionRole
+      Description: CloudFormation assumes this role to execute a stack set
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sts:AssumeRole
+      Policies:
+        -
+          PolicyName: ManageCloudFormationStack
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action: cloudformation:*
+                Resource: '*'
+        -
+          PolicyName: PantherSetupRealTimeEvents
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action:
+                  - events:*
+                  - sns:*
+                Resource: '*'
+      Tags:
+        - Key: Application
+          Value: Panther
+
+  RemediationRole:
+    Condition: AutoRemediation
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherRemediationRole
+      Description: The Panther master account assumes this role for automatic remediation of policy violations
+      MaxSessionDuration: 3600  # 1 hour
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              Bool:
+                aws:SecureTransport: true
+      Policies:
+        -
+          PolicyName: AllowRemediativeActions
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudtrail:CreateTrail
+                  - cloudtrail:StartLogging
+                  - cloudtrail:UpdateTrail
+                  - dynamodb:UpdateTable
+                  - ec2:CreateFlowLogs
+                  - ec2:StopInstances
+                  - ec2:TerminateInstances
+                  - guardduty:CreateDetector
+                  - iam:CreateAccessKey
+                  - iam:CreateServiceLinkedRole
+                  - iam:DeleteAccessKey
+                  - iam:UpdateAccessKey
+                  - iam:UpdateAccountPasswordPolicy
+                  - kms:EnableKeyRotation
+                  - logs:CreateLogDelivery
+                  - rds:ModifyDBInstance
+                  - rds:ModifyDBSnapshotAttribute
+                  - s3:PutBucketAcl
+                  - s3:PutBucketPublicAccessBlock
+                  - s3:PutBucketVersioning
+                  - s3:PutBucketLogging
+                  - s3:PutEncryptionConfiguration
+                Resource: '*'
+      Tags:
+        - Key: Application
+          Value: Panther
+
+Outputs:
+  PantherAuditRoleArn:
+    Condition: AuditRole
+    Description: The Arn of the Panther Audit IAM Role
+    Value: !GetAtt AuditRole.Arn
+  CloudFormationStackSetExecutionRoleArn:
+    Condition: CloudWatchEventSetup
+    Description: The Arn of the CloudFormation StackSet Execution Role for configuring Panther infra.
+    Value: !GetAtt CloudFormationStackSetExecutionRole.Arn
+  PantherRemediationRoleArn:
+    Condition: AutoRemediation
+    Description: The Arn of the Panther Auto Remediation IAM Role
+    Value: !GetAtt RemediationRole.Arn 

--- a/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: IAM roles for log ingestion from an S3 bucket.
 

--- a/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM roles for log ingestion from an S3 bucket.
+
+Metadata:
+  Version: v1.0.1
+
+Parameters:
+  # Required parameters
+  MasterAccountId:
+    Type: String
+    Description: AWS account ID of the account running the Panther backend
+  # Optional configuration parameters
+  S3Buckets:
+    Type: CommaDelimitedList
+    Description: Allow Panther master account to get location of these bucket patterns. >
+      E.g. "arn:aws:s3:::my-bucket,arn:aws:s3:::another-bucket*"
+  S3ObjectPrefixes:
+    Type: CommaDelimitedList
+    Description: Allow Panther master account access to access S3 objects that have the following patterns >
+      E.g. "arn:aws:s3:::my-bucket/prefix*,arn:aws:s3:::my-bucket/prefix-2*"
+  EncryptionKeys:
+    Type: CommaDelimitedList
+    Description: Allow Panther master account access to decrypt these KMS keys. >
+      E.g. "arn:aws:kms:us-west-2:111122223333:key/14f5c696-8198-417b-bb22-699990b400cf"
+    Default: ''
+
+Conditions:
+  WithKmsPermissions: !Not [!Equals [!Join ['', !Ref EncryptionKeys], '']]
+
+Resources:
+  LogProcessingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherLogProcessingRole
+      Description: The Panther master account assumes this role to read log data
+      MaxSessionDuration: 3600  # 1 hour
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              Bool:
+                aws:SecureTransport: true
+      Policies:
+        -
+          PolicyName: ReadData
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetBucketLocation
+                Resource: !Ref S3Buckets
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Ref S3ObjectPrefixes
+              - !If
+                - WithKmsPermissions
+                - Effect: Allow
+                  Action: kms:Decrypt
+                  Resource: !Ref EncryptionKeys
+                - !Ref 'AWS::NoValue'
+      Tags:
+        - Key: Application
+          Value: Panther

--- a/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
@@ -1,0 +1,165 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: All the infrastructure needed to setup LogProcessing ingestion to Panther.
+
+Metadata:
+  Version: v1.0.1
+
+Parameters:
+  MasterAccountId:
+    Type: String
+    Description: The Panther Master account ID.
+  ExpireData:
+    Type: String
+    Description: Indicates if LogProcessing bucket should automatically delete data after a certain timefame.
+    Default: true
+    AllowedValues: [true, false]
+  DataLifetime:
+    Type: Number 
+    Description: How long to wait before automatically deleting data, if ExpireData is set to true.
+    Default: 30
+
+Conditions:
+  ExpireData: !Equals [true, !Ref ExpireData]
+
+Resources:
+  # This is the location that LogProcessing will be stored
+  LogProcessingBucket:
+    Type: AWS::S3::Bucket
+    DependsOn: LogProcessingNotificationsTopicPolicy
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: 30DayExpiration
+            Status: !If [ExpireData, Enabled, Disabled]
+            ExpirationInDays: !If [ExpireData, !Ref DataLifetime, !Ref "AWS::NoValue"]
+            NoncurrentVersionExpirationInDays: !If [ExpireData, !Ref DataLifetime, !Ref "AWS::NoValue"]
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      AccessControl: Private
+      VersioningConfiguration:
+        Status: Enabled
+      NotificationConfiguration:
+        TopicConfigurations:
+          -
+            Topic: !Ref LogProcessingNotificationsTopic
+            Event: s3:ObjectCreated:*
+
+  # This policy grants the CloudTrail and VPC FLow Logs services write permissions, and blocks
+  # insecure access.
+  # Consider expanding on this policy to increase the security of the LogProcessing bucket.
+  LogProcessingBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LogProcessingBucket
+      PolicyDocument:
+        Statement:
+          # The following two statements are required for CloudTrail to work
+          - Sid: CloudTrailAclCheck
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt LogProcessingBucket.Arn
+          - Sid: CloudTrailWrite
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${LogProcessingBucket.Arn}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+          # The following statement enforces secure access to the data
+          - Sid: EnforceSecureAccess
+            Effect: Deny
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub ${LogProcessingBucket.Arn}/*
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+          # The following two statements are required for VPC FlowLogs to work
+          - Sid: VPCFlowAclCheck
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt LogProcessingBucket.Arn
+          - Sid: VPCFlowWrite
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${LogProcessingBucket.Arn}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+
+  # This topic is used to notify the Panther master account whenever new data is written to the
+  # LogProcessing bucket.
+  LogProcessingNotificationsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: panther-log-processing-topic
+
+  # This policy is used to allow S3 to publish to the topic when new data is written to S3
+  LogProcessingNotificationsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            # Reference: https://amzn.to/2ouFmhK
+            Sid: S3NotificationPublish
+            Effect: Allow
+            Principal:
+              Service: 's3.amazonaws.com'
+            Action: sns:Publish
+            Resource: !Ref LogProcessingNotificationsTopic
+          -
+            Sid: CrossAccountSubscription
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+            Action: sns:Subscribe
+            Resource: !Ref LogProcessingNotificationsTopic
+      Topics:
+        - !Ref LogProcessingNotificationsTopic
+
+  # This subscription subscribes the Panther Master account SQS queue to the topic created above
+  Subscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub arn:aws:sqs:us-west-2:${MasterAccountId}:panther-log-notifications
+      Protocol: sqs
+      RawMessageDelivery: false
+      TopicArn: !Ref LogProcessingNotificationsTopic
+
+  # This trail will generate audit logs and send them to an S3 bucket for storage
+  LogProcessingCloudTrail:
+    Type: AWS::CloudTrail::Trail
+    DependsOn: LogProcessingBucketPolicy
+    Properties:
+      TrailName: panther-log-processing-trail
+      S3BucketName: !Ref LogProcessingBucket
+      IsLogging: true
+      IsMultiRegionTrail: true
+      IncludeGlobalServiceEvents: true
+      EnableLogFileValidation: true
+
+
+Outputs:
+  SnsTopicArn:
+    Description: The ARN of the SNS Topic that will be notifying Panther of new data.
+    Value: !Ref LogProcessingNotificationsTopic
+  S3BucketArn:
+    Description: The ARN of the S3 Bucket that will be storing Log Data.
+    Value: !GetAtt LogProcessingBucket.Arn

--- a/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: All the infrastructure needed to setup LogProcessing ingestion to Panther.
 

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -1,0 +1,88 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Sets up an SNS topic and subscribes it to Panther Log processing SQS queue.
+
+Metadata:
+  Version: v1.0.0
+
+Parameters:
+  SnsTopicName:
+    Type: String
+    Description: The name of the SNS topic
+    Default: panther-notifications-topic
+  PantherAccountId:
+    Type: String
+    Description: The AWS AccountId where you have deployed Panther
+  PantherRegion:
+    Type: String
+    Description: The region where you have deployed Panther.
+    AllowedValues:
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
+      - ap-east-1
+      - ap-south-1
+      - ap-northeast-1
+      - ap-northeast-2
+      - ap-southeast-1
+      - ap-southeast-2
+      - ca-central-1
+      - eu-central-1
+      - eu-west-1
+      - eu-west-2
+      - eu-west-3
+      - eu-north-1
+      - me-south-1
+      - sa-east-1
+
+Resources:
+  # This topic is used to notify the Panther master account whenever new data is written to the
+  # LogProcessing bucket.
+  Topic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Ref SnsTopicName
+
+  # This policy is used to allow S3 to publish to the topic when new data is written to S3
+  TopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          # Reference: https://amzn.to/2ouFmhK
+          - Sid: AllowS3EventNotifications
+            Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref Topic
+          - Sid: AllowCloudTrailNotification
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref Topic
+          - Sid: AllowSubscriptionToPanther
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${PantherAccountId}:root
+            Action: sns:Subscribe
+            Resource: !Ref Topic
+      Topics:
+        - !Ref Topic
+
+  # SNS Topic subscription to Panther
+  Subscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub arn:aws:sqs:${PantherRegion}:${PantherAccountId}:panther-input-data-notifications
+      Protocol: sqs
+      RawMessageDelivery: false
+      TopicArn: !Ref Topic
+
+
+Outputs:
+  SnsTopicArn:
+    Description: The ARN of the SNS Topic that will be notifying Panther of new data.
+    Value: !Ref Topic

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: Sets up an SNS topic and subscribes it to Panther Log processing SQS queue.
 

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Panther IAM Role for creating and managing StackSets. The purpose of this role is to assume
+  the execution IAM roles in each target account for configuring various Panther infrastructure.
+
+Metadata:
+  Version: v0.1.0
+
+Resources:
+  CloudFormationStackSetAdminRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherCloudFormationStackSetAdminRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service: cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        -
+          PolicyName: AssumeRolesInTargetAccounts
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: arn:aws:iam::*:role/PantherCloudFormationStackSetExecutionRole
+
+Outputs:
+  CloudFormationStackSetAdminRoleArn:
+    Description: The Arn of the CloudFormation StackSet IAM Role for sending data to Panther.
+    Value: !GetAtt CloudFormationStackSetAdminRole.Arn

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
   Panther IAM Role for creating and managing StackSets. The purpose of this role is to assume

--- a/deployments/auxiliary/terraform/README.md
+++ b/deployments/auxiliary/terraform/README.md
@@ -1,0 +1,6 @@
+# Panther's Terraform Templates
+A collection of Terraform Templates to interact with Panther.
+
+## Templates
+
+* Coming soon!


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

We were hosting some CloudFormation templates in a public S3 bucket for use with Panther, decided to move them into the repo directly so they can be access by the frontend directly and users can configure their own custom default templates.

## Changes
> List your changes here in more detail

* Created an `auxiliary` directory under `deployments`, will be used to store templates that build auxiliary/non-core infrastructure for running Panther

## Testing
> How did you test your change? 

* N/A
