### PR TITLE
Add IAM fallback for ACM certificate import

### DIFF
--- a/tools/mage/deploy_certificate.go
+++ b/tools/mage/deploy_certificate.go
@@ -128,10 +128,12 @@ func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 // uploadIAMCertificate creates an IAM certificate resource and returns its ARN
 func uploadIAMCertificate(privateKeyBytes, certificateBytes []byte, session *session.Session) (string, error) {
 	iamClient := iam.New(session)
+	t := time.Now()
+	certName := "PantherCertificate-" + t.Format("2006-01-02T15-04-05")
 	input := &iam.UploadServerCertificateInput{
 		CertificateBody:       aws.String(string(certificateBytes)),
 		PrivateKey:            aws.String(string(privateKeyBytes)),
-		ServerCertificateName: aws.String("PantherCertificate"),
+		ServerCertificateName: aws.String(certName),
 	}
 	output, err := iamClient.UploadServerCertificate(input)
 	if err != nil {

--- a/tools/mage/deploy_certificate.go
+++ b/tools/mage/deploy_certificate.go
@@ -95,7 +95,7 @@ func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 
 	// Check if the ACM service is supported before tossing the private key out into the ether
 	acmClient := acm.New(awsSession)
-	_, err = acmClient.ListCertificates(&acm.ListCertificatesInput{MaxItems: aws.Int64(0)})
+	_, err = acmClient.ListCertificates(&acm.ListCertificatesInput{MaxItems: aws.Int64(1)})
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "SubscriptionRequiredException" {

--- a/tools/mage/deploy_certificate.go
+++ b/tools/mage/deploy_certificate.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/iam"
 )
 
 const (
@@ -48,6 +49,8 @@ const (
 )
 
 // Upload a local self-signed TLS certificate to ACM. Only needs to happen once per installation
+//
+// In regions/partitions where ACM is not supported, we fall back to IAM certificate management.
 func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 	// Check if certificate has already been uploaded
 	certArn, err := getExistingCertificate(awsSession)
@@ -55,10 +58,10 @@ func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 		return "", err
 	}
 	if certArn != "" {
-		fmt.Println("deploy: ACM certificate already exists")
+		fmt.Println("deploy: load balancer certificate already exists")
 		return certArn, nil
 	}
-	fmt.Println("deploy: uploading ACM certificate")
+	fmt.Println("deploy: uploading load balancer certificate")
 
 	// Ensure the certificate and key file exist. If not, create them.
 	_, certErr := os.Stat(certificateFile)
@@ -90,6 +93,19 @@ func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 		return "", err
 	}
 
+	// Check if the ACM service is supported before tossing the private key out into the ether
+	acmClient := acm.New(awsSession)
+	_, err = acmClient.ListCertificates(&acm.ListCertificatesInput{MaxItems: aws.Int64(0)})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			// ACM is not supported in this region or for this user, fall back to IAM
+			if awsErr.Code() == "SubscriptionRequiredException" {
+				return uploadIAMCertificate(privateKeyBytes, certificateBytes, awsSession)
+			}
+		}
+		// Some other AWS based error
+		return "", err
+	}
 	input := &acm.ImportCertificateInput{
 		Certificate: certificateBytes,
 		PrivateKey:  privateKeyBytes,
@@ -100,15 +116,31 @@ func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 			},
 		},
 	}
-
-	acmClient := acm.New(awsSession)
 	output, err := acmClient.ImportCertificate(input)
 	if err != nil {
 		return "", err
 	}
+
 	return *output.CertificateArn, nil
 }
 
+// uploadIAMCertificate creates an IAM certificate resource and returns its ARN
+func uploadIAMCertificate(privateKeyBytes, certificateBytes []byte, session *session.Session) (string, error) {
+	iamClient := iam.New(session)
+	input := &iam.UploadServerCertificateInput{
+		CertificateBody:       aws.String(string(certificateBytes)),
+		PrivateKey:            aws.String(string(privateKeyBytes)),
+		ServerCertificateName: aws.String("PantherCertificate"),
+	}
+	output, err := iamClient.UploadServerCertificate(input)
+	if err != nil {
+		return "", err
+	}
+
+	return *output.ServerCertificateMetadata.Arn, nil
+}
+
+// getExistingCertificate checks to see if there is already an ACM/IAM certificate configured
 func getExistingCertificate(awsSession *session.Session) (string, error) {
 	outputs, err := getStackOutputs(awsSession, backendStack)
 	if err != nil {
@@ -125,7 +157,7 @@ func getExistingCertificate(awsSession *session.Session) (string, error) {
 	return "", nil
 }
 
-// Generate the self signed private key and certificate for HTTPS access to the web application
+// generateKeys generates the self signed private key and certificate for HTTPS access to the web application
 func generateKeys() error {
 	fmt.Println("deploy: WARNING no ACM certificate ARN provided and no certificate file provided, generating a self-signed certificate")
 	// Create the private key

--- a/tools/mage/deploy_certificate.go
+++ b/tools/mage/deploy_certificate.go
@@ -98,12 +98,13 @@ func uploadLocalCertificate(awsSession *session.Session) (string, error) {
 	_, err = acmClient.ListCertificates(&acm.ListCertificatesInput{MaxItems: aws.Int64(0)})
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			// ACM is not supported in this region or for this user, fall back to IAM
 			if awsErr.Code() == "SubscriptionRequiredException" {
+				// ACM is not supported in this region or for this user, fall back to IAM
+				fmt.Println("deploy: ACM not supported, falling back to IAM for certificate management")
 				return uploadIAMCertificate(privateKeyBytes, certificateBytes, awsSession)
 			}
 		}
-		// Some other AWS based error
+		// Some other error
 		return "", err
 	}
 	input := &acm.ImportCertificateInput{


### PR DESCRIPTION
## Background

@gavinelder reported that the deploy process fails when deployed in either of the `cn` regions at the upload ACM certificate step. Further investigation by @austinbyers showed that ACM is in fact not supported in those regions.

This change modifies the deploy process to fallback to uploading a certificate to IAM in cases where the ACM service is not available.

Closes: #67 

## Changes

- Added a check to see if the ACM service is available
- When the ACM service is not available, upload the self signed certificate to IAM instead of ACM

## Testing

- None yet, looking into setting up an account in `cn`
