### PR TITLE
Support AWS Partition deployment within Cloudformation.

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
@@ -111,7 +111,7 @@ Resources:
           - Sid: CloudWatchEventsPublish
             Effect: Allow
             Principal:
-              Service: events.${AWS::URLSuffix}
+              Service: !Sub events.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref PantherEventsTopic
           - Sid: CrossAccountSubscription

--- a/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
@@ -97,7 +97,6 @@ Conditions:
   SSMEvents: !Equals [!Ref SSMEvents, 'True']
 
 Resources:
-
   # SNS Topic, Policy, and Subscription to SQS
 
   PantherEventsTopic:
@@ -109,18 +108,16 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Sid: CloudWatchEventsPublish
+          - Sid: CloudWatchEventsPublish
             Effect: Allow
             Principal:
-              Service: events.amazonaws.com
+              Service: events.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref PantherEventsTopic
-          -
-            Sid: CrossAccountSubscription
+          - Sid: CrossAccountSubscription
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sns:Subscribe
             Resource: !Ref PantherEventsTopic
       Topics:
@@ -146,8 +143,7 @@ Resources:
           - AWS API Call via CloudTrail
       State: ENABLED
       Targets:
-        -
-          Arn: !Ref PantherEventsTopic
+        - Arn: !Ref PantherEventsTopic
           Id: panther-collect-cloudtrail-events
 
   SecurityRule:

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -66,7 +66,7 @@ Resources:
               Bool:
                 aws:SecureTransport: true
       ManagedPolicyArns:
-        - arn:${AWS::Partition}:iam::aws:policy/SecurityAudit
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/SecurityAudit
       Policies:
         - PolicyName: CloudFormationStackDriftDetection
           PolicyDocument:

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -115,7 +115,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:${AWS:: Partition}:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
       Policies:
         - PolicyName: ManageCloudFormationStack
@@ -150,7 +150,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:${AWS:: Partition}:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
             Condition:
               Bool:

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -30,12 +30,12 @@ Parameters:
   DeployAuditRole:
     Type: String
     Description: Creates the panther-audit-role required for compliance scanning.
-    Default: True 
+    Default: True
     AllowedValues: [true, false]
   DeployCloudWatchEventSetup:
     Type: String
     Description: Creates a StackSet Execution Role to configure CloudWatch Events to send to Panther for compliance processing (optional).
-    Default: True 
+    Default: True
     AllowedValues: [true, false]
   DeployRemediation:
     Type: String
@@ -44,9 +44,9 @@ Parameters:
     AllowedValues: [true, false]
 
 Conditions:
-  AuditRole:       !Equals [true, !Ref DeployAuditRole]
-  CloudWatchEventSetup:     !Equals [true, !Ref DeployCloudWatchEventSetup]
-  AutoRemediation:  !Equals [true, !Ref DeployRemediation]
+  AuditRole: !Equals [true, !Ref DeployAuditRole]
+  CloudWatchEventSetup: !Equals [true, !Ref DeployCloudWatchEventSetup]
+  AutoRemediation: !Equals [true, !Ref DeployRemediation]
 
 Resources:
   AuditRole:
@@ -58,19 +58,17 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
             Condition:
               Bool:
                 aws:SecureTransport: true
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/SecurityAudit
+        - arn:${AWS::Partition}:iam::aws:policy/SecurityAudit
       Policies:
-        -
-          PolicyName: CloudFormationStackDriftDetection
+        - PolicyName: CloudFormationStackDriftDetection
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -79,8 +77,7 @@ Resources:
                   - cloudformation:DetectStackDrift
                   - cloudformation:DetectStackResourceDrift
                 Resource: '*'
-        -
-          PolicyName: GetWAFACLs
+        - PolicyName: GetWAFACLs
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -92,8 +89,7 @@ Resources:
                   - waf-regional:GetWebACL
                   - waf-regional:GetWebACLForResource
                 Resource: '*'
-        -
-          PolicyName: GetTags
+        - PolicyName: GetTags
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -119,25 +115,21 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS:: Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
       Policies:
-        -
-          PolicyName: ManageCloudFormationStack
+        - PolicyName: ManageCloudFormationStack
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              -
-                Effect: Allow
+              - Effect: Allow
                 Action: cloudformation:*
                 Resource: '*'
-        -
-          PolicyName: PantherSetupRealTimeEvents
+        - PolicyName: PantherSetupRealTimeEvents
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              -
-                Effect: Allow
+              - Effect: Allow
                 Action:
                   - events:*
                   - sns:*
@@ -152,20 +144,19 @@ Resources:
     Properties:
       RoleName: PantherRemediationRole
       Description: The Panther master account assumes this role for automatic remediation of policy violations
-      MaxSessionDuration: 3600  # 1 hour
+      MaxSessionDuration: 3600 # 1 hour
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS:: Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
             Condition:
               Bool:
                 aws:SecureTransport: true
       Policies:
-        -
-          PolicyName: AllowRemediativeActions
+        - PolicyName: AllowRemediativeActions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -210,4 +201,4 @@ Outputs:
   PantherRemediationRoleArn:
     Condition: AutoRemediation
     Description: The Arn of the Panther Auto Remediation IAM Role
-    Value: !GetAtt RemediationRole.Arn 
+    Value: !GetAtt RemediationRole.Arn

--- a/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
@@ -32,7 +32,8 @@ Parameters:
       E.g. "arn:aws:s3:::my-bucket,arn:aws:s3:::another-bucket*"
   S3ObjectPrefixes:
     Type: CommaDelimitedList
-    Description: Allow Panther master account access to access S3 objects that have the following patterns.
+    Description:
+      Allow Panther master account access to access S3 objects that have the following patterns.
       E.g. "arn:aws:s3:::my-bucket/prefix*,arn:aws:s3:::my-bucket/prefix-2*"
   EncryptionKeys:
     Type: CommaDelimitedList
@@ -49,20 +50,19 @@ Resources:
     Properties:
       RoleName: PantherLogProcessingRole
       Description: The Panther master account assumes this role to read log data
-      MaxSessionDuration: 3600  # 1 hour
+      MaxSessionDuration: 3600 # 1 hour
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
             Condition:
               Bool:
                 aws:SecureTransport: true
       Policies:
-        -
-          PolicyName: ReadData
+        - PolicyName: ReadData
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
@@ -30,7 +30,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
   DataLifetime:
-    Type: Number 
+    Type: Number
     Description: How long to wait before automatically deleting data, if ExpireData is set to true.
     Default: 30
 
@@ -51,8 +51,9 @@ Resources:
         Rules:
           - Id: 30DayExpiration
             Status: !If [ExpireData, Enabled, Disabled]
-            ExpirationInDays: !If [ExpireData, !Ref DataLifetime, !Ref "AWS::NoValue"]
-            NoncurrentVersionExpirationInDays: !If [ExpireData, !Ref DataLifetime, !Ref "AWS::NoValue"]
+            ExpirationInDays: !If [ExpireData, !Ref DataLifetime, !Ref 'AWS::NoValue']
+            NoncurrentVersionExpirationInDays:
+              !If [ExpireData, !Ref DataLifetime, !Ref 'AWS::NoValue']
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -63,8 +64,7 @@ Resources:
         Status: Enabled
       NotificationConfiguration:
         TopicConfigurations:
-          -
-            Topic: !Ref LogProcessingNotificationsTopic
+          - Topic: !Ref LogProcessingNotificationsTopic
             Event: s3:ObjectCreated:*
 
   # This policy grants the CloudTrail and VPC FLow Logs services write permissions, and blocks
@@ -80,13 +80,13 @@ Resources:
           - Sid: CloudTrailAclCheck
             Effect: Allow
             Principal:
-              Service: cloudtrail.amazonaws.com
+              Service: cloudtrail.${AWS::URLSuffix}
             Action: s3:GetBucketAcl
             Resource: !GetAtt LogProcessingBucket.Arn
           - Sid: CloudTrailWrite
             Effect: Allow
             Principal:
-              Service: cloudtrail.amazonaws.com
+              Service: cloudtrail.${AWS::URLSuffix}
             Action: s3:PutObject
             Resource: !Sub ${LogProcessingBucket.Arn}/*
             Condition:
@@ -105,13 +105,13 @@ Resources:
           - Sid: VPCFlowAclCheck
             Effect: Allow
             Principal:
-              Service: delivery.logs.amazonaws.com
+              Service: delivery.logs.${AWS::URLSuffix}
             Action: s3:GetBucketAcl
             Resource: !GetAtt LogProcessingBucket.Arn
           - Sid: VPCFlowWrite
             Effect: Allow
             Principal:
-              Service: delivery.logs.amazonaws.com
+              Service: delivery.logs.${AWS::URLSuffix}
             Action: s3:PutObject
             Resource: !Sub ${LogProcessingBucket.Arn}/*
             Condition:
@@ -132,19 +132,17 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            # Reference: https://amzn.to/2ouFmhK
+          - # Reference: https://amzn.to/2ouFmhK
             Sid: S3NotificationPublish
             Effect: Allow
             Principal:
-              Service: 's3.amazonaws.com'
+              Service: 's3.${AWS::URLSuffix}'
             Action: sns:Publish
             Resource: !Ref LogProcessingNotificationsTopic
-          -
-            Sid: CrossAccountSubscription
+          - Sid: CrossAccountSubscription
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sns:Subscribe
             Resource: !Ref LogProcessingNotificationsTopic
       Topics:
@@ -154,7 +152,7 @@ Resources:
   Subscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Sub arn:aws:sqs:us-west-2:${MasterAccountId}:panther-log-notifications
+      Endpoint: !Sub arn:${AWS::Partition}:sqs:us-west-2:${MasterAccountId}:panther-log-notifications
       Protocol: sqs
       RawMessageDelivery: false
       TopicArn: !Ref LogProcessingNotificationsTopic
@@ -170,7 +168,6 @@ Resources:
       IsMultiRegionTrail: true
       IncludeGlobalServiceEvents: true
       EnableLogFileValidation: true
-
 
 Outputs:
   SnsTopicArn:

--- a/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
@@ -80,13 +80,13 @@ Resources:
           - Sid: CloudTrailAclCheck
             Effect: Allow
             Principal:
-              Service: cloudtrail.${AWS::URLSuffix}
+              Service: !Sub cloudtrail.${AWS::URLSuffix}
             Action: s3:GetBucketAcl
             Resource: !GetAtt LogProcessingBucket.Arn
           - Sid: CloudTrailWrite
             Effect: Allow
             Principal:
-              Service: cloudtrail.${AWS::URLSuffix}
+              Service: !Sub cloudtrail.${AWS::URLSuffix}
             Action: s3:PutObject
             Resource: !Sub ${LogProcessingBucket.Arn}/*
             Condition:
@@ -105,13 +105,13 @@ Resources:
           - Sid: VPCFlowAclCheck
             Effect: Allow
             Principal:
-              Service: delivery.logs.${AWS::URLSuffix}
+              Service: !Sub delivery.logs.${AWS::URLSuffix}
             Action: s3:GetBucketAcl
             Resource: !GetAtt LogProcessingBucket.Arn
           - Sid: VPCFlowWrite
             Effect: Allow
             Principal:
-              Service: delivery.logs.${AWS::URLSuffix}
+              Service: !Sub delivery.logs.${AWS::URLSuffix}
             Action: s3:PutObject
             Resource: !Sub ${LogProcessingBucket.Arn}/*
             Condition:
@@ -136,7 +136,7 @@ Resources:
             Sid: S3NotificationPublish
             Effect: Allow
             Principal:
-              Service: 's3.${AWS::URLSuffix}'
+              Service: !Sub s3.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref LogProcessingNotificationsTopic
           - Sid: CrossAccountSubscription

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -76,13 +76,13 @@ Resources:
           - Sid: AllowS3EventNotifications
             Effect: Allow
             Principal:
-              Service: s3.${AWS::URLSuffix}
+              Service: !Sub s3.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref Topic
           - Sid: AllowCloudTrailNotification
             Effect: Allow
             Principal:
-              Service: cloudtrail.${AWS::URLSuffix}
+              Service: !Sub cloudtrail.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref Topic
           - Sid: AllowSubscriptionToPanther

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -50,6 +50,12 @@ Parameters:
       - eu-north-1
       - me-south-1
       - sa-east-1
+      # AWS China Regions
+      - cn-north-1
+      - cn-northwest-1
+      # AWS Gov Cloud
+      - us-gov-east-1
+      - us-gov-west-1
 
 Resources:
   # This topic is used to notify the Panther master account whenever new data is written to the
@@ -70,19 +76,19 @@ Resources:
           - Sid: AllowS3EventNotifications
             Effect: Allow
             Principal:
-              Service: s3.amazonaws.com
+              Service: s3.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref Topic
           - Sid: AllowCloudTrailNotification
             Effect: Allow
             Principal:
-              Service: cloudtrail.amazonaws.com
+              Service: cloudtrail.${AWS::URLSuffix}
             Action: sns:Publish
             Resource: !Ref Topic
           - Sid: AllowSubscriptionToPanther
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:{AWS::Partition}:iam::${MasterAccountId}:root
             Action: sns:Subscribe
             Resource: !Ref Topic
       Topics:
@@ -92,7 +98,7 @@ Resources:
   Subscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Sub arn:aws:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications
+      Endpoint: !Sub arn:{AWS::Partition}:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications
       Protocol: sqs
       RawMessageDelivery: false
       TopicArn: !Ref Topic

--- a/deployments/auxiliary/cloudformation/panther-remediations-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-remediations-iam.yml
@@ -36,7 +36,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
             Condition:
               Bool:

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -32,7 +32,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: cloudformation.${AWS::URLSuffix}
+              Service: !Sub cloudformation.${AWS::URLSuffix}
             Action: sts:AssumeRole
       Policies:
         - PolicyName: AssumeRolesInTargetAccounts

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -30,21 +30,18 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
-              Service: cloudformation.amazonaws.com
+              Service: cloudformation.${AWS::URLSuffix}
             Action: sts:AssumeRole
       Policies:
-        -
-          PolicyName: AssumeRolesInTargetAccounts
+        - PolicyName: AssumeRolesInTargetAccounts
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              -
-                Effect: Allow
+              - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: arn:aws:iam::*:role/PantherCloudFormationStackSetExecutionRole
+                Resource: arn:{AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole
 
 Outputs:
   CloudFormationStackSetAdminRoleArn:

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -73,7 +73,7 @@ Resources:
               Service: apigateway.${AWS::URLSuffix}
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:${AWS::Partition}::iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+        - arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
   GatewayAccount:
     Type: AWS::ApiGateway::Account

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -73,7 +73,7 @@ Resources:
               Service: !Sub apigateway.${AWS::URLSuffix}
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
   GatewayAccount:
     Type: AWS::ApiGateway::Account
@@ -95,7 +95,7 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Principal:
-              Service: sns.${AWS::URLSuffix}
+              Service: !Sub sns.${AWS::URLSuffix}
             Action:
               - kms:GenerateDataKey
               - kms:Decrypt

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -70,7 +70,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: apigateway.${AWS::URLSuffix}
+              Service: !Sub apigateway.${AWS::URLSuffix}
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -70,10 +70,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: apigateway.amazonaws.com
+              Service: apigateway.${AWS::URLSuffix}
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+        - arn:${AWS::Partition}::iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
   GatewayAccount:
     Type: AWS::ApiGateway::Account
@@ -95,7 +95,7 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Principal:
-              Service: sns.amazonaws.com
+              Service: sns.${AWS::URLSuffix}
             Action:
               - kms:GenerateDataKey
               - kms:Decrypt
@@ -196,10 +196,10 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        AnalysisApi: !Sub https://${AnalysisAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
-        ComplianceApi: !Sub https://${ComplianceAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
-        RemediationApi: !Sub https://${RemediationAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
-        ResourcesApi: !Sub https://${ResourcesAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
+        AnalysisApi: !Sub https://${AnalysisAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
+        ComplianceApi: !Sub https://${ComplianceAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
+        RemediationApi: !Sub https://${RemediationAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
+        ResourcesApi: !Sub https://${ResourcesAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
         UserPoolId: !GetAtt Cognito.Outputs.UserPoolId
       TemplateURL: ../out/deployments/core/embedded.appsync.yml
 
@@ -364,13 +364,13 @@ Resources:
 Outputs:
   AnalysisApiEndpoint:
     Description: panther-analysis-api Gateway HTTPS endpoint
-    Value: !Sub ${AnalysisAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
+    Value: !Sub ${AnalysisAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
   ComplianceApiEndpoint:
     Description: panther-compliance-api Gateway HTTPS endpoint
-    Value: !Sub ${ComplianceAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
+    Value: !Sub ${ComplianceAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
   ResourcesApiEndpoint:
     Description: panther-resources-api Gateway HTTPS endpoint
-    Value: !Sub ${ResourcesAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.amazonaws.com
+    Value: !Sub ${ResourcesAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}
   LoadBalancerUrl:
     Description: Panther URL (application load balancer)
     Value: !GetAtt WebApplicationLoadBalancer.Outputs.LoadBalancerUrl

--- a/dev.sh
+++ b/dev.sh
@@ -10,11 +10,11 @@ docker run \
     -v $(pwd):/code \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -e AWS_ACCESS_KEY_ID \
+    -e AWS_PARTITION \
     -e AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN \
     -e AWS_SECURITY_TOKEN \
     -e AWS_REGION=$(if [ -z "$AWS_REGION" ]; then echo $AWS_DEFAULT_REGION; else echo $AWS_REGION; fi) \
-    -e AWS_PARTITION=$(if [ -z "$AWS_PARTITION" ]; then echo $AWS_PARTITION; else echo $AWS_PARTITION; fi) \
     -it \
     --rm \
     pantherlabs/panther-development-pack:latest

--- a/dev.sh
+++ b/dev.sh
@@ -14,6 +14,7 @@ docker run \
     -e AWS_SESSION_TOKEN \
     -e AWS_SECURITY_TOKEN \
     -e AWS_REGION=$(if [ -z "$AWS_REGION" ]; then echo $AWS_DEFAULT_REGION; else echo $AWS_REGION; fi) \
+    -e AWS_PARTITION=$(if [ -z "$AWS_PARTITION" ]; then echo $AWS_PARTITION; else echo $AWS_PARTITION; fi) \
     -it \
     --rm \
     pantherlabs/panther-development-pack:latest


### PR DESCRIPTION
## Background
> Why are you making this change? Reference any related issues and PRs

The following change moves to using AWS Supported [Pseudo paramaters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html) where possible enabling deployment in AWS partitions `aws-cn` & `aws-govcloud`

## Changes
> List your changes here in more detail

* Allow passing of `AWS_PARTITION` into the dev docker 
* Change to using AWS Pseudo variables as part of the SDK & Cloud formation templating. 

## Testing
> How did you test your change? 

* Deploy to `AWS-CN`
* Deploy to `AWS (West)`
