### PR TITLE
Fix sns email

### DIFF
--- a/internal/core/alert_delivery/outputs/email.go
+++ b/internal/core/alert_delivery/outputs/email.go
@@ -40,7 +40,7 @@ var sesConfigurationSet = os.Getenv("SES_CONFIGURATION_SET")
 func generateEmailContent(alert *alertmodels.Alert) string {
 	messageField := fmt.Sprintf("<a href='%s'>%s</a>",
 		generateURL(alert),
-		aws.StringValue(generateAlertMessage(alert)))
+		generateAlertMessage(alert))
 	return fmt.Sprintf(
 		emailTemplate,
 		messageField,
@@ -59,7 +59,7 @@ func (client *OutputClient) Email(alert *alertmodels.Alert, config *outputmodels
 		Message: &ses.Message{
 			Subject: &ses.Content{
 				Charset: aws.String("UTF-8"),
-				Data:    generateAlertTitle(alert),
+				Data:    aws.String(generateAlertTitle(alert)),
 			},
 			Body: &ses.Body{
 				Html: &ses.Content{

--- a/internal/core/alert_delivery/outputs/email.go
+++ b/internal/core/alert_delivery/outputs/email.go
@@ -37,17 +37,17 @@ const emailTemplate = "<h2>Message</h2>%s<br>" +
 
 var sesConfigurationSet = os.Getenv("SES_CONFIGURATION_SET")
 
-func generateEmailContent(alert *alertmodels.Alert) *string {
+func generateEmailContent(alert *alertmodels.Alert) string {
 	messageField := fmt.Sprintf("<a href='%s'>%s</a>",
 		generateURL(alert),
 		aws.StringValue(generateAlertMessage(alert)))
-	return aws.String(fmt.Sprintf(
+	return fmt.Sprintf(
 		emailTemplate,
 		messageField,
 		aws.StringValue(alert.Severity),
 		aws.StringValue(alert.Runbook),
 		aws.StringValue(alert.PolicyDescription),
-	))
+	)
 }
 
 // Email sends email to destination
@@ -64,7 +64,7 @@ func (client *OutputClient) Email(alert *alertmodels.Alert, config *outputmodels
 			Body: &ses.Body{
 				Html: &ses.Content{
 					Charset: aws.String("UTF-8"),
-					Data:    generateEmailContent(alert),
+					Data:    aws.String(generateEmailContent(alert)),
 				},
 			},
 		},

--- a/internal/core/alert_delivery/outputs/github.go
+++ b/internal/core/alert_delivery/outputs/github.go
@@ -46,7 +46,7 @@ func (client *OutputClient) Github(
 	tags := "\n **Tags:** " + strings.Join(tagsItem, ", ")
 
 	githubRequest := map[string]interface{}{
-		"title": aws.StringValue(generateAlertTitle(alert)),
+		"title": generateAlertTitle(alert),
 		"body":  description + link + runBook + severity + tags,
 	}
 

--- a/internal/core/alert_delivery/outputs/jira.go
+++ b/internal/core/alert_delivery/outputs/jira.go
@@ -45,7 +45,7 @@ func (client *OutputClient) Jira(
 	tags := "\n *Tags:* " + strings.Join(tagsItem, ", ")
 
 	fields := map[string]interface{}{
-		"summary":     *generateAlertTitle(alert),
+		"summary":     generateAlertTitle(alert),
 		"description": description + link + runBook + severity + tags,
 		"project": map[string]*string{
 			"key": config.ProjectKey,

--- a/internal/core/alert_delivery/outputs/msteams.go
+++ b/internal/core/alert_delivery/outputs/msteams.go
@@ -42,7 +42,7 @@ func (client *OutputClient) MsTeams(
 	msTeamsRequestBody := map[string]interface{}{
 		"@context": "http://schema.org/extensions",
 		"@type":    "MessageCard",
-		"text":     *generateAlertTitle(alert),
+		"text":     generateAlertTitle(alert),
 		"sections": []interface{}{
 			map[string]interface{}{
 				"facts": []interface{}{

--- a/internal/core/alert_delivery/outputs/opsgenie.go
+++ b/internal/core/alert_delivery/outputs/opsgenie.go
@@ -49,7 +49,7 @@ func (client *OutputClient) Opsgenie(
 	severity := "\n <strong>Severity:</strong> " + aws.StringValue(alert.Severity)
 
 	opsgenieRequest := map[string]interface{}{
-		"message":     *generateAlertTitle(alert),
+		"message":     generateAlertTitle(alert),
 		"description": description + link + runBook + severity,
 		"tags":        tagsItem,
 		"priority":    pantherToOpsGeniePriority[aws.StringValue(alert.Severity)],

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -102,18 +102,18 @@ func New(sess *session.Session) *OutputClient {
 	}
 }
 
-func generateAlertMessage(alert *alertmodels.Alert) *string {
+func generateAlertMessage(alert *alertmodels.Alert) string {
 	if aws.StringValue(alert.Type) == alertmodels.RuleType {
-		return aws.String(getDisplayName(alert) + " failed")
+		return getDisplayName(alert) + " failed"
 	}
-	return aws.String(getDisplayName(alert) + " failed on new resources")
+	return getDisplayName(alert) + " failed on new resources"
 }
 
-func generateAlertTitle(alert *alertmodels.Alert) *string {
+func generateAlertTitle(alert *alertmodels.Alert) string {
 	if aws.StringValue(alert.Type) == alertmodels.RuleType {
-		return aws.String("New Alert: " + getDisplayName(alert))
+		return "New Alert: " + getDisplayName(alert)
 	}
-	return aws.String("Policy Failure: " + getDisplayName(alert))
+	return "Policy Failure: " + getDisplayName(alert)
 }
 
 func getDisplayName(alert *alertmodels.Alert) string {

--- a/internal/core/alert_delivery/outputs/pagerduty.go
+++ b/internal/core/alert_delivery/outputs/pagerduty.go
@@ -55,7 +55,7 @@ func (client *OutputClient) PagerDuty(alert *alertmodels.Alert, config *outputmo
 	}
 
 	payload := map[string]interface{}{
-		"summary":   *generateAlertTitle(alert),
+		"summary":   generateAlertTitle(alert),
 		"severity":  aws.StringValue(severity),
 		"timestamp": alert.CreatedAt.Format(time.RFC3339),
 		"source":    "pantherlabs",

--- a/internal/core/alert_delivery/outputs/slack.go
+++ b/internal/core/alert_delivery/outputs/slack.go
@@ -61,9 +61,9 @@ func (client *OutputClient) Slack(alert *alertmodels.Alert, config *outputmodels
 	payload := map[string]interface{}{
 		"attachments": []map[string]interface{}{
 			{
-				"fallback": aws.StringValue(generateAlertTitle(alert)),
+				"fallback": generateAlertTitle(alert),
 				"color":    severityColors[aws.StringValue(alert.Severity)],
-				"title":    aws.StringValue(generateAlertTitle(alert)),
+				"title":    generateAlertTitle(alert),
 				"fields":   fields,
 			},
 		},

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -19,68 +19,21 @@ package outputs
  */
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	outputmodels "github.com/panther-labs/panther/api/lambda/outputs/models"
 	alertmodels "github.com/panther-labs/panther/internal/core/alert_delivery/models"
 )
 
-// Sns sends an alert to an SNS Topic.
-// nolint: dupl
-func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.SnsConfig) *AlertDeliveryError {
-
-	snsDefaultMessage := snsDefaultMessage{
-		ID:          alert.PolicyID,
-		Name:        alert.PolicyName,
-		VersionID:   alert.PolicyVersionID,
-		Description: alert.PolicyDescription,
-		Runbook:     alert.Runbook,
-		Severity:    alert.Severity,
-		Tags:        alert.Tags,
-	}
-
-	serializedDefaultMessage, err := jsoniter.MarshalToString(snsDefaultMessage)
-	if err != nil {
-		zap.L().Error("Failed to serialize message", zap.Error(err))
-		return &AlertDeliveryError{Message: "Failed to serialize message"}
-	}
-
-	outputMessage := &snsMessage{
-		DefaultMessage: serializedDefaultMessage,
-		EmailMessage: generateEmailContent(alert),
-	}
-
-	serializedMessage, err := jsoniter.MarshalToString(outputMessage)
-	if err != nil {
-		zap.L().Error("Failed to serialize message", zap.Error(err))
-		return &AlertDeliveryError{Message: "Failed to serialize message"}
-	}
-
-	snsMessageInput := &sns.PublishInput{
-		TopicArn: config.TopicArn,
-		Message:  aws.String(serializedMessage),
-		// Subject is optional in case the topic is subscribed to Email
-		Subject:          generateAlertTitle(alert),
-		MessageStructure: aws.String("json"),
-	}
-
-	snsClient, err := client.getSnsClient(*config.TopicArn)
-	if err != nil {
-		return &AlertDeliveryError{Message: "Failed to create SNS client for topic", Permanent: true}
-	}
-
-	_, err = snsClient.Publish(snsMessageInput)
-	if err != nil {
-		zap.L().Error("Failed to send message to SNS topic", zap.Error(err))
-		return &AlertDeliveryError{Message: "Failed to send message to SNS topic"}
-	}
-	return nil
-}
+const snsEmailTemplate = "%s\nFor more details please visit: %s\nSeverity: %s\nRunbook: %s\nDescription:%s"
 
 type snsMessage struct {
 	DefaultMessage string `json:"default"`
@@ -97,6 +50,73 @@ type snsDefaultMessage struct {
 	Runbook     *string   `json:"runbook,omitempty"`
 	Severity    *string   `json:"severity"`
 	Tags        []*string `json:"tags,omitempty"`
+}
+
+// Sns sends an alert to an SNS Topic.
+// nolint: dupl
+func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.SnsConfig) *AlertDeliveryError {
+	snsDefaultMessage := snsDefaultMessage{
+		ID:          alert.PolicyID,
+		Name:        alert.PolicyName,
+		VersionID:   alert.PolicyVersionID,
+		Description: alert.PolicyDescription,
+		Runbook:     alert.Runbook,
+		Severity:    alert.Severity,
+		Tags:        alert.Tags,
+	}
+
+	serializedDefaultMessage, err := jsoniter.MarshalToString(snsDefaultMessage)
+	if err != nil {
+		errorMsg := "Failed to serialize default message"
+		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
+		return &AlertDeliveryError{Message: errorMsg, Permanent: true}
+	}
+
+	outputMessage := &snsMessage{
+		DefaultMessage: serializedDefaultMessage,
+		EmailMessage:   generateSnsEmailMessage(alert),
+	}
+
+	serializedMessage, err := jsoniter.MarshalToString(outputMessage)
+	if err != nil {
+		errorMsg := "Failed to serialize message"
+		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
+		return &AlertDeliveryError{Message: errorMsg, Permanent: true}
+	}
+
+	snsMessageInput := &sns.PublishInput{
+		TopicArn: config.TopicArn,
+		Message:  aws.String(serializedMessage),
+		// Subject is optional in case the topic is subscribed to Email
+		Subject:          aws.String(generateAlertTitle(alert)),
+		MessageStructure: aws.String("json"),
+	}
+
+	snsClient, err := client.getSnsClient(*config.TopicArn)
+	if err != nil {
+		errorMsg := "Failed to create SNS client for topic"
+		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
+		return &AlertDeliveryError{Message: errorMsg, Permanent: true}
+	}
+
+	_, err = snsClient.Publish(snsMessageInput)
+	if err != nil {
+		errorMsg := "Failed to send message to SNS topic"
+		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
+		return &AlertDeliveryError{Message: errorMsg}
+	}
+	return nil
+}
+
+func generateSnsEmailMessage(alert *alertmodels.Alert) string {
+	return fmt.Sprintf(
+		snsEmailTemplate,
+		generateAlertMessage(alert),
+		generateURL(alert),
+		aws.StringValue(alert.Severity),
+		aws.StringValue(alert.Runbook),
+		aws.StringValue(alert.PolicyDescription),
+	)
 }
 
 func (client *OutputClient) getSnsClient(topicArn string) (snsiface.SNSAPI, error) {

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -35,13 +35,13 @@ import (
 func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.SnsConfig) *AlertDeliveryError {
 	outputMessage := &snsMessage{
 		DefaultMessage: snsDefaultMessage{
-		ID:          alert.PolicyID,
-		Name:        alert.PolicyName,
-		VersionID:   alert.PolicyVersionID,
-		Description: alert.PolicyDescription,
-		Runbook:     alert.Runbook,
-		Severity:    alert.Severity,
-		Tags:        alert.Tags,
+			ID:          alert.PolicyID,
+			Name:        alert.PolicyName,
+			VersionID:   alert.PolicyVersionID,
+			Description: alert.PolicyDescription,
+			Runbook:     alert.Runbook,
+			Severity:    alert.Severity,
+			Tags:        alert.Tags,
 		},
 		EmailMessage: generateEmailContent(alert),
 	}
@@ -56,9 +56,8 @@ func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.S
 		TopicArn: config.TopicArn,
 		Message:  aws.String(serializedMessage),
 		// Subject is optional in case the topic is subscribed to Email
-		Subject: generateAlertTitle(alert),
+		Subject:          generateAlertTitle(alert),
 		MessageStructure: aws.String("json"),
-
 	}
 
 	snsClient, err := client.getSnsClient(*config.TopicArn)

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -52,6 +52,7 @@ func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.S
 	snsMessageInput := &sns.PublishInput{
 		TopicArn: config.TopicArn,
 		Message:  aws.String(serializedMessage),
+		Subject: generateAlertTitle(alert),
 	}
 
 	snsClient, err := client.getSnsClient(*config.TopicArn)

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -59,9 +59,7 @@ func TestSendSns(t *testing.T) {
 
 	expectedSnsMessage := &snsMessage{
 		DefaultMessage: `{"id":"policyId","name":"policyName","description":"policyDescription","runbook":"runbook","severity":"severity"}`,
-		EmailMessage: "<h2>Message</h2><a href='https://panther.io/policies/policyId'>" +
-			"policyName failed on new resources</a><br><h2>Severity</h2>severity<br>" +
-			"<h2>Runbook</h2>runbook<br><h2>Description</h2>policyDescription",
+		EmailMessage: "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\nSeverity: severity\nRunbook: runbook\nDescription:policyDescription",
 	}
 	expectedSerializedSnsMessage, _ := jsoniter.MarshalToString(expectedSnsMessage)
 	expectedSnsPublishInput := &sns.PublishInput{

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -71,10 +71,10 @@ func TestSendSns(t *testing.T) {
 	}
 	expectedSerializedSnsMessage, _ := jsoniter.MarshalToString(expectedSnsMessage)
 	expectedSnsPublishInput := &sns.PublishInput{
-		TopicArn: snsOutputConfig.TopicArn,
-		Message:  aws.String(expectedSerializedSnsMessage),
+		TopicArn:         snsOutputConfig.TopicArn,
+		Message:          aws.String(expectedSerializedSnsMessage),
 		MessageStructure: aws.String("json"),
-		Subject: aws.String("Policy Failure: policyName"),
+		Subject:          aws.String("Policy Failure: policyName"),
 	}
 
 	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{}, nil)

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -57,17 +57,24 @@ func TestSendSns(t *testing.T) {
 		Runbook:           aws.String("runbook"),
 	}
 
-	expectedSnsMessage := &snsOutputMessage{
-		ID:          alert.PolicyID,
-		Name:        alert.PolicyName,
-		Description: alert.PolicyDescription,
-		Severity:    alert.Severity,
-		Runbook:     alert.Runbook,
+	expectedSnsMessage := &snsMessage{
+		DefaultMessage: snsDefaultMessage{
+			ID:          alert.PolicyID,
+			Name:        alert.PolicyName,
+			Description: alert.PolicyDescription,
+			Severity:    alert.Severity,
+			Runbook:     alert.Runbook,
+		},
+		EmailMessage: "<h2>Message</h2><a href='https://panther.io/policies/policyId'>" +
+			"policyName failed on new resources</a><br><h2>Severity</h2>severity<br>" +
+			"<h2>Runbook</h2>runbook<br><h2>Description</h2>policyDescription",
 	}
 	expectedSerializedSnsMessage, _ := jsoniter.MarshalToString(expectedSnsMessage)
 	expectedSnsPublishInput := &sns.PublishInput{
 		TopicArn: snsOutputConfig.TopicArn,
 		Message:  aws.String(expectedSerializedSnsMessage),
+		MessageStructure: aws.String("json"),
+		Subject: aws.String("Policy Failure: policyName"),
 	}
 
 	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{}, nil)

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -58,13 +58,7 @@ func TestSendSns(t *testing.T) {
 	}
 
 	expectedSnsMessage := &snsMessage{
-		DefaultMessage: snsDefaultMessage{
-			ID:          alert.PolicyID,
-			Name:        alert.PolicyName,
-			Description: alert.PolicyDescription,
-			Severity:    alert.Severity,
-			Runbook:     alert.Runbook,
-		},
+		DefaultMessage: `{"id":"policyId","name":"policyName","description":"policyDescription","runbook":"runbook","severity":"severity"}`,
 		EmailMessage: "<h2>Message</h2><a href='https://panther.io/policies/policyId'>" +
 			"policyName failed on new resources</a><br><h2>Severity</h2>severity<br>" +
 			"<h2>Runbook</h2>runbook<br><h2>Description</h2>policyDescription",

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -59,7 +59,7 @@ func TestSendSns(t *testing.T) {
 
 	expectedSnsMessage := &snsMessage{
 		DefaultMessage: `{"id":"policyId","name":"policyName","description":"policyDescription","runbook":"runbook","severity":"severity"}`,
-		EmailMessage:   "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\n" +
+		EmailMessage: "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\n" +
 			"Severity: severity\nRunbook: runbook\nDescription:policyDescription",
 	}
 	expectedSerializedSnsMessage, _ := jsoniter.MarshalToString(expectedSnsMessage)

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -59,7 +59,7 @@ func TestSendSns(t *testing.T) {
 
 	expectedSnsMessage := &snsMessage{
 		DefaultMessage: `{"id":"policyId","name":"policyName","description":"policyDescription","runbook":"runbook","severity":"severity"}`,
-		EmailMessage: "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\nSeverity: severity\nRunbook: runbook\nDescription:policyDescription",
+		EmailMessage:   "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\nSeverity: severity\nRunbook: runbook\nDescription:policyDescription",
 	}
 	expectedSerializedSnsMessage, _ := jsoniter.MarshalToString(expectedSnsMessage)
 	expectedSnsPublishInput := &sns.PublishInput{

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -59,7 +59,8 @@ func TestSendSns(t *testing.T) {
 
 	expectedSnsMessage := &snsMessage{
 		DefaultMessage: `{"id":"policyId","name":"policyName","description":"policyDescription","runbook":"runbook","severity":"severity"}`,
-		EmailMessage:   "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\nSeverity: severity\nRunbook: runbook\nDescription:policyDescription",
+		EmailMessage:   "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\n" +
+			"Severity: severity\nRunbook: runbook\nDescription:policyDescription",
 	}
 	expectedSerializedSnsMessage, _ := jsoniter.MarshalToString(expectedSnsMessage)
 	expectedSnsPublishInput := &sns.PublishInput{


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Improving the quality of email delivered through SNS -> Email subscription. 
Apparently SNS makes it possible to configure different message content per destination. 
I am updating existing code so that in case we have an Email subscription to an SNS topic. Note that this delivery doesn't allow us to use HTML markup. 
## Changes
> List your changes here in more detail

* Email subscribers to our SNS topic will get human readable email.
* Converted several `*string` to `string`
## Testing
> How did you test your change? 

* Unit tests
* Deployed in my account. Created an SNS topic and added it as destination. Subscribed my email and an SQS queue to that topic. Performed an action that triggered a rule. 
Got the following email: 

![Screen Shot 2020-01-22 at 2 45 06 PM](https://user-images.githubusercontent.com/2652630/72899267-ebf4e180-3d25-11ea-97b6-f75bbce435e0.png)
And the following message was delivered to the SQS queue: 
```
{"id":"AWS.CloudTrail.CloudTrailModified","name":"CloudTrail Modified","description":"A CloudTrail Trail was modified. \n","runbook":"reference.link \n","severity":"MEDIUM","tags":["AWS","CIS","CIS 3.5"]}
```