### PR TITLE
Glue schema generation: fix bug in applying custom mapping

### DIFF
--- a/tools/cfngen/gluecf/schema.go
+++ b/tools/cfngen/gluecf/schema.go
@@ -105,6 +105,11 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 
 	comment = sf.Tag.Get("description")
 
+	if to, found := customMappingsTable[t.String()]; found {
+		jsonType = to
+		return
+	}
+
 	switch t.Kind() { // NOTE: not all possible nestings have been implemented
 	case reflect.Slice:
 
@@ -125,12 +130,6 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 		return fieldName, inferMap(t, customMappingsTable), comment, skip
 
 	case reflect.Struct:
-
-		if to, found := customMappingsTable[t.String()]; found {
-			jsonType = to
-			return
-		}
-
 		if sf.Anonymous { // composed struct, fields part of enclosing struct
 			fieldName = ""
 			jsonType = inferStruct(t, customMappingsTable)

--- a/tools/cfngen/gluecf/schema_test.go
+++ b/tools/cfngen/gluecf/schema_test.go
@@ -30,6 +30,8 @@ import (
 
 type TestCustomSimpleType int
 
+type TestCustomSliceType []byte
+
 type TestCustomStructType struct {
 	Foo int
 }
@@ -110,6 +112,7 @@ func TestInferJsonColumns(t *testing.T) {
 		NestedStructField NestedStruct
 
 		CustomTypeField   TestCustomSimpleType
+		CustomSliceField  TestCustomSliceType
 		CustomStructField TestCustomStructType
 	}{
 		BoolField: true,
@@ -169,6 +172,10 @@ func TestInferJsonColumns(t *testing.T) {
 		From: reflect.TypeOf(simpleTestType),
 		To:   "foo",
 	}
+	customSliceTypeMapping := CustomMapping{
+		From: reflect.TypeOf(TestCustomSliceType{}),
+		To:   "baz",
+	}
 	customStructTypeMapping := CustomMapping{
 		From: reflect.TypeOf(TestCustomStructType{}),
 		To:   "bar",
@@ -201,10 +208,11 @@ func TestInferJsonColumns(t *testing.T) {
 		{Name: "StructField", Type: "struct<Field1:string,Field2:int>"},
 		{Name: "NestedStructField", Type: "struct<InheritedField:string,A:struct<Field1:string,Field2:int>,B:struct<Field1:string,Field2:int>,C:struct<Field1:string,Field2:int>>"}, // nolint
 		{Name: "CustomTypeField", Type: "foo"},
+		{Name: "CustomSliceField", Type: "baz"},
 		{Name: "CustomStructField", Type: "bar"},
 	}
 
-	cols := InferJSONColumns(obj, customSimpleTypeMapping, customStructTypeMapping)
+	cols := InferJSONColumns(obj, customSimpleTypeMapping, customSliceTypeMapping, customStructTypeMapping)
 
 	// uncomment to see results
 	/*


### PR DESCRIPTION
## Background
Before: Custom mappings only applied to slices. 
After: Custom mappings apply independent of type.


## Testing
* mage test:unit
* used with new log processing changes
