### PR TITLE
Add tag support to describe columns in Glue tables

### DIFF
--- a/tools/cfngen/gluecf/schema.go
+++ b/tools/cfngen/gluecf/schema.go
@@ -58,17 +58,17 @@ func inferJSONColumns(t reflect.Type, customMappingsTable map[string]string) (co
 		if field.Anonymous { // if composing a struct, treat fields as part of this struct
 			cols = append(cols, inferJSONColumns(field.Type, customMappingsTable)...)
 		} else {
-			fieldName, jsonType, skip := inferStructFieldType(field, customMappingsTable)
+			fieldName, jsonType, comment, skip := inferStructFieldType(field, customMappingsTable)
 			if skip {
 				continue
 			}
-			cols = append(cols, Column{Name: fieldName, Type: jsonType})
+			cols = append(cols, Column{Name: fieldName, Type: jsonType, Comment: comment})
 		}
 	}
 	return cols
 }
 
-func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string]string) (fieldName, jsonType string, skip bool) {
+func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string]string) (fieldName, jsonType, comment string, skip bool) {
 	t := sf.Type
 
 	// deference pointers
@@ -97,10 +97,13 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 		skip = true
 		return
 	}
+
 	fieldName, _ = parseTag(tag)
 	if fieldName == "" {
 		fieldName = sf.Name
 	}
+
+	comment = sf.Tag.Get("description")
 
 	switch t.Kind() { // NOTE: not all possible nestings have been implemented
 	case reflect.Slice:
@@ -119,7 +122,7 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 		}
 
 	case reflect.Map:
-		return fieldName, inferMap(t, customMappingsTable), skip
+		return fieldName, inferMap(t, customMappingsTable), comment, skip
 
 	case reflect.Struct:
 
@@ -154,7 +157,7 @@ func inferStruct(structType reflect.Type, customMappingsTable map[string]string)
 	numFields := structType.NumField()
 	var keyPairs []string
 	for i := 0; i < numFields; i++ {
-		subFieldName, subFieldJSONType, subFieldSkip := inferStructFieldType(structType.Field(i), customMappingsTable)
+		subFieldName, subFieldJSONType, _, subFieldSkip := inferStructFieldType(structType.Field(i), customMappingsTable)
 		if subFieldSkip {
 			continue
 		}

--- a/tools/cfngen/gluecf/schema_test.go
+++ b/tools/cfngen/gluecf/schema_test.go
@@ -226,7 +226,7 @@ type composedStruct struct {
 }
 
 type fooStruct struct {
-	Foo string
+	Foo string `description:"this is Foo field and it is awesome"`
 }
 
 func TestComposeStructs(t *testing.T) {
@@ -239,7 +239,7 @@ func TestComposeStructs(t *testing.T) {
 	}
 	cols := InferJSONColumns(&composition)
 	expectedColumns := []Column{
-		{Name: "Foo", Type: "string"},
+		{Name: "Foo", Type: "string", Comment: "this is Foo field and it is awesome"},
 		{Name: "Bar", Type: "string"},
 	}
 	require.Equal(t, expectedColumns, cols)


### PR DESCRIPTION
## Background
Developers can add a struct field tag called "description" which will be added to the Glue table column description. This shows up when users hover over columns in the Athena console.

## Testing
* mage test:unit
* add to columns of log process types and confirmed works in dev account (future PR).


![image](https://user-images.githubusercontent.com/18419762/73099992-a0277100-3eba-11ea-98fd-6e7425d4b739.png)
