### PR TITLE
When listing alerts and assoc rule is not found set severity to unknown

### DIFF
--- a/internal/log_analysis/alerts_api/api/list_alerts.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts.go
@@ -87,6 +87,8 @@ func alertItemsToAlertSummary(items []*models.AlertItem) ([]*models.AlertSummary
 			if !strings.Contains(err.Error(), "getRuleNotFound") {
 				return nil, err
 			}
+			unknownSeverity := "Unknown (rule deleted)"
+			severity = &unknownSeverity
 		}
 		ruleIDToSeverity[ruleID] = severity
 	}


### PR DESCRIPTION
When listing alerts and assoc rule is not found set alert severity: Unknown (rule deleted) in order to let use know that rule is delete. Before this change it was very unclear which rules were current and severity defaulted.

## Testing
Manually in dev env using UI.