### PR TITLE
Creating organization

### DIFF
--- a/deployments/compliance/remediation.yml
+++ b/deployments/compliance/remediation.yml
@@ -331,3 +331,6 @@ Outputs:
   GatewayId:
     Description: Remediation API Gateway ID
     Value: !Ref GatewayApi
+  RemediationLambdaArn:
+    Description: The ARN of the Remediation Function
+    Value: !GetAtt RemediationFunction.Arn

--- a/deployments/template.yml
+++ b/deployments/template.yml
@@ -390,3 +390,6 @@ Outputs:
   WebApplicationCertificateArn:
     Description: ARN of the certificate used by the web application
     Value: !Ref WebApplicationCertificateArn
+  RemediationLambdaArn:
+    Description: The ARN of the Remediation Function
+    Value: !GetAtt RemediationAPI.Outputs.RemediationLambdaArn

--- a/internal/core/organization_api/table/get.go
+++ b/internal/core/organization_api/table/get.go
@@ -32,7 +32,7 @@ import (
 func (table *OrganizationsTable) Get() (*models.Organization, error) {
 	zap.L().Info("retrieving organization from dynamo")
 	response, err := table.client.GetItem(&dynamodb.GetItemInput{
-		Key:       DynamoItem{"id": {S: aws.String("1")}},
+		Key:       DynamoItem{"id": {S: aws.String(orgID)}},
 		TableName: table.Name,
 	})
 	if err != nil {

--- a/internal/core/organization_api/table/get.go
+++ b/internal/core/organization_api/table/get.go
@@ -44,7 +44,7 @@ func (table *OrganizationsTable) Get() (*models.Organization, error) {
 		return nil, &genericapi.InternalError{
 			Message: "failed to unmarshal dynamo item to an Organization: " + err.Error()}
 	}
-	if org.AwsConfig == nil {
+	if org.Email == nil {
 		return nil, &genericapi.DoesNotExistError{}
 	}
 

--- a/internal/core/organization_api/table/get_test.go
+++ b/internal/core/organization_api/table/get_test.go
@@ -87,8 +87,8 @@ func TestGetItem(t *testing.T) {
 		TableName: aws.String("test-table"),
 	}
 	output := &dynamodb.GetItemOutput{Item: DynamoItem{
-		"id":        {S: aws.String("1")},
-		"awsConfig": dynamoAwsConfig,
+		"id":    {S: aws.String("1")},
+		"email": {S: aws.String("email")},
 	}}
 	mockClient.On("GetItem", expectedInput).Return(output, nil)
 	table := &OrganizationsTable{client: mockClient, Name: aws.String("test-table")}

--- a/internal/core/organization_api/table/get_test.go
+++ b/internal/core/organization_api/table/get_test.go
@@ -83,11 +83,11 @@ func TestGetItemDoesNotExistError(t *testing.T) {
 func TestGetItem(t *testing.T) {
 	mockClient := &mockDynamoClient{}
 	expectedInput := &dynamodb.GetItemInput{
-		Key:       DynamoItem{"id": {S: aws.String("1")}},
+		Key:       DynamoItem{"id": {S: aws.String(orgID)}},
 		TableName: aws.String("test-table"),
 	}
 	output := &dynamodb.GetItemOutput{Item: DynamoItem{
-		"id":    {S: aws.String("1")},
+		"id":    {S: aws.String(orgID)},
 		"email": {S: aws.String("email")},
 	}}
 	mockClient.On("GetItem", expectedInput).Return(output, nil)

--- a/internal/core/organization_api/table/put.go
+++ b/internal/core/organization_api/table/put.go
@@ -35,7 +35,7 @@ func (table *OrganizationsTable) Put(org *models.Organization) error {
 			Message: "failed to marshal Organization to a dynamo item: " + err.Error()}
 	}
 
-	item["id"] = &dynamodb.AttributeValue{S: aws.String("1")}
+	item["id"] = &dynamodb.AttributeValue{S: aws.String(orgID)}
 	input := &dynamodb.PutItemInput{Item: item, TableName: table.Name}
 	if _, err = table.client.PutItem(input); err != nil {
 		return &genericapi.AWSError{Method: "dynamodb.PutItem", Err: err}

--- a/internal/core/organization_api/table/table.go
+++ b/internal/core/organization_api/table/table.go
@@ -28,6 +28,9 @@ import (
 	"github.com/panther-labs/panther/api/lambda/organization/models"
 )
 
+// The default organization ID. Note that we can currently have only one organization.
+const orgID = "defaultOrganizationId"
+
 // API defines the interface for the table which can be used for mocking.
 type API interface {
 	Get() (*models.Organization, error)

--- a/internal/core/organization_api/table/table_test.go
+++ b/internal/core/organization_api/table/table_test.go
@@ -21,20 +21,10 @@ package table
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-)
-
-var (
-	dynamoAwsConfig = &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-		"appClientId":    {S: aws.String("111")},
-		"identityPoolId": {S: aws.String("us-west-2:1234")},
-		"userPoolId":     {S: aws.String("us-west-2_1234")},
-	}}
 )
 
 type mockDynamoClient struct {

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -35,8 +35,8 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 
-	"github.com/panther-labs/panther/api/lambda/users/models"
 	orgmodels "github.com/panther-labs/panther/api/lambda/organization/models"
+	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/shutil"
 )
 
@@ -116,7 +116,7 @@ func Deploy() error {
 		return err
 	}
 
-	if err := inviteFirstUser(awsSession, outputs["UserPoolId"]); err != nil {
+	if err := setupOrganization(awsSession, outputs["UserPoolId"], outputs["RemediationLambdaArn"]); err != nil {
 		return err
 	}
 
@@ -252,8 +252,8 @@ func enableTOTP(awsSession *session.Session, userPoolID string) error {
 	return err
 }
 
-// If the Admin group is empty (e.g. on the initial deploy), create the initial admin user.
-func inviteFirstUser(awsSession *session.Session, userPoolID string) error {
+// If the Admin group is empty (e.g. on the initial deploy), create the initial admin user and organization
+func setupOrganization(awsSession *session.Session, userPoolID string, remediationLambdaArn string) error {
 	cognitoClient := cognitoidentityprovider.New(awsSession)
 	group, err := cognitoClient.ListUsersInGroup(&cognitoidentityprovider.ListUsersInGroupInput{
 		GroupName:  aws.String("Admin"),
@@ -282,30 +282,29 @@ func inviteFirstUser(awsSession *session.Session, userPoolID string) error {
 			Role:       aws.String("Admin"),
 		},
 	}
-	if err := invokeLambda(input, "panther-users-api"); err != nil {
+	if err := invokeLambda(awsSession, "panther-users-api", input); err != nil {
 		return err
 	}
 
+	// Hit organization-api.CreateOrganization to create organization entry
 	createOrgInput := &orgmodels.LambdaInput{
 		CreateOrganization: &orgmodels.CreateOrganizationInput{
-			Email: &email,
-			DisplayName: &firstName,
+			Email:             &email,
+			DisplayName:       aws.String(firstName + "-" + lastName),
+			RemediationConfig: &orgmodels.RemediationConfig{AwsRemediationLambdaArn: aws.String(remediationLambdaArn)},
 		},
 	}
-
-	if err := invokeLambda(createOrgInput, "panther-organization-api"); err != nil {
+	if err := invokeLambda(awsSession, "panther-organization-api", createOrgInput); err != nil {
 		return err
 	}
 	return nil
 }
 
-func invokeLambda(input interface{}, functionName string) error {
+func invokeLambda(awsSession *session.Session, functionName string, input interface{}) error {
 	payload, err := jsoniter.Marshal(input)
 	if err != nil {
 		return err
 	}
-
-	awsSession, err := session.NewSession()
 
 	lambdaClient := lambda.New(awsSession)
 	response, err := lambdaClient.Invoke(&lambda.InvokeInput{
@@ -317,8 +316,8 @@ func invokeLambda(input interface{}, functionName string) error {
 	}
 
 	if response.FunctionError != nil {
-		return fmt.Errorf("failed to invoke panther-users-api: %s error: %s",
-			*response.FunctionError, string(response.Payload))
+		return fmt.Errorf("failed to invoke %s: %s error: %s",
+			functionName, *response.FunctionError, string(response.Payload))
 	}
 	return nil
 }


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Creating an organization on first deployment. This is needed by UI but also for remediation capabilities. 
Using as organization email the email of the first user and as organization name the name of the user. This change is needed for the frontend PR https://github.com/panther-labs/panther/pull/25 that fixes a lot of UI issues. 

## Changes
> List your changes here in more detail

* On first deploy, creating an organization. 
* Modified the Organization.Get method to check for required field `email` instead of previous check that was checking optional field. 

## Testing
> How did you test your change? 

* Deleted my user from cognito & `panther-users` DDB table. Ran deploy script again - seen it populate the Organization. Verified with @3nvi  that he was able to use the new organization field. 
