### PR TITLE
Fixing flaky integration tests

### DIFF
--- a/internal/compliance/resources_api/main/integration_test.go
+++ b/internal/compliance/resources_api/main/integration_test.go
@@ -266,9 +266,9 @@ func getSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	assert.NoError(t, result.Payload.Validate(nil))
+	require.NoError(t, result.Payload.Validate(nil))
 	bucket.LastModified = result.Payload.LastModified
-	assert.Equal(t, bucket, result.Payload)
+	require.Equal(t, bucket, result.Payload)
 }
 
 func modifyInvalid(t *testing.T) {

--- a/internal/core/organization_api/main/integration_test.go
+++ b/internal/core/organization_api/main/integration_test.go
@@ -145,7 +145,7 @@ func getTest(t *testing.T) {
 	require.NoError(t, genericapi.Invoke(lambdaClient, orgAPI, &input, &output))
 
 	expected := models.GetOrganizationOutput{Organization: org}
-	assert.Equal(t, expected, output)
+	require.Equal(t, expected, output)
 }
 
 func getOrg(t *testing.T) {
@@ -177,7 +177,6 @@ func updateOrg(t *testing.T) {
 		Organization: &models.Organization{
 			CompletedActions: org.CompletedActions,
 			CreatedAt:        org.CreatedAt,
-
 			AlertReportFrequency: input.UpdateOrganization.AlertReportFrequency,
 			AwsConfig:            input.UpdateOrganization.AwsConfig,
 			DisplayName:          input.UpdateOrganization.DisplayName,
@@ -186,9 +185,8 @@ func updateOrg(t *testing.T) {
 			RemediationConfig:    input.UpdateOrganization.RemediationConfig,
 		},
 	}
-	assert.Equal(t, expected, output)
+	require.Equal(t, expected, output)
 	org = output.Organization
-
 	getTest(t)
 }
 

--- a/internal/core/organization_api/main/integration_test.go
+++ b/internal/core/organization_api/main/integration_test.go
@@ -175,8 +175,8 @@ func updateOrg(t *testing.T) {
 
 	expected := models.UpdateOrganizationOutput{
 		Organization: &models.Organization{
-			CompletedActions: org.CompletedActions,
-			CreatedAt:        org.CreatedAt,
+			CompletedActions:     org.CompletedActions,
+			CreatedAt:            org.CreatedAt,
 			AlertReportFrequency: input.UpdateOrganization.AlertReportFrequency,
 			AwsConfig:            input.UpdateOrganization.AwsConfig,
 			DisplayName:          input.UpdateOrganization.DisplayName,

--- a/internal/core/organization_api/table/update.go
+++ b/internal/core/organization_api/table/update.go
@@ -73,7 +73,7 @@ func (table *OrganizationsTable) doUpdate(update expression.UpdateBuilder) (*mod
 		ConditionExpression:       expr.Condition(),
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
-		Key:                       DynamoItem{"id": {S: aws.String("1")}},
+		Key:                       DynamoItem{"id": {S: aws.String(orgID)}},
 		ReturnValues:              aws.String("ALL_NEW"),
 		TableName:                 table.Name,
 		UpdateExpression:          expr.Update(),

--- a/internal/core/organization_api/table/update_test.go
+++ b/internal/core/organization_api/table/update_test.go
@@ -87,7 +87,7 @@ func TestUpdate(t *testing.T) {
 	org := &models.Organization{}
 
 	output := &dynamodb.UpdateItemOutput{
-		Attributes: DynamoItem{"id": {S: aws.String("1")}},
+		Attributes: DynamoItem{"id": {S: aws.String(orgID)}},
 	}
 
 	expectedUpdate := expression.
@@ -104,7 +104,7 @@ func TestUpdate(t *testing.T) {
 		ConditionExpression:       expectedExpression.Condition(),
 		ExpressionAttributeNames:  expectedExpression.Names(),
 		ExpressionAttributeValues: expectedExpression.Values(),
-		Key:                       DynamoItem{"id": {S: aws.String("1")}},
+		Key:                       DynamoItem{"id": {S: aws.String(orgID)}},
 		ReturnValues:              aws.String("ALL_NEW"),
 		TableName:                 aws.String("test-table"),
 		UpdateExpression:          expectedExpression.Update(),
@@ -123,7 +123,7 @@ func TestUpdate(t *testing.T) {
 func TestAddActions(t *testing.T) {
 	mockClient := &mockDynamoClient{}
 	output := &dynamodb.UpdateItemOutput{
-		Attributes: DynamoItem{"id": {S: aws.String("1")}},
+		Attributes: DynamoItem{"id": {S: aws.String(orgID)}},
 	}
 	mockClient.On("UpdateItem", mock.Anything).Return(output, nil)
 	table := &OrganizationsTable{client: mockClient, Name: aws.String("test-table")}

--- a/internal/core/outputs_api/api/add_output.go
+++ b/internal/core/outputs_api/api/add_output.go
@@ -95,6 +95,7 @@ func addToDefaults(severities []*string, outputID *string) error {
 		if err != nil {
 			return err
 		}
+		zap.L().Info("Defaults for severity", zap.Any("defaults", defaults), zap.String("severity", *severity))
 
 		if defaults == nil {
 			defaults = &models.DefaultOutputsItem{
@@ -104,6 +105,7 @@ func addToDefaults(severities []*string, outputID *string) error {
 		} else {
 			defaults.OutputIDs = append(defaults.OutputIDs, outputID)
 		}
+		zap.L().Info("Putting defaults", zap.Any("defaults", defaults), zap.String("severity", *severity))
 
 		if err = defaultsTable.PutDefaults(defaults); err != nil {
 			return err

--- a/internal/core/outputs_api/api/add_output.go
+++ b/internal/core/outputs_api/api/add_output.go
@@ -95,7 +95,6 @@ func addToDefaults(severities []*string, outputID *string) error {
 		if err != nil {
 			return err
 		}
-		zap.L().Info("Defaults for severity", zap.Any("defaults", defaults), zap.String("severity", *severity))
 
 		if defaults == nil {
 			defaults = &models.DefaultOutputsItem{
@@ -105,7 +104,6 @@ func addToDefaults(severities []*string, outputID *string) error {
 		} else {
 			defaults.OutputIDs = append(defaults.OutputIDs, outputID)
 		}
-		zap.L().Info("Putting defaults", zap.Any("defaults", defaults), zap.String("severity", *severity))
 
 		if err = defaultsTable.PutDefaults(defaults); err != nil {
 			return err

--- a/internal/core/outputs_api/api/api_test.go
+++ b/internal/core/outputs_api/api/api_test.go
@@ -78,6 +78,9 @@ func (m *mockDefaultsTable) GetDefaults() ([]*models.DefaultOutputsItem, error) 
 
 func (m *mockDefaultsTable) GetDefault(severity *string) (*models.DefaultOutputsItem, error) {
 	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*models.DefaultOutputsItem), args.Error(1)
 }
 

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -72,7 +72,7 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 	// Removing outputId from all defaults
 	for _, defaultOutput := range defaults {
 		var removed bool
-		defaultOutput.OutputIDs, removed = removeSlice(defaultOutput.OutputIDs, input.OutputID)
+		defaultOutput.OutputIDs, removed = removeFromSlice(defaultOutput.OutputIDs, input.OutputID)
 		if removed {
 			if err := defaultsTable.PutDefaults(defaultOutput); err != nil {
 				return nil, err
@@ -93,7 +93,7 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 
 // Removes an item from a slice if it exists. Returns the resulting slice
 // and a boolean indicating whether an item was removed or not
-func removeSlice(slice []*string, item *string) ([]*string, bool) {
+func removeFromSlice(slice []*string, item *string) ([]*string, bool) {
 	new := make([]*string, 0, len(slice))
 	for _, element := range slice {
 		if *element != *item {

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -71,9 +71,12 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 
 	// Removing outputId from all defaults
 	for _, defaultOutput := range defaults {
-		defaultOutput.OutputIDs = removeFromSlice(defaultOutput.OutputIDs, input.OutputID)
-		if err := defaultsTable.PutDefaults(defaultOutput); err != nil {
-			return nil, err
+		var removed bool
+		defaultOutput.OutputIDs, removed = removeFromSlice(defaultOutput.OutputIDs, input.OutputID)
+		if removed {
+			if err := defaultsTable.PutDefaults(defaultOutput); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -88,11 +91,13 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 	return alertOutput, nil
 }
 
-func removeFromSlice(slice []*string, item *string) []*string {
+// Removes an item from a slice if it exists. Returns a boolean indicating whether an item
+// was removed or not
+func removeFromSlice(slice []*string, item *string) ([]*string, bool) {
 	for i, element := range slice {
 		if *element == *item {
-			return append(slice[:i], slice[i+1:]...)
+			return append(slice[:i], slice[i+1:]...), true
 		}
 	}
-	return slice
+	return slice, false
 }

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -72,7 +72,7 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 	// Removing outputId from all defaults
 	for _, defaultOutput := range defaults {
 		var removed bool
-		defaultOutput.OutputIDs, removed = removeFromSlice(defaultOutput.OutputIDs, input.OutputID)
+		defaultOutput.OutputIDs, removed = removeSlice(defaultOutput.OutputIDs, input.OutputID)
 		if removed {
 			if err := defaultsTable.PutDefaults(defaultOutput); err != nil {
 				return nil, err
@@ -91,13 +91,14 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 	return alertOutput, nil
 }
 
-// Removes an item from a slice if it exists. Returns a boolean indicating whether an item
-// was removed or not
-func removeFromSlice(slice []*string, item *string) ([]*string, bool) {
-	for i, element := range slice {
-		if *element == *item {
-			return append(slice[:i], slice[i+1:]...), true
+// Removes an item from a slice if it exists. Returns the resulting slice
+// and a boolean indicating whether an item was removed or not
+func removeSlice(slice []*string, item *string) ([]*string, bool) {
+	new := make([]*string, 0, len(slice))
+	for _, element := range slice {
+		if *element != *item {
+			new = append(new, element)
 		}
 	}
-	return slice, false
+	return new, len(new) < len(slice)
 }

--- a/internal/core/outputs_api/api/update_output_test.go
+++ b/internal/core/outputs_api/api/update_output_test.go
@@ -135,8 +135,8 @@ func TestUpdateSameOutpuOutput(t *testing.T) {
 }
 
 func TestUpdateOutputAddSeverity(t *testing.T) {
-	// The output was configured to have only CRITICAL severity.
-	// Update configures it be be for CRITICAL and HIGH severity
+	// The output was configured to be default for only CRITICAL severity.
+	// Update configures it be default for CRITICAL and HIGH severity
 	mockOutputsTable := &mockOutputTable{}
 	outputsTable = mockOutputsTable
 	mockEncryptionKey := &mockEncryptionKey{}
@@ -197,8 +197,8 @@ func TestUpdateOutputAddSeverity(t *testing.T) {
 }
 
 func TestUpdateOutputRemoveSeverity(t *testing.T) {
-	// The output was configured to have only CRITICAL and HIGH severity.
-	// Update configures it be be only for CRITICAL severity
+	// The output was configured to be default for CRITICAL and HIGH severity.
+	// Update configures it be default for only CRITICAL severity
 	mockOutputsTable := &mockOutputTable{}
 	outputsTable = mockOutputsTable
 	mockEncryptionKey := &mockEncryptionKey{}

--- a/internal/core/outputs_api/api/update_output_test.go
+++ b/internal/core/outputs_api/api/update_output_test.go
@@ -133,3 +133,131 @@ func TestUpdateSameOutpuOutput(t *testing.T) {
 
 	mockOutputsTable.AssertExpectations(t)
 }
+
+func TestUpdateOutputAddSeverity(t *testing.T) {
+	// The output was configured to have only CRITICAL severity.
+	// Update configures it be be for CRITICAL and HIGH severity
+	mockOutputsTable := &mockOutputTable{}
+	outputsTable = mockOutputsTable
+	mockEncryptionKey := &mockEncryptionKey{}
+	encryptionKey = mockEncryptionKey
+	mockDefaultsTable := &mockDefaultsTable{}
+	defaultsTable = mockDefaultsTable
+
+	// Output was default for CRITICAL severity
+	previousDefaults := []*models.DefaultOutputsItem{
+		{
+			Severity:  aws.String("CRITICAL"),
+			OutputIDs: []*string{alertOutputItem.OutputID},
+		},
+	}
+	mockDefaultsTable.On("GetDefaults", mock.Anything).Return(previousDefaults, nil)
+
+	// First the output will be removed from CRITICAL
+	expectedRemoveDefaultOutputForCritical := &models.DefaultOutputsItem{
+		Severity:  aws.String("CRITICAL"),
+		OutputIDs: []*string{},
+	}
+	mockDefaultsTable.On("PutDefaults", expectedRemoveDefaultOutputForCritical).Return(nil).Once()
+
+	// We expect that the output will be added as default for CRITICAL and HIGH
+	expectedAddDefaultOutputForCritical := &models.DefaultOutputsItem{
+		Severity:  aws.String("CRITICAL"),
+		OutputIDs: []*string{alertOutputItem.OutputID},
+	}
+	expectedAddDefaultOutputForHigh := &models.DefaultOutputsItem{
+		Severity:  aws.String("HIGH"),
+		OutputIDs: []*string{alertOutputItem.OutputID},
+	}
+	mockDefaultsTable.On("PutDefaults", expectedAddDefaultOutputForCritical).Return(nil).Once()
+	mockDefaultsTable.On("PutDefaults", expectedAddDefaultOutputForHigh).Return(nil).Once()
+
+	mockOutputsTable.On("GetOutputByName", aws.String("displayName")).Return(alertOutputItem, nil)
+	mockDefaultsTable.On("GetDefault", mock.Anything).Return(nil, nil)
+	mockOutputsTable.On("UpdateOutput", mock.Anything).Return(alertOutputItem, nil)
+	mockEncryptionKey.On("EncryptConfig", mock.Anything).Return(make([]byte, 1), nil)
+	mockEncryptionKey.On("DecryptConfig", mock.Anything, mock.Anything).Return(nil)
+
+	updateOutputInput := &models.UpdateOutputInput{
+		OutputID:           alertOutputItem.OutputID,
+		DisplayName:        alertOutputItem.DisplayName,
+		UserID:             alertOutputItem.LastModifiedBy,
+		OutputConfig:       &models.OutputConfig{Sns: &models.SnsConfig{}},
+		DefaultForSeverity: aws.StringSlice([]string{"CRITICAL", "HIGH"}),
+	}
+	result, err := (API{}).UpdateOutput(updateOutputInput)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updateOutputInput.OutputID, result.OutputID)
+	assert.Equal(t, updateOutputInput.DisplayName, result.DisplayName)
+	assert.Equal(t, updateOutputInput.UserID, result.LastModifiedBy)
+	assert.Equal(t, aws.String("sns"), result.OutputType)
+
+	mockOutputsTable.AssertExpectations(t)
+}
+
+func TestUpdateOutputRemoveSeverity(t *testing.T) {
+	// The output was configured to have only CRITICAL and HIGH severity.
+	// Update configures it be be only for CRITICAL severity
+	mockOutputsTable := &mockOutputTable{}
+	outputsTable = mockOutputsTable
+	mockEncryptionKey := &mockEncryptionKey{}
+	encryptionKey = mockEncryptionKey
+	mockDefaultsTable := &mockDefaultsTable{}
+	defaultsTable = mockDefaultsTable
+
+	// Output was default for CRITICAL and HIGH severity
+	previousDefaults := []*models.DefaultOutputsItem{
+		{
+			Severity:  aws.String("CRITICAL"),
+			OutputIDs: []*string{alertOutputItem.OutputID},
+		},
+		{
+			Severity:  aws.String("HIGH"),
+			OutputIDs: []*string{alertOutputItem.OutputID},
+		},
+	}
+	mockDefaultsTable.On("GetDefaults", mock.Anything).Return(previousDefaults, nil)
+
+	// First the output will be removed from CRITICAL and HIGH
+	expectedRemoveDefaultOutputForCritical := &models.DefaultOutputsItem{
+		Severity:  aws.String("CRITICAL"),
+		OutputIDs: []*string{},
+	}
+	expectedRemoveDefaultOutputForHigh := &models.DefaultOutputsItem{
+		Severity:  aws.String("HIGH"),
+		OutputIDs: []*string{},
+	}
+	mockDefaultsTable.On("PutDefaults", expectedRemoveDefaultOutputForCritical).Return(nil).Once()
+	mockDefaultsTable.On("PutDefaults", expectedRemoveDefaultOutputForHigh).Return(nil).Once()
+
+	// We expect that the output will be added as default for CRITICAL and HIGH
+	expectedAddDefaultOutputForCritical := &models.DefaultOutputsItem{
+		Severity:  aws.String("CRITICAL"),
+		OutputIDs: []*string{alertOutputItem.OutputID},
+	}
+	mockDefaultsTable.On("PutDefaults", expectedAddDefaultOutputForCritical).Return(nil).Once()
+
+	mockOutputsTable.On("GetOutputByName", aws.String("displayName")).Return(alertOutputItem, nil)
+	mockDefaultsTable.On("GetDefault", mock.Anything).Return(nil, nil)
+	mockOutputsTable.On("UpdateOutput", mock.Anything).Return(alertOutputItem, nil)
+	mockEncryptionKey.On("EncryptConfig", mock.Anything).Return(make([]byte, 1), nil)
+	mockEncryptionKey.On("DecryptConfig", mock.Anything, mock.Anything).Return(nil)
+
+	updateOutputInput := &models.UpdateOutputInput{
+		OutputID:           alertOutputItem.OutputID,
+		DisplayName:        alertOutputItem.DisplayName,
+		UserID:             alertOutputItem.LastModifiedBy,
+		OutputConfig:       &models.OutputConfig{Sns: &models.SnsConfig{}},
+		DefaultForSeverity: aws.StringSlice([]string{"CRITICAL"}),
+	}
+	result, err := (API{}).UpdateOutput(updateOutputInput)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updateOutputInput.OutputID, result.OutputID)
+	assert.Equal(t, updateOutputInput.DisplayName, result.DisplayName)
+	assert.Equal(t, updateOutputInput.UserID, result.LastModifiedBy)
+	assert.Equal(t, aws.String("sns"), result.OutputType)
+
+	mockOutputsTable.AssertExpectations(t)
+}

--- a/internal/core/outputs_api/main/integration_test.go
+++ b/internal/core/outputs_api/main/integration_test.go
@@ -333,7 +333,6 @@ func updateInvalid(t *testing.T) {
 }
 
 func updateSlack(t *testing.T) {
-	t.Parallel()
 	slack.WebhookURL = aws.String("https://hooks.slack.com/services/DDDDDDDDD/EEEEEEEEE/" +
 		"abcdefghijklmnopqrstuvwx")
 	input := models.LambdaInput{
@@ -346,12 +345,12 @@ func updateSlack(t *testing.T) {
 		},
 	}
 	var output models.UpdateOutputOutput
-	assert.NoError(t, genericapi.Invoke(lambdaClient, outputsAPI, &input, &output))
-	assert.Equal(t, slackOutputID, output.OutputID)
-	assert.Equal(t, aws.String("alert-channel-new"), output.DisplayName)
-	assert.Equal(t, slack, output.OutputConfig.Slack)
-	assert.Equal(t, aws.String("slack"), output.OutputType)
-	assert.Nil(t, output.OutputConfig.Sns)
+	require.NoError(t, genericapi.Invoke(lambdaClient, outputsAPI, &input, &output))
+	require.Equal(t, slackOutputID, output.OutputID)
+	require.Equal(t, aws.String("alert-channel-new"), output.DisplayName)
+	require.Equal(t, slack, output.OutputConfig.Slack)
+	require.Equal(t, aws.String("slack"), output.OutputType)
+	require.Nil(t, output.OutputConfig.Sns)
 
 	defaults, err := getDefaultOutputsInternal()
 	require.NoError(t, err)
@@ -359,11 +358,10 @@ func updateSlack(t *testing.T) {
 		Severity:  aws.String("CRITICAL"),
 		OutputIDs: []*string{slackOutputID},
 	}
-	assert.Equal(t, []*models.DefaultOutputs{expectedDefaultOutputs}, defaults.Defaults)
+	require.Equal(t, []*models.DefaultOutputs{expectedDefaultOutputs}, defaults.Defaults)
 }
 
 func updateSns(t *testing.T) {
-	t.Parallel()
 	sns.TopicArn = aws.String("arn:aws:sns:us-west-2:123456789012:MyTopic")
 	input := models.LambdaInput{
 		UpdateOutput: &models.UpdateOutputInput{

--- a/internal/core/outputs_api/table/get_default.go
+++ b/internal/core/outputs_api/table/get_default.go
@@ -34,6 +34,8 @@ func (table *DefaultsTable) GetDefault(severity *string) (*models.DefaultOutputs
 			Key: DynamoItem{
 				"severity": {S: severity},
 			},
+			// Need consistent reads since code performs some
+			// quick read-after-write operations that require consistency.
 			ConsistentRead: aws.Bool(true),
 		})
 

--- a/internal/core/outputs_api/table/get_default.go
+++ b/internal/core/outputs_api/table/get_default.go
@@ -19,6 +19,7 @@ package table
  */
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 
@@ -33,6 +34,7 @@ func (table *DefaultsTable) GetDefault(severity *string) (*models.DefaultOutputs
 			Key: DynamoItem{
 				"severity": {S: severity},
 			},
+			ConsistentRead: aws.Bool(true),
 		})
 
 	if err != nil {

--- a/internal/core/outputs_api/table/query_defaults.go
+++ b/internal/core/outputs_api/table/query_defaults.go
@@ -30,7 +30,7 @@ import (
 // GetDefaults returns the default outputs for one organization
 func (table *DefaultsTable) GetDefaults() (defaults []*models.DefaultOutputsItem, err error) {
 	var scanInput = &dynamodb.ScanInput{
-		TableName:      table.Name,
+		TableName: table.Name,
 		// Need consistent reads since code performs some
 		// quick read-after-write operations that require consistency.
 		ConsistentRead: aws.Bool(true),

--- a/internal/core/outputs_api/table/query_defaults.go
+++ b/internal/core/outputs_api/table/query_defaults.go
@@ -31,6 +31,8 @@ import (
 func (table *DefaultsTable) GetDefaults() (defaults []*models.DefaultOutputsItem, err error) {
 	var scanInput = &dynamodb.ScanInput{
 		TableName:      table.Name,
+		// Need consistent reads since code performs some
+		// quick read-after-write operations that require consistency.
 		ConsistentRead: aws.Bool(true),
 	}
 

--- a/internal/core/outputs_api/table/query_defaults.go
+++ b/internal/core/outputs_api/table/query_defaults.go
@@ -19,6 +19,7 @@ package table
  */
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 
@@ -29,7 +30,8 @@ import (
 // GetDefaults returns the default outputs for one organization
 func (table *DefaultsTable) GetDefaults() (defaults []*models.DefaultOutputsItem, err error) {
 	var scanInput = &dynamodb.ScanInput{
-		TableName: table.Name,
+		TableName:      table.Name,
+		ConsistentRead: aws.Bool(true),
 	}
 
 	var internalErr error


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Fixing flaky integration tests

## Changes
> List your changes here in more detail

* Changed some `assert` to `require` - thinking it was more appropriate. 
* Replacing `"1"` magic string with `orgID` in `UpdateOrganization` API. I believe this method is no longer used, but I will postpone removing it until we have a better plan for this. 
* Fixed `UpdateSns` & `UpdateSlack` output integration tests:
   * In some parts of the code we are performing read-after-write on the DDB table `panther-default-outputs` and we need the reads to be consistent. Modified the GetDefault* methods to perform consistent queries. We make these operations upon user actions, so there is no real concern for increased costs
   * Tests were failing because we had configured `UpdateSns` & `UpdateSlack` to run in parallel. This currently can cause the two operations to overlap and cause one of them to fail. 
  * It would be a better plan of action to remove the `panther-default-outputs` table. It is not offering much of a benefit right now and it can also cause issue when two outputs are updated simultaneously. Can do in separate PR. 

## Testing
> How did you test your change? 

* Ran 30 times the integration tests after making the changes. Didn't seen them fail once. 
