### PR TITLE
Removed incorrect ACM Certificate Scanning Step

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -104,15 +104,6 @@ Resources:
                   - waf:ListTagsForResource
                   - waf-regional:ListTagsForResource
                 Resource: '*'
-        -
-          PolicyName: GetCertificates
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - acm:GetCertificate
-                Resource: '*'
       Tags:
         - Key: Application
           Value: Panther


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

The ACM individual resource snapshot poller failed due to an incorrect intermediate step.

## Changes
> List your changes here in more detail

* Remove the `acm.GetCertificate` call from the ACM single resource snapshot poller

## Testing
> How did you test your change? 

* local linting, formatting, unit testing
* deployed to dev account and manually tested
