### PR TITLE
Fix resource filtering by source integration

### DIFF
--- a/internal/compliance/resources_api/handlers/list_resources.go
+++ b/internal/compliance/resources_api/handlers/list_resources.go
@@ -117,6 +117,7 @@ func parseListResources(request *events.APIGatewayProxyRequest) (*operations.Lis
 		if err := models.IntegrationID(integrationID).Validate(nil); err != nil {
 			return nil, errors.New("invalid integrationId: " + err.Error())
 		}
+		result.IntegrationID = aws.String(integrationID)
 	}
 
 	if integrationType := request.QueryStringParameters["integrationType"]; integrationType != "" {


### PR DESCRIPTION
## Background
Filtering by source account does not work - it still shows all resources

Turns out we parse and validate the `integrationId` in the query parameters but never actually use it!

## Changes
* One-line fix for resource filtering

## Testing

* @nhakmiller 's dev account 
