### PR TITLE
Fix warning while uploading ECR image

### DIFF
--- a/tools/mage/deploy_frontend.go
+++ b/tools/mage/deploy_frontend.go
@@ -51,26 +51,7 @@ func buildAndPushImageFromSource(awsSession *session.Session, imageTag string) e
 	}
 	credentials := strings.Split(string(decodedCredentialsInBytes), ":")
 
-	// Piping the Docker password to stdin
-	// before calling docker login command.
-	_, pipeWriter, err := os.Pipe()
-	if err != nil {
-		return  err
-	}
-	defer func() {
-		pipeWriter.Close()
-	}()
-	if _, err := pipeWriter.WriteString(credentials[1]); err != nil {
-		return err
-	}
-
-
-	fmt.Println("deploy: logging in to remote image repo")
-	if err := sh.Run("docker", "login",
-		"-u", credentials[0],
-		"--password-stdin",
-		ecrServer,
-	); err != nil {
+	if err := dockerLogin(ecrServer, credentials); err != nil {
 		return err
 	}
 
@@ -90,6 +71,37 @@ func buildAndPushImageFromSource(awsSession *session.Session, imageTag string) e
 	}
 
 	return nil
+}
+
+func dockerLogin(ecrServer string, dockerCredentials []string) error {
+	// We are going to replace Stdin with a pipe reader, so temporarily
+	// cache previous Stdin
+	existingStdin := os.Stdin
+	// Make sure to reset the Stdin.
+	defer func() {
+		os.Stdin = existingStdin
+	}()
+	// Create a pipe to pass docker password to the docker login command
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	os.Stdin = pipeReader
+
+	// Write password to pipe
+	if _, err := pipeWriter.WriteString(dockerCredentials[1]); err != nil {
+		return err
+	}
+	if err := pipeWriter.Close(); err != nil {
+		return err
+	}
+
+	fmt.Println("deploy: logging in to remote image repo")
+	return sh.Run("docker", "login",
+		"-u", dockerCredentials[0],
+		"--password-stdin",
+		ecrServer,
+	)
 }
 
 // Accepts Cloudformation outputs, converts the keys into a screaming snakecase format and stores them in a dotenv file


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

While running `mage deploy` I got the following warning: 
```
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
```

According to docker [docs](https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin): 
```
To run the docker login command non-interactively, you can set the --password-stdin flag to provide a password through STDIN. Using STDIN prevents the password from ending up in the shell’s history, or log-files.

The following example reads a password from a file, and passes it to the docker login command using STDIN:
```

## Changes
> List your changes here in more detail

* Switched docker login to use ``--password-stdin` command
* Using a pipe to pipe the password to the docker login command

## Testing
> How did you test your change? 

* Ran `mage deploy` and seen it succeed
