### PR TITLE
[ENG-1355]Add issue type for jira destination

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -361,7 +361,7 @@ type JiraConfig {
   userName: String!
   apiKey: String!
   assigneeId: String
-  issueType: String
+  issueType: JiraIssueTypesEnum
 }
 
 type GithubConfig {
@@ -418,6 +418,7 @@ input JiraConfigInput {
   userName: String!
   apiKey: String!
   assigneeId: String
+  issueType: JiraIssueTypesEnum
 }
 
 input GithubConfigInput {
@@ -676,6 +677,12 @@ enum SeverityEnum {
   MEDIUM
   HIGH
   CRITICAL
+}
+
+enum JiraIssueTypesEnum {
+  Bug
+  Story
+  Task
 }
 
 enum AccountTypeEnum {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -361,6 +361,7 @@ type JiraConfig {
   userName: String!
   apiKey: String!
   assigneeId: String
+  issueType: String
 }
 
 type GithubConfig {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -258,7 +258,7 @@ export type JiraConfig = {
   userName: Scalars['String'];
   apiKey: Scalars['String'];
   assigneeId?: Maybe<Scalars['String']>;
-  issueType?: Maybe<Scalars['String']>;
+  issueType?: Maybe<JiraIssueTypesEnum>;
 };
 
 export type JiraConfigInput = {
@@ -268,6 +268,12 @@ export type JiraConfigInput = {
   apiKey: Scalars['String'];
   assigneeId?: Maybe<Scalars['String']>;
 };
+
+export enum JiraIssueTypesEnum {
+  Bug = 'Bug',
+  Story = 'Story',
+  Task = 'Task',
+}
 
 export type ListAlertsInput = {
   ruleId?: Maybe<Scalars['ID']>;

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -267,6 +267,7 @@ export type JiraConfigInput = {
   userName: Scalars['String'];
   apiKey: Scalars['String'];
   assigneeId?: Maybe<Scalars['String']>;
+  issueType?: Maybe<JiraIssueTypesEnum>;
 };
 
 export enum JiraIssueTypesEnum {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -258,6 +258,7 @@ export type JiraConfig = {
   userName: Scalars['String'];
   apiKey: Scalars['String'];
   assigneeId?: Maybe<Scalars['String']>;
+  issueType?: Maybe<Scalars['String']>;
 };
 
 export type JiraConfigInput = {
@@ -491,7 +492,6 @@ export type Organization = {
   displayName?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   alertReportFrequency?: Maybe<AlertReportFrequencyEnum>;
-  remediationConfig?: Maybe<RemediationConfig>;
 };
 
 export type OrganizationReportBySeverity = {
@@ -679,15 +679,6 @@ export type RemediateResourceInput = {
   resourceId: Scalars['ID'];
 };
 
-export type RemediationConfig = {
-  __typename?: 'RemediationConfig';
-  awsRemediationLambdaArn?: Maybe<Scalars['String']>;
-};
-
-export type RemediationConfigInput = {
-  awsRemediationLambdaArn?: Maybe<Scalars['String']>;
-};
-
 export type ResourceDetails = {
   __typename?: 'ResourceDetails';
   attributes?: Maybe<Scalars['AWSJSON']>;
@@ -838,7 +829,6 @@ export type UpdateOrganizationInput = {
   displayName?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   alertReportFrequency?: Maybe<AlertReportFrequencyEnum>;
-  remediationConfig?: Maybe<RemediationConfigInput>;
 };
 
 export type UpdateUserInput = {

--- a/web/src/components/forms/destination-form/jira-destination-form.tsx
+++ b/web/src/components/forms/destination-form/jira-destination-form.tsx
@@ -20,11 +20,13 @@ import React from 'react';
 import { Field } from 'formik';
 import * as Yup from 'yup';
 import FormikTextInput from 'Components/fields/text-input';
+import FormikCombobox from 'Components/fields/combobox';
 import { DestinationConfigInput } from 'Generated/schema';
 import BaseDestinationForm, {
   BaseDestinationFormValues,
   defaultValidationSchema,
 } from 'Components/forms/common/base-destination-form';
+import { JIRA_ISSUE_TYPE } from 'Source/constants';
 
 type JiraFieldValues = Pick<DestinationConfigInput, 'jira'>;
 
@@ -43,6 +45,7 @@ const jiraFieldsValidationSchema = Yup.object().shape({
       projectKey: Yup.string().required(),
       apiKey: Yup.string().required(),
       assigneeId: Yup.string(),
+      issueType: Yup.string().required(),
     }),
   }),
 });
@@ -80,7 +83,7 @@ const JiraDestinationForm: React.FC<JiraDestinationFormProps> = ({ onSubmit, ini
       <Field
         as={FormikTextInput}
         name="outputConfig.jira.userName"
-        label="User Name"
+        label="Email"
         placeholder="What's the name of the reporting user?"
         mb={6}
       />
@@ -100,6 +103,14 @@ const JiraDestinationForm: React.FC<JiraDestinationFormProps> = ({ onSubmit, ini
         label="Assignee ID"
         placeholder="Who should we assign this to?"
         mb={6}
+      />
+      <Field
+        as={FormikCombobox}
+        name="outputConfig.jira.issueType"
+        label="Issue Types"
+        mb={6}
+        aria-required
+        items={JIRA_ISSUE_TYPE}
       />
     </BaseDestinationForm>
   );

--- a/web/src/components/forms/destination-form/jira-destination-form.tsx
+++ b/web/src/components/forms/destination-form/jira-destination-form.tsx
@@ -45,7 +45,7 @@ const jiraFieldsValidationSchema = Yup.object().shape({
       apiKey: Yup.string().required(),
       assigneeId: Yup.string(),
       issueType: Yup.string().test('oneOf', 'Please select a valid value', value =>
-        Object.keys(JiraIssueTypesEnum).includes(value)
+        Object.values(JiraIssueTypesEnum).includes(value)
       ),
     }),
   }),
@@ -112,6 +112,7 @@ const JiraDestinationForm: React.FC<JiraDestinationFormProps> = ({ onSubmit, ini
         mb={6}
         aria-required
         items={Object.keys(JiraIssueTypesEnum)}
+        inputProps={{ placeholder: 'Select a type of issue' }}
       />
     </BaseDestinationForm>
   );

--- a/web/src/components/forms/destination-form/jira-destination-form.tsx
+++ b/web/src/components/forms/destination-form/jira-destination-form.tsx
@@ -21,12 +21,11 @@ import { Field } from 'formik';
 import * as Yup from 'yup';
 import FormikTextInput from 'Components/fields/text-input';
 import FormikCombobox from 'Components/fields/combobox';
-import { DestinationConfigInput } from 'Generated/schema';
+import { DestinationConfigInput, JiraIssueTypesEnum } from 'Generated/schema';
 import BaseDestinationForm, {
   BaseDestinationFormValues,
   defaultValidationSchema,
 } from 'Components/forms/common/base-destination-form';
-import { JIRA_ISSUE_TYPE } from 'Source/constants';
 
 type JiraFieldValues = Pick<DestinationConfigInput, 'jira'>;
 
@@ -45,7 +44,9 @@ const jiraFieldsValidationSchema = Yup.object().shape({
       projectKey: Yup.string().required(),
       apiKey: Yup.string().required(),
       assigneeId: Yup.string(),
-      issueType: Yup.string().required(),
+      issueType: Yup.string().test('oneOf', 'Please select a valid value', value =>
+        Object.keys(JiraIssueTypesEnum).includes(value)
+      ),
     }),
   }),
 });
@@ -84,7 +85,7 @@ const JiraDestinationForm: React.FC<JiraDestinationFormProps> = ({ onSubmit, ini
         as={FormikTextInput}
         name="outputConfig.jira.userName"
         label="Email"
-        placeholder="What's the name of the reporting user?"
+        placeholder="What's the email of the reporting user?"
         mb={6}
       />
       <Field
@@ -107,10 +108,10 @@ const JiraDestinationForm: React.FC<JiraDestinationFormProps> = ({ onSubmit, ini
       <Field
         as={FormikCombobox}
         name="outputConfig.jira.issueType"
-        label="Issue Types"
+        label="Issue Type"
         mb={6}
         aria-required
-        items={JIRA_ISSUE_TYPE}
+        items={Object.keys(JiraIssueTypesEnum)}
       />
     </BaseDestinationForm>
   );

--- a/web/src/components/sidesheets/add-destination-sidesheet.tsx
+++ b/web/src/components/sidesheets/add-destination-sidesheet.tsx
@@ -72,6 +72,7 @@ const ADD_DESTINATION = gql`
           userName
           apiKey
           assigneeId
+          issueType
         }
         opsgenie {
           apiKey

--- a/web/src/components/sidesheets/add-destination-sidesheet.tsx
+++ b/web/src/components/sidesheets/add-destination-sidesheet.tsx
@@ -201,6 +201,7 @@ const AddDestinationSidesheet: React.FC<AddDestinationSidesheetProps> = ({ desti
                   userName: '',
                   apiKey: '',
                   assigneeId: '',
+                  issueType: null,
                 },
               },
             }}

--- a/web/src/components/sidesheets/update-destination-sidesheet.tsx
+++ b/web/src/components/sidesheets/update-destination-sidesheet.tsx
@@ -72,6 +72,7 @@ const UPDATE_DESTINATION = gql`
           userName
           apiKey
           assigneeId
+          issueType
         }
         opsgenie {
           apiKey
@@ -191,6 +192,7 @@ export const UpdateDestinationSidesheet: React.FC<UpdateDestinationSidesheetProp
                 'jira.userName',
                 'jira.apiKey',
                 'jira.assigneeId',
+                'jira.issueType',
               ]),
             }}
             onSubmit={handleSubmit}

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -79,6 +79,8 @@ export const LOG_TYPES = [
   'Osquery.Status',
 ] as const;
 
+export const JIRA_ISSUE_TYPE = ['Bug', 'Story', 'Task'] as const;
+
 export const SEVERITY_COLOR_MAP: { [key in SeverityEnum]: BadgeProps['color'] } = {
   [SeverityEnum.Critical]: 'red' as const,
   [SeverityEnum.High]: 'pink' as const,

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -79,8 +79,6 @@ export const LOG_TYPES = [
   'Osquery.Status',
 ] as const;
 
-export const JIRA_ISSUE_TYPE = ['Bug', 'Story', 'Task'] as const;
-
 export const SEVERITY_COLOR_MAP: { [key in SeverityEnum]: BadgeProps['color'] } = {
   [SeverityEnum.Critical]: 'red' as const,
   [SeverityEnum.High]: 'pink' as const,

--- a/web/src/pages/destinations/index.tsx
+++ b/web/src/pages/destinations/index.tsx
@@ -59,6 +59,7 @@ export const LIST_DESTINATIONS = gql`
           userName
           apiKey
           assigneeId
+          issueType
         }
         opsgenie {
           apiKey


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

The JIRA destination currently defaults to creating a `Task`. We don't have `Task`s enabled in our JIRA account so this fails. I've switched it over to create a `Bug` and it works, but theoretically another organization may have and prefer `Task`s and not even have `Bug`s enabled. Please add an input named `type` or something similar, which can accept the values `Bug`, `Story`, and `Task`. Preferably in a convenient little dropdown select thingy or something so users don't have to type it 

In addition, we'll change the user name to email address
## Changes
> List your changes here in more detail

* Add `issueType` into the jira destination form which is reflected in `schema.graphql`, list destinations component and the jira form

## Testing
> How did you test your change? 

* Local testing with a deployed instance on personal account
