### PR TITLE
[UI FIX] Fix minor UI issues

### DIFF
--- a/web/src/components/navigation.tsx
+++ b/web/src/components/navigation.tsx
@@ -94,7 +94,7 @@ const Navigation = () => {
   }, [isSettingsPage]);
 
   return (
-    <Flex is="nav" boxShadow="dark50" zIndex={1} position="sticky" top={0} height="100vh">
+    <Flex is="nav" boxShadow="dark50" zIndex={1} position="sticky" top={0} minHeight="100vh">
       <Box width={72} height="100%" boxShadow="dark150">
         <Flex justifyContent="center" py={8} m="auto">
           <IconButton variant="primary" is={Link} to="/" mb={10}>

--- a/web/src/components/sidesheets/add-destination-sidesheet.tsx
+++ b/web/src/components/sidesheets/add-destination-sidesheet.tsx
@@ -43,7 +43,7 @@ import { LIST_DESTINATIONS, ListDestinationsQueryData } from 'Pages/destinations
 import { capitalize, extractErrorMessage } from 'Helpers/utils';
 
 const ADD_DESTINATION = gql`
-  mutation AddSlackDestination($input: DestinationInput!) {
+  mutation AddDestination($input: DestinationInput!) {
     addDestination(input: $input) {
       createdBy
       creationTime

--- a/web/src/components/sidesheets/update-destination-sidesheet.tsx
+++ b/web/src/components/sidesheets/update-destination-sidesheet.tsx
@@ -43,7 +43,7 @@ import {
 import { extractErrorMessage } from 'Helpers/utils';
 
 const UPDATE_DESTINATION = gql`
-  mutation UpdateSlackDestination($input: DestinationInput!) {
+  mutation UpdateDestination($input: DestinationInput!) {
     updateDestination(input: $input) {
       createdBy
       creationTime

--- a/web/src/pages/list-sources/log-source-columns.tsx
+++ b/web/src/pages/list-sources/log-source-columns.tsx
@@ -19,7 +19,7 @@
 /* eslint-disable react/display-name */
 
 import React from 'react';
-import { TableProps, Box } from 'pouncejs';
+import { TableProps, Box, Text } from 'pouncejs';
 import { Integration } from 'Generated/schema';
 import { generateEnumerationColumn } from 'Helpers/utils';
 import ListSourcesTableRowOptionsProps from 'Pages/list-sources/subcomponents/list-sources-table-row-options';
@@ -44,7 +44,16 @@ const columns = [
   {
     key: 's3Buckets',
     header: 'S3 Buckets',
-    flex: '1 0 200px',
+    flex: '1 0 300px',
+    renderCell: ({ s3Buckets }) => (
+      <React.Fragment>
+        {s3Buckets.map(s3Arn => (
+          <Text size="medium" key={s3Arn} mb={1}>
+            {s3Arn}
+          </Text>
+        ))}
+      </React.Fragment>
+    ),
   },
 
   {


### PR DESCRIPTION
## Background

Why are you making this change? Please provide a reference to any related issues and PRs
S3 buckets on log sources table can overlap, leading to a small visual glitch where a bucket name is split into multiple lines and concatenated with another.

This PR makes sure that each S3 bucket occupies exactly one line and that the navigation doesn't overflow for small screens.

## Changes

- List your changes here in more detail
* Make sure not to break line on S3 bucket values on log source table
* Make sure that the vertical navigation doesn't overflow when the screen has a small height
* Rename GraphQL mutation & query, since there was a typo (unnecessary `Slack` prefix)

## Testing

- How did you test your change?

Locally
