### PR TITLE
Renamed api field

### DIFF
--- a/api/lambda/alerts/models/api.go
+++ b/api/lambda/alerts/models/api.go
@@ -108,7 +108,7 @@ type Alert struct {
 	RuleID                 *string    `json:"ruleId"`
 	CreationTime           *time.Time `json:"creationTime"`
 	LastEventMatched       *time.Time `json:"lastEventMatched"`
-	MatchedEventNum        *int       `json:"matchedEventNum"`
+	EventsMatched          *int       `json:"eventsMatched"`
 	Events                 []*string  `json:"events"`
 	EventsLastEvaluatedKey *string    `json:"eventsLastEvaluatedKey,omitempty"`
 }

--- a/internal/log_analysis/alerts_api/api/get_alert.go
+++ b/internal/log_analysis/alerts_api/api/get_alert.go
@@ -47,7 +47,7 @@ func (API) GetAlert(input *models.GetAlertInput) (result *models.GetAlertOutput,
 		RuleID:           alertItem.RuleID,
 		CreationTime:     alertItem.CreationTime,
 		LastEventMatched: alertItem.LastEventMatched,
-		MatchedEventNum:  aws.Int(len(alertItem.EventHashes)),
+		EventsMatched:    aws.Int(len(alertItem.EventHashes)),
 	}
 
 	var eventHashesToReturn [][]byte


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

Renaming field in `Alert` struct to match the name in `AlertSummary`. 

## Testing
> How did you test your change? 

* `mage test:ci`. 
