### PR TITLE
Fixing remediations IAM role

### DIFF
--- a/deployments/auxiliary/cloudformation/README.md
+++ b/deployments/auxiliary/cloudformation/README.md
@@ -5,8 +5,7 @@ A collection of CloudFormation templates to configure data collection and remedi
 ## Templates
 
 - `panther-aws-compliance-iam`: The IAM Roles used in conjunction with the compliance features.
-- `panther-aws-remediations-master-account`: The Serverless Application and IAM Role used for Automatic Remediation deployed in the master account.
-- `panther-aws-remediations-satellite-account`: The Serverless Application and IAM Role used for Automatic Remediation in the satellite accounts.
+- `panther-remediations-iam`: The IAM Role used for Automatic Remediation in the satellite accounts.
 - `panther-cloudwatch-events`: Configures AWS CloudWatch Events to send to SNS/SQS.
 - `panther-stackset-iam-admin-role`: The IAM Role orchestrating the StackSet creation.
 - `panther-log-processing-iam`: The IAM Roles used in conjunction with the log processing features.

--- a/deployments/auxiliary/cloudformation/panther-remediations-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-remediations-iam.yml
@@ -29,7 +29,7 @@ Resources:
   RemediationRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: AwsRemediationRole
+      RoleName: PantherRemediationRole
       MaxSessionDuration: 3600
       AssumeRolePolicyDocument:
         Version: 2012-10-17

--- a/deployments/compliance/remediation.yml
+++ b/deployments/compliance/remediation.yml
@@ -78,7 +78,7 @@ Parameters:
   RemediationRoleName:
     Type: String
     Description: The name of the IAM role to assume to perform remediation actions
-    Default: AwsRemediationRole
+    Default: PantherRemediationRole
 
   AnalysisApiId:
     Type: String

--- a/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
@@ -128,7 +128,7 @@ class RemediationBase:
             """Refresh credentials by invoking STS AssumeRole operation"""
             cls.logger.info("Refreshing credentials for account %s and region %s", account_id, region)
             params = {
-                'RoleArn': 'arn:aws:iam::{}:role/AwsRemediationRole'.format(account_id),
+                'RoleArn': 'arn:aws:iam::{}:role/PantherRemediationRole'.format(account_id),
                 'RoleSessionName': 'RemediationSession',
                 'DurationSeconds': 3600,
             }

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -102,5 +102,3 @@ export enum INTEGRATION_TYPES {
   AWS_LOGS = 'aws-s3',
   AWS_INFRA = 'aws-scan',
 }
-
-export const PANTHER_REMEDIATION_SATELLITE_ACCOUNT = 'panther-aws-remediations-satellite-account';

--- a/web/src/pages/create-source/subcomponents/create-infra-source/subcomponents/remediation-panel.tsx
+++ b/web/src/pages/create-source/subcomponents/create-infra-source/subcomponents/remediation-panel.tsx
@@ -18,13 +18,12 @@
 
 import React from 'react';
 import { Box, Button, Heading, Text } from 'pouncejs';
-import { PANTHER_REMEDIATION_SATELLITE_ACCOUNT } from 'Source/constants';
 
 const RemediationPanel: React.FC = () => {
-  const cfnLink =
-    `https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review` +
-    `?templateURL=https://s3-us-west-2.amazonaws.com/panther-public-cloudformation-templates/${PANTHER_REMEDIATION_SATELLITE_ACCOUNT}/latest/template.yml` +
-    `&stackName=${PANTHER_REMEDIATION_SATELLITE_ACCOUNT}` +
+  const cfnConsoleLink =
+    `https://${process.env.AWS_REGION}.console.aws.amazon.com/cloudformation/home?region=${process.env.AWS_REGION}#/stacks/create/review` +
+    `?templateURL=https://s3-us-west-2.amazonaws.com/panther-public-cloudformation-templates/panther-remediations-iam/latest/template.yml` +
+    `&stackName=panther-remediations-iam-roles` +
     `&param_MasterAccountId=${process.env.AWS_ACCOUNT_ID}`;
 
   return (
@@ -57,7 +56,7 @@ const RemediationPanel: React.FC = () => {
         target="_blank"
         is="a"
         rel="noopener noreferrer"
-        href={cfnLink}
+        href={cfnConsoleLink}
       >
         Launch Stack
       </Button>


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

All resources we create have the `Panther` prefix. Fixing remediations IAM role so that it has it as well. 

## Changes
> List your changes here in more detail

* Renamed `AwsRemediationsRole` to `PantherRemediationsRole`. 
* Updated README for aux CFN templates
* Updated remediation panel to follow the same style we use in the rest of the wizard panels. 
PR depends on https://github.com/panther-labs/cfn-templates-public/pull/58

## Testing
> How did you test your change? 

* Deployed and verified in account
