### PR TITLE
Add .gitbook yaml

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,1 @@
+root: ./docs/

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,1 +1,1 @@
-root: ./docs/
+root: ./docs/gitbook


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Adding .gitbook yaml will set the root folder for gitbook to be under `docs`. This will allow gitbook to compile it's content into Markdown files and sync the gitbook documentation with our github repo.

## Changes
> List your changes here in more detail

* Add .gitbook.yaml

