### PR TITLE
[cfn] rename fields for consistency, formatting fixes

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
@@ -28,15 +28,15 @@ Parameters:
   # Optional configuration parameters
   S3Buckets:
     Type: CommaDelimitedList
-    Description: Allow Panther master account to get location of these bucket patterns. >
+    Description: Allow Panther master account to get location of these bucket patterns.
       E.g. "arn:aws:s3:::my-bucket,arn:aws:s3:::another-bucket*"
   S3ObjectPrefixes:
     Type: CommaDelimitedList
-    Description: Allow Panther master account access to access S3 objects that have the following patterns >
+    Description: Allow Panther master account access to access S3 objects that have the following patterns.
       E.g. "arn:aws:s3:::my-bucket/prefix*,arn:aws:s3:::my-bucket/prefix-2*"
   EncryptionKeys:
     Type: CommaDelimitedList
-    Description: Allow Panther master account access to decrypt these KMS keys. >
+    Description: Allow Panther master account access to decrypt these KMS keys.
       E.g. "arn:aws:kms:us-west-2:111122223333:key/14f5c696-8198-417b-bb22-699990b400cf"
     Default: ''
 
@@ -67,19 +67,17 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action:
-                  - s3:GetBucketLocation
+                Action: s3:GetBucketLocation
                 Resource: !Ref S3Buckets
               - Effect: Allow
-                Action:
-                  - s3:GetObject
+                Action: s3:GetObject
                 Resource: !Ref S3ObjectPrefixes
               - !If
                 - WithKmsPermissions
                 - Effect: Allow
                   Action: kms:Decrypt
                   Resource: !Ref EncryptionKeys
-                - !Ref 'AWS::NoValue'
+                - !Ref AWS::NoValue
       Tags:
         - Key: Application
           Value: Panther

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -25,7 +25,7 @@ Parameters:
     Type: String
     Description: The name of the SNS topic
     Default: panther-notifications-topic
-  PantherAccountId:
+  MasterAccountId:
     Type: String
     Description: The AWS AccountId where you have deployed Panther
   PantherRegion:
@@ -82,7 +82,7 @@ Resources:
           - Sid: AllowSubscriptionToPanther
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${PantherAccountId}:root
+              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
             Action: sns:Subscribe
             Resource: !Ref Topic
       Topics:
@@ -92,11 +92,10 @@ Resources:
   Subscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Sub arn:aws:sqs:${PantherRegion}:${PantherAccountId}:panther-input-data-notifications
+      Endpoint: !Sub arn:aws:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications
       Protocol: sqs
       RawMessageDelivery: false
       TopicArn: !Ref Topic
-
 
 Outputs:
   SnsTopicArn:


### PR DESCRIPTION
## Background

A small PR to update the description and param naming for two CloudFormation templates

## Changes

* Change `PantherAccountId` to `MasterAccountId` for consistency across templates
* Remove the `>` in some param descriptions, this looks awkward in the AWS CloudFormation Console

## Testing

* Just CFN-lint