### PR TITLE
[ENG-1340]  Cannot add new log sources

### DIFF
--- a/deployments/compliance/snapshot.yml
+++ b/deployments/compliance/snapshot.yml
@@ -238,7 +238,7 @@ Resources:
           Version: 2012-10-17
           Statement:
             - Effect: Allow
-              Action: sqs:*Permission
+              Action: sqs:*QueueAttributes
               Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${LogAnalysisQueueName}
 
   ApiLogGroup:

--- a/internal/compliance/snapshot_api/api/put_integration.go
+++ b/internal/compliance/snapshot_api/api/put_integration.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/snapshot/models"
@@ -65,11 +64,8 @@ func (API) PutIntegration(input *models.PutIntegrationInput) ([]*models.SourceIn
 			continue
 		}
 		err = AddPermissionToLogProcessorQueue(*integration.AWSAccountID)
-		if err != nil {
-			zap.L().Error("failed to add permission to log procesor queue",
-				zap.Error(errors.Wrap(err, "failed to add permission to log procesor queue")))
-			// Returning user friendly message
-			return nil, &genericapi.InternalError{Message: "failed to add integration"}
+		if err != nil { // logging handled in function
+			return nil, err
 		}
 		permissionsAddedForIntegrations = append(permissionsAddedForIntegrations, integration)
 	}

--- a/internal/compliance/snapshot_api/api/sqs_utils.go
+++ b/internal/compliance/snapshot_api/api/sqs_utils.go
@@ -65,10 +65,12 @@ func AddPermissionToLogProcessorQueue(accountID string) error {
 	}
 
 	if findStatementIndex(existingPolicy, accountID) >= 0 {
-		err = &genericapi.DoesNotExistError{Message: "AWS Account ID already exists"}
-		zap.L().Error("AWS Account already exists",
+		errMsg := "account: " + accountID + " has already been configured"
+		err = errors.WithStack(&genericapi.AlreadyExistsError{Message: errMsg})
+		zap.L().Error(errMsg,
+			zap.String("sqsQueueARN", logProcessorQueueArn),
 			zap.String("awsAccountId", accountID),
-			zap.Error(errors.Wrap(err, "AWS Account already exists")))
+			zap.Error(err))
 
 		// // Returning user friendly message
 		return err


### PR DESCRIPTION
## Background
Bad merge lost lambda perms, causes UI not to be able to onboard a Log Source.

## Changes
*  Fix perms
* Improve error messages and logging

## Testing
Deployed and tested UI manually.

* 
