### PR TITLE
credential report timeout handling

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/cloudformation_stack.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudformation_stack.go
@@ -38,15 +38,17 @@ import (
 	"github.com/panther-labs/panther/internal/compliance/snapshot_poller/pollers/utils"
 )
 
+const (
+	// Time to delay the requeue of a scan of a CloudFormation stack whose drift detection was in
+	// progress when this scan started.
+	driftDetectionRequeueDelaySeconds = 30
+	requeueRequiredError              = "CloudFormation: re-queue required"
+)
+
 var (
 	// Set as variables to be overridden in testing
 	CloudFormationClientFunc = setupCloudFormationClient
 	maxDriftDetectionBackoff = 2 * time.Minute
-
-	// Time to delay the requeue of a scan of a CloudFormation stack whose drift detection was in
-	// progress when this scan started.
-	driftDetectionRequeueDelaySeconds int64 = 30
-	requeueRequiredError                    = "CloudFormation: re-queue required"
 )
 
 func setupCloudFormationClient(sess *session.Session, cfg *aws.Config) interface{} {

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
@@ -531,7 +531,6 @@ func PollIAMUsers(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.AddR
 	}
 
 	// Build the credential report for all users
-	// error ghere
 	userCredentialReports, err = buildCredentialReport(iamSvc)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
@@ -79,6 +79,7 @@ func PollIAMUser(
 		if awsErr, ok := err.(awserr.Error); ok {
 			// Check if we got rate limited, happens sometimes when the credential report takes a long time to generate
 			if awsErr.Code() == iam.ErrCodeLimitExceededException {
+				zap.L().Debug("credential report lookup rate limited during single user scan", zap.String("resourceId", *scanRequest.ResourceID))
 				utils.Requeue(pollermodels.ScanMsg{
 					Entries: []*pollermodels.ScanEntry{scanRequest},
 				}, credentialReportRequeueDelaySeconds)
@@ -536,6 +537,9 @@ func PollIAMUsers(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.AddR
 		if awsErr, ok := err.(awserr.Error); ok {
 			// Check if we got rate limited, happens sometimes when the credential report takes a long time to generate
 			if awsErr.Code() == iam.ErrCodeLimitExceededException {
+				zap.L().Debug(
+					"credential report lookup rate limited during all users scan",
+					zap.String("accountId", pollerInput.AuthSourceParsedARN.AccountID))
 				utils.Requeue(pollermodels.ScanMsg{
 					Entries: []*pollermodels.ScanEntry{{
 						AWSAccountID:  aws.String(pollerInput.AuthSourceParsedARN.AccountID),

--- a/internal/compliance/snapshot_poller/pollers/aws/poll.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll.go
@@ -335,10 +335,14 @@ func Poll(scanRequest *pollermodels.ScanEntry) (
 		// Account wide resource type scan
 	} else if scanRequest.ResourceType != nil {
 		zap.L().Info("processing full account resource type scan")
-		return serviceScan(
-			[]resourcePoller{ServicePollers[*scanRequest.ResourceType]},
-			pollerResourceInput,
-		)
+		if poller, ok := ServicePollers[*scanRequest.ResourceType]; ok {
+			return serviceScan(
+				[]resourcePoller{poller},
+				pollerResourceInput,
+			)
+		} else {
+			return nil, errors.Errorf("invalid single region resource type '%s' scan requested", *scanRequest.ResourceType)
+		}
 	}
 
 	zap.L().Error("Invalid scan request input")

--- a/internal/compliance/snapshot_poller/pollers/aws/poll.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll.go
@@ -19,7 +19,6 @@ package aws
  */
 
 import (
-	"errors"
 	"os"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	resourcesapimodels "github.com/panther-labs/panther/api/gateway/resources/models"
@@ -298,10 +298,14 @@ func Poll(scanRequest *pollermodels.ScanEntry) (
 		// Single region service scan
 	} else if scanRequest.Region != nil && scanRequest.ResourceType != nil {
 		zap.L().Info("processing single region service scan")
-		return serviceScan(
-			[]resourcePoller{ServicePollers[*scanRequest.ResourceType]},
-			pollerResourceInput,
-		)
+		if poller, ok := ServicePollers[*scanRequest.ResourceType]; ok {
+			return serviceScan(
+				[]resourcePoller{poller},
+				pollerResourceInput,
+			)
+		} else {
+			return nil, errors.Errorf("invalid single region resource type '%s' scan requested", *scanRequest.ResourceType)
+		}
 	}
 
 	// Get the list of active regions to scan

--- a/internal/compliance/snapshot_poller/pollers/utils/requeue.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/requeue.go
@@ -47,6 +47,12 @@ func Requeue(scanRequest poller.ScanMsg, delay int64) {
 		delay = MaxRequeueDelaySeconds
 	}
 
+	zap.L().Info(
+		"initiating scan re-queue",
+		zap.Int64("delaySeconds", delay),
+		zap.String("requeueRequest", body),
+	)
+
 	sqsClient := sqs.New(session.Must(session.NewSession()))
 	_, err = sqsClient.SendMessage(
 		&sqs.SendMessageInput{


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

When doing AWS IAM User scanning, we need a credential report. Building credential reports can sometimes take a long time, but generally not too long, so we just wait for it to complete then continue the scan.

Sometimes, we get rate limited while waiting for it to complete (we're doing a polling wait with exponential backoff). In the past we've increased the wait time and interval which helped this issue, but it happened again on my dev account the other day while doing a fresh installation.

This is a more permanent fix than raising the limits, as we catch the rate limit exception explicitly and re-queue a scan for the account in 90 seconds. If we get rate limited again, we'll just re-queue the scan for another 90 seconds later. We follow a similar-ish model for waiting for CloudFormation stack drift detections to complete.

Ideally we can add some fuzzy/randomization to the re-queue logic at some point, although we sort of get that for free as we are doing exponential/fuzzy back off each time it runs while waiting on the credential report to finish.

## Changes
> List your changes here in more detail

* Added re-queue logic to the IAM User snapshot poller around rate limiting
* Added some correctness checking when performing scans based on resource type

## Testing
> How did you test your change? 

* Testing on this is difficult, as credential reports can only be generated once every 4 hours (AWS limitation). I will attempt some further testing on Monday, perhaps trying to write an example program that imitates the poll logic and catch the error there but realistically there is not an easy way to test against a live system
