### PR TITLE
Fixed alerting configuration issue

### DIFF
--- a/deployments/compliance/alert_processing.yml
+++ b/deployments/compliance/alert_processing.yml
@@ -203,7 +203,7 @@ Resources:
       Description: Forwards the alerts to the alert delivery mechanism
       Environment:
         Variables:
-          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-alert-processor-queue
+          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-alerts
           DEBUG: !Ref Debug
       Events:
         DynamoDBEvent:


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Fixed environment variable configuration issue on the `panther-alert-processor` lambda that was causing alerts to fail. Alerts are back in business.

## Changes
> List your changes here in more detail

* Changed an environment variable in `alert_processing.yml`

## Testing
> How did you test your change? 

* Manually in my development account
