### PR TITLE
Updated scheduler ENV and permissions

### DIFF
--- a/deployments/compliance/snapshot.yml
+++ b/deployments/compliance/snapshot.yml
@@ -256,6 +256,7 @@ Resources:
       Environment:
         Variables:
           DEBUG: !Ref Debug
+          SNAPSHOT_POLLERS_QUEUE_URL: !Ref Queue
       Events:
         ScheduleScans:
           Type: Schedule
@@ -277,6 +278,22 @@ Resources:
             - Effect: Allow
               Action: lambda:InvokeFunction
               Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-snapshot-api
+        -
+          Id: SendSQSMessages
+          Version: 2012-10-17
+          Statement:
+            -
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt Queue.Arn
+            -
+              Effect: Allow
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey
+              Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${SQSKeyId}
 
   SchedulerLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

@jacknagz identified an issue with the `snapshot-scheduler` failing to issue new scans. The root cause was that after migrating to the mono repo, in a few cases we simplified some things by calling functions directly instead of via invoking their lambda function. When doing so, we lost access to the environment variables of those functions.

## Changes
> List your changes here in more detail

* Updated the `snapshot-scheduler` environment variables and permissions to be able to send messages directly to the `panther-snapshot-queue`

## Testing
> How did you test your change? 

* Tested manually in dev account
