### PR TITLE
Adding Asana destination

### DIFF
--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -261,7 +261,7 @@ type SqsConfig struct {
 // AsanaConfig defines options for each Asana output
 type AsanaConfig struct {
 	PersonalAccessToken *string   `json:"personalAccessToken" validate:"required,min=1"`
-	ProjectGids         []*string `json:"projectGids" validate:"required,min=1,dive,numeric"`
+	ProjectGids         []*string `json:"projectGids" validate:"required,min=1,dive,required"`
 }
 
 // DefaultOutputs is the structure holding the information about default outputs for severity

--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -260,9 +260,8 @@ type SqsConfig struct {
 
 // AsanaConfig defines options for each Asana output
 type AsanaConfig struct {
-	AccessToken *string `json:"accessToken" validate:"required,min=1"`
-	WorkspaceGid *string `json:"workspaceGid" validate:"required,min=1"`
-	ProjectGids []*string `json:"projectGids,omitempty"`
+	PersonalAccessToken *string   `json:"personalAccessToken" validate:"required,min=1"`
+	ProjectGids         []*string `json:"projectGids" validate:"required,min=1,dive,numeric"`
 }
 
 // DefaultOutputs is the structure holding the information about default outputs for severity

--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -202,6 +202,9 @@ type OutputConfig struct {
 
 	// SqsConfig contains the configuration for SQS alert output
 	Sqs *SqsConfig `json:"sqs,omitempty"`
+
+	// AsanaConfig contains the configuration for Asana alert output
+	Asana *AsanaConfig `json:"asana,omitempty"`
 }
 
 // SlackConfig defines options for each Slack output.
@@ -253,6 +256,13 @@ type MsTeamsConfig struct {
 // SqsConfig defines options for each Sqs topic output
 type SqsConfig struct {
 	QueueURL *string `json:"queueUrl" validate:"required,url"`
+}
+
+// AsanaConfig defines options for each Asana output
+type AsanaConfig struct {
+	AccessToken *string `json:"accessToken" validate:"required,min=1"`
+	WorkspaceGid *string `json:"workspaceGid" validate:"required,min=1"`
+	ProjectGids []*string `json:"projectGids,omitempty"`
 }
 
 // DefaultOutputs is the structure holding the information about default outputs for severity

--- a/internal/core/alert_delivery/models/api.go
+++ b/internal/core/alert_delivery/models/api.go
@@ -30,7 +30,7 @@ const PolicyType = "POLICY"
 type Alert struct {
 
 	// CreatedAt is the creation timestamp (seconds since epoch).
-	CreatedAt *time.Time `json:"createdAt", validate:"required"`
+	CreatedAt *time.Time `json:"createdAt" validate:"required"`
 
 	// OutputIDs is the set of outputs for this alert.
 	OutputIDs []*string `json:"outputIds,omitempty"`

--- a/internal/core/alert_delivery/models/api.go
+++ b/internal/core/alert_delivery/models/api.go
@@ -30,7 +30,7 @@ const PolicyType = "POLICY"
 type Alert struct {
 
 	// CreatedAt is the creation timestamp (seconds since epoch).
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt *time.Time `json:"createdAt", validate:"required"`
 
 	// OutputIDs is the set of outputs for this alert.
 	OutputIDs []*string `json:"outputIds,omitempty"`

--- a/internal/core/alert_delivery/outputs/asana.go
+++ b/internal/core/alert_delivery/outputs/asana.go
@@ -19,7 +19,7 @@ package outputs
  */
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 
@@ -27,39 +27,29 @@ import (
 	alertmodels "github.com/panther-labs/panther/internal/core/alert_delivery/models"
 )
 
-// Severity colors match those in the Panther UI
 const (
-	githubEndpoint = "https://api.github.com/repos/"
-	requestType    = "/issues"
+	asanaCreateTaskURL             = "https://app.asana.com/api/1.0/tasks"
+	asanaAuthorizationHeaderFormat = "Bearer %s"
 )
 
-// Github alert send an issue.
-func (client *OutputClient) Github(
-	alert *alertmodels.Alert, config *outputmodels.GithubConfig) *AlertDeliveryError {
-
-	var tagsItem = aws.StringValueSlice(alert.Tags)
-
-	description := "**Description:** " + aws.StringValue(alert.PolicyDescription)
-	link := "\n [Click here to view in the Panther UI](" + generateURL(alert) + ")"
-	runBook := "\n **Runbook:** " + aws.StringValue(alert.Runbook)
-	severity := "\n **Severity:** " + aws.StringValue(alert.Severity)
-	tags := "\n **Tags:** " + strings.Join(tagsItem, ", ")
-
-	githubRequest := map[string]interface{}{
-		"title": generateAlertTitle(alert),
-		"body":  description + link + runBook + severity + tags,
-	}
-
-	token := "token " + *config.Token
-	repoURL := githubEndpoint + *config.RepoName + requestType
-	requestHeader := map[string]string{
-		AuthorizationHTTPHeader: token,
+// Asana creates a task in Asana projects
+func (client *OutputClient) Asana(alert *alertmodels.Alert, config *outputmodels.AsanaConfig) *AlertDeliveryError {
+	payload := map[string]interface{}{
+		"data": []map[string]interface{}{
+			{
+				"name":     generateAlertTitle(alert),
+				"projects": config.ProjectGids,
+				"notes":    generateDetailedAlertMessage(alert),
+			},
+		},
 	}
 
 	postInput := &PostInput{
-		url:     repoURL,
-		body:    githubRequest,
-		headers: requestHeader,
+		url:  asanaCreateTaskURL,
+		body: payload,
+		headers: map[string]string{
+			AuthorizationHTTPHeader: fmt.Sprintf(asanaAuthorizationHeaderFormat, aws.StringValue(config.PersonalAccessToken)),
+		},
 	}
 	return client.httpWrapper.post(postInput)
 }

--- a/internal/core/alert_delivery/outputs/asana.go
+++ b/internal/core/alert_delivery/outputs/asana.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"go.uber.org/zap"
 
 	outputmodels "github.com/panther-labs/panther/api/lambda/outputs/models"
 	alertmodels "github.com/panther-labs/panther/internal/core/alert_delivery/models"
@@ -34,13 +35,12 @@ const (
 
 // Asana creates a task in Asana projects
 func (client *OutputClient) Asana(alert *alertmodels.Alert, config *outputmodels.AsanaConfig) *AlertDeliveryError {
+	zap.L().Debug("sending alert to Asana")
 	payload := map[string]interface{}{
-		"data": []map[string]interface{}{
-			{
-				"name":     generateAlertTitle(alert),
-				"projects": config.ProjectGids,
-				"notes":    generateDetailedAlertMessage(alert),
-			},
+		"data": map[string]interface{}{
+			"name":     generateAlertTitle(alert),
+			"projects": config.ProjectGids,
+			"notes":    generateDetailedAlertMessage(alert),
 		},
 	}
 

--- a/internal/core/alert_delivery/outputs/asana_test.go
+++ b/internal/core/alert_delivery/outputs/asana_test.go
@@ -48,8 +48,9 @@ func TestAsanaAlert(t *testing.T) {
 
 	asanaRequest := map[string]interface{}{
 		"data": map[string]interface{}{
-			"name":     "Policy Failure: policy_name",
-			"notes":    "policy_name failed on new resources\nFor more details please visit: https://panther.io/policies/ruleId\nSeverity: INFO\nRunbook: \nDescription:description",
+			"name": "Policy Failure: policy_name",
+			"notes": "policy_name failed on new resources\n" +
+				"For more details please visit: https://panther.io/policies/ruleId\nSeverity: INFO\nRunbook: \nDescription:description",
 			"projects": aws.StringSlice([]string{"projectGid"}),
 		},
 	}

--- a/internal/core/alert_delivery/outputs/asana_test.go
+++ b/internal/core/alert_delivery/outputs/asana_test.go
@@ -1,0 +1,19 @@
+package outputs
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */

--- a/internal/core/alert_delivery/outputs/github_test.go
+++ b/internal/core/alert_delivery/outputs/github_test.go
@@ -53,14 +53,12 @@ func TestGithubAlert(t *testing.T) {
 	}
 
 	authorization := "token " + *githubConfig.Token
-	accept := "application/json"
-	requestHeader := map[string]*string{
-		"Authorization": &authorization,
-		"Accept":        &accept,
+	requestHeader := map[string]string{
+		AuthorizationHTTPHeader: authorization,
 	}
 	requestEndpoint := "https://api.github.com/repos/profile/reponame/issues"
 	expectedPostInput := &PostInput{
-		url:     &requestEndpoint,
+		url:     requestEndpoint,
 		body:    githubRequest,
 		headers: requestHeader,
 	}

--- a/internal/core/alert_delivery/outputs/jira.go
+++ b/internal/core/alert_delivery/outputs/jira.go
@@ -67,15 +67,13 @@ func (client *OutputClient) Jira(
 
 	auth := *config.UserName + ":" + *config.APIKey
 	basicAuthToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
-	accept := "application/json"
 	jiraRestURL := *config.OrgDomain + jiraEndpoint
-	requestHeader := map[string]*string{
-		"Accept":        &accept,
-		"Authorization": &basicAuthToken,
+	requestHeader := map[string]string{
+		AuthorizationHTTPHeader: basicAuthToken,
 	}
 
 	postInput := &PostInput{
-		url:     &jiraRestURL,
+		url:     jiraRestURL,
 		body:    jiraRequest,
 		headers: requestHeader,
 	}

--- a/internal/core/alert_delivery/outputs/jira_test.go
+++ b/internal/core/alert_delivery/outputs/jira_test.go
@@ -71,14 +71,12 @@ func TestJiraAlert(t *testing.T) {
 	}
 	auth := *jiraConfig.UserName + ":" + *jiraConfig.APIKey
 	basicAuthToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
-	accept := "application/json"
-	requestHeader := map[string]*string{
-		"Authorization": &basicAuthToken,
-		"Accept":        &accept,
+	requestHeader := map[string]string{
+		AuthorizationHTTPHeader: basicAuthToken,
 	}
 	requestEndpoint := "https://panther-labs.atlassian.net/rest/api/latest/issue/"
 	expectedPostInput := &PostInput{
-		url:     &requestEndpoint,
+		url:     requestEndpoint,
 		body:    jiraPayload,
 		headers: requestHeader,
 	}

--- a/internal/core/alert_delivery/outputs/msteams.go
+++ b/internal/core/alert_delivery/outputs/msteams.go
@@ -68,15 +68,10 @@ func (client *OutputClient) MsTeams(
 		},
 	}
 
-	accept := "application/json"
-	requestHeader := map[string]*string{
-		"Accept": &accept,
-	}
 	requestURL := *config.WebhookURL
 	postInput := &PostInput{
-		url:     &requestURL,
-		body:    msTeamsRequestBody,
-		headers: requestHeader,
+		url:  requestURL,
+		body: msTeamsRequestBody,
 	}
 	return client.httpWrapper.post(postInput)
 }

--- a/internal/core/alert_delivery/outputs/msteams_test.go
+++ b/internal/core/alert_delivery/outputs/msteams_test.go
@@ -76,14 +76,10 @@ func TestMsTeamsAlert(t *testing.T) {
 	}
 
 	requestURL := *msTeamConfig.WebhookURL
-	accept := "application/json"
-	requestHeader := map[string]*string{
-		"Accept": &accept,
-	}
+
 	expectedPostInput := &PostInput{
-		url:     &requestURL,
-		body:    msTeamsPayload,
-		headers: requestHeader,
+		url:  requestURL,
+		body: msTeamsPayload,
 	}
 
 	httpWrapper.On("post", expectedPostInput).Return((*AlertDeliveryError)(nil))

--- a/internal/core/alert_delivery/outputs/opsgenie.go
+++ b/internal/core/alert_delivery/outputs/opsgenie.go
@@ -55,14 +55,12 @@ func (client *OutputClient) Opsgenie(
 		"priority":    pantherToOpsGeniePriority[aws.StringValue(alert.Severity)],
 	}
 	authorization := "GenieKey " + *config.APIKey
-	accept := "application/json"
-	requestHeader := map[string]*string{
-		"Accept":        &accept,
-		"Authorization": &authorization,
+	requestHeader := map[string]string{
+		AuthorizationHTTPHeader: authorization,
 	}
 
 	postInput := &PostInput{
-		url:     &opsgenieEndpoint,
+		url:     opsgenieEndpoint,
 		body:    opsgenieRequest,
 		headers: requestHeader,
 	}

--- a/internal/core/alert_delivery/outputs/opsgenie_test.go
+++ b/internal/core/alert_delivery/outputs/opsgenie_test.go
@@ -59,14 +59,12 @@ func TestOpsgenieAlert(t *testing.T) {
 
 	authorization := "GenieKey " + *opsgenieConfig.APIKey
 
-	accept := "application/json"
-	requestHeader := map[string]*string{
-		"Accept":        &accept,
-		"Authorization": &authorization,
+	requestHeader := map[string]string{
+		AuthorizationHTTPHeader: authorization,
 	}
 	requestEndpoint := "https://api.opsgenie.com/v2/alerts"
 	expectedPostInput := &PostInput{
-		url:     &requestEndpoint,
+		url:     requestEndpoint,
 		body:    opsgenieRequest,
 		headers: requestHeader,
 	}

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -19,6 +19,7 @@ package outputs
  */
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 
@@ -45,9 +46,9 @@ type HTTPWrapper struct {
 
 // PostInput type
 type PostInput struct {
-	url     *string
+	url     string
 	body    map[string]interface{}
-	headers map[string]*string
+	headers map[string]string
 }
 
 // HTTPWrapperiface is the interface for our wrapper around Golang's http client
@@ -71,8 +72,7 @@ type API interface {
 	MsTeams(*alertmodels.Alert, *outputmodels.MsTeamsConfig) *AlertDeliveryError
 	Sqs(*alertmodels.Alert, *outputmodels.SqsConfig) *AlertDeliveryError
 	Sns(*alertmodels.Alert, *outputmodels.SnsConfig) *AlertDeliveryError
-	getSnsClient(topicArn string) (snsiface.SNSAPI, error)
-	getSqsClient(queueURL string) (sqsiface.SQSAPI, error)
+	Asana(*alertmodels.Alert, *outputmodels.AsanaConfig) *AlertDeliveryError
 }
 
 // OutputClient encapsulates the clients that allow sending alerts to multiple outputs
@@ -102,11 +102,24 @@ func New(sess *session.Session) *OutputClient {
 	}
 }
 
+const detailedMessageTemplate = "%s\nFor more details please visit: %s\nSeverity: %s\nRunbook: %s\nDescription:%s"
+
 func generateAlertMessage(alert *alertmodels.Alert) string {
 	if aws.StringValue(alert.Type) == alertmodels.RuleType {
 		return getDisplayName(alert) + " failed"
 	}
 	return getDisplayName(alert) + " failed on new resources"
+}
+
+func generateDetailedAlertMessage(alert *alertmodels.Alert) string {
+	return fmt.Sprintf(
+		detailedMessageTemplate,
+		generateAlertMessage(alert),
+		generateURL(alert),
+		aws.StringValue(alert.Severity),
+		aws.StringValue(alert.Runbook),
+		aws.StringValue(alert.PolicyDescription),
+	)
 }
 
 func generateAlertTitle(alert *alertmodels.Alert) string {

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -130,7 +130,7 @@ func generateAlertTitle(alert *alertmodels.Alert) string {
 }
 
 func getDisplayName(alert *alertmodels.Alert) string {
-	if alert.PolicyName != nil && *alert.PolicyName != "" {
+	if aws.StringValue(alert.PolicyName) != "" {
 		return *alert.PolicyName
 	}
 	return *alert.PolicyID

--- a/internal/core/alert_delivery/outputs/pagerduty.go
+++ b/internal/core/alert_delivery/outputs/pagerduty.go
@@ -72,7 +72,7 @@ func (client *OutputClient) PagerDuty(alert *alertmodels.Alert, config *outputmo
 	}
 
 	postInput := &PostInput{
-		url:  &pagerDutyEndpoint,
+		url:  pagerDutyEndpoint,
 		body: pagerDutyRequest,
 	}
 

--- a/internal/core/alert_delivery/outputs/pagerduty_test.go
+++ b/internal/core/alert_delivery/outputs/pagerduty_test.go
@@ -64,7 +64,7 @@ func TestSendPagerDutyAlert(t *testing.T) {
 	}
 	requestEndpoint := "https://events.pagerduty.com/v2/enqueue"
 	expectedPostInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: expectedPostPayload,
 	}
 

--- a/internal/core/alert_delivery/outputs/post.go
+++ b/internal/core/alert_delivery/outputs/post.go
@@ -26,6 +26,10 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
+const (
+	AuthorizationHTTPHeader = "Authorization"
+)
+
 // post sends a JSON body to an endpoint.
 func (client *HTTPWrapper) post(input *PostInput) *AlertDeliveryError {
 	payload, err := jsoniter.Marshal(input.body)
@@ -33,16 +37,17 @@ func (client *HTTPWrapper) post(input *PostInput) *AlertDeliveryError {
 		return &AlertDeliveryError{Message: "json marshal error: " + err.Error(), Permanent: true}
 	}
 
-	request, err := http.NewRequest("POST", *input.url, bytes.NewBuffer(payload))
+	request, err := http.NewRequest("POST", input.url, bytes.NewBuffer(payload))
 	if err != nil {
 		return &AlertDeliveryError{Message: "http request error: " + err.Error(), Permanent: true}
 	}
 
 	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
 
 	//Adding dynamic headers
 	for key, value := range input.headers {
-		request.Header.Set(key, *value)
+		request.Header.Set(key, value)
 	}
 
 	response, err := client.httpClient.Do(request)

--- a/internal/core/alert_delivery/outputs/post_test.go
+++ b/internal/core/alert_delivery/outputs/post_test.go
@@ -54,7 +54,7 @@ func (m *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 func TestPostInvalidJSON(t *testing.T) {
 	body := map[string]interface{}{"func": TestPostInvalidJSON}
 	postInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: body,
 	}
 	c := &HTTPWrapper{httpClient: &mockHTTPClient{}}
@@ -64,7 +64,7 @@ func TestPostInvalidJSON(t *testing.T) {
 func TestPostErrorSubmittingRequest(t *testing.T) {
 	c := &HTTPWrapper{httpClient: &mockHTTPClient{requestError: true}}
 	postInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: map[string]interface{}{"abc": 123},
 	}
 	assert.NotNil(t, c.post(postInput))
@@ -73,7 +73,7 @@ func TestPostErrorSubmittingRequest(t *testing.T) {
 func TestPostNotOk(t *testing.T) {
 	c := &HTTPWrapper{httpClient: &mockHTTPClient{statusCode: http.StatusBadRequest}}
 	postInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: map[string]interface{}{"abc": 123},
 	}
 	assert.NotNil(t, c.post(postInput))
@@ -82,7 +82,7 @@ func TestPostNotOk(t *testing.T) {
 func TestPostOk(t *testing.T) {
 	c := &HTTPWrapper{httpClient: &mockHTTPClient{statusCode: http.StatusOK}}
 	postInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: map[string]interface{}{"abc": 123},
 	}
 	assert.Nil(t, c.post(postInput))
@@ -91,7 +91,7 @@ func TestPostOk(t *testing.T) {
 func TestPostCreated(t *testing.T) {
 	c := &HTTPWrapper{httpClient: &mockHTTPClient{statusCode: http.StatusCreated}}
 	postInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: map[string]interface{}{"abc": 123},
 	}
 	assert.Nil(t, c.post(postInput))

--- a/internal/core/alert_delivery/outputs/slack.go
+++ b/internal/core/alert_delivery/outputs/slack.go
@@ -70,7 +70,7 @@ func (client *OutputClient) Slack(alert *alertmodels.Alert, config *outputmodels
 	}
 	requestEndpoint := *config.WebhookURL
 	postInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: payload,
 	}
 

--- a/internal/core/alert_delivery/outputs/slack_test.go
+++ b/internal/core/alert_delivery/outputs/slack_test.go
@@ -70,7 +70,7 @@ func TestSlackAlert(t *testing.T) {
 	}
 	requestEndpoint := "slack-channel-url"
 	expectedPostInput := &PostInput{
-		url:  &requestEndpoint,
+		url:  requestEndpoint,
 		body: expectedPostPayload,
 	}
 

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -19,8 +19,6 @@ package outputs
  */
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/sns"
@@ -32,8 +30,6 @@ import (
 	outputmodels "github.com/panther-labs/panther/api/lambda/outputs/models"
 	alertmodels "github.com/panther-labs/panther/internal/core/alert_delivery/models"
 )
-
-const snsEmailTemplate = "%s\nFor more details please visit: %s\nSeverity: %s\nRunbook: %s\nDescription:%s"
 
 type snsMessage struct {
 	DefaultMessage string `json:"default"`
@@ -74,7 +70,7 @@ func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.S
 
 	outputMessage := &snsMessage{
 		DefaultMessage: serializedDefaultMessage,
-		EmailMessage:   generateSnsEmailMessage(alert),
+		EmailMessage:   generateDetailedAlertMessage(alert),
 	}
 
 	serializedMessage, err := jsoniter.MarshalToString(outputMessage)
@@ -106,17 +102,6 @@ func (client *OutputClient) Sns(alert *alertmodels.Alert, config *outputmodels.S
 		return &AlertDeliveryError{Message: errorMsg}
 	}
 	return nil
-}
-
-func generateSnsEmailMessage(alert *alertmodels.Alert) string {
-	return fmt.Sprintf(
-		snsEmailTemplate,
-		generateAlertMessage(alert),
-		generateURL(alert),
-		aws.StringValue(alert.Severity),
-		aws.StringValue(alert.Runbook),
-		aws.StringValue(alert.PolicyDescription),
-	)
 }
 
 func (client *OutputClient) getSnsClient(topicArn string) (snsiface.SNSAPI, error) {

--- a/internal/core/alert_delivery/outputs/sqs.go
+++ b/internal/core/alert_delivery/outputs/sqs.go
@@ -55,10 +55,7 @@ func (client *OutputClient) Sqs(alert *alertmodels.Alert, config *outputmodels.S
 		MessageBody: aws.String(serializedMessage),
 	}
 
-	sqsClient, err := client.getSqsClient(*config.QueueURL)
-	if err != nil {
-		return &AlertDeliveryError{Message: "Failed to create Sqs client for queue", Permanent: true}
-	}
+	sqsClient := client.getSqsClient(*config.QueueURL)
 
 	_, err = sqsClient.SendMessage(sqsSendMessageInput)
 	if err != nil {
@@ -79,13 +76,13 @@ type sqsOutputMessage struct {
 	Tags        []*string `json:"tags,omitempty"`
 }
 
-func (client *OutputClient) getSqsClient(queueURL string) (sqsiface.SQSAPI, error) {
-	// Queue URL is like "https://sqs.us-west-2.amazonaws.com/415773754570/panther-alert-queue"
+func (client *OutputClient) getSqsClient(queueURL string) sqsiface.SQSAPI {
+	// Queue URL is like "https://sqs.us-west-2.amazonaws.com/123456789012/panther-alert-queue"
 	region := strings.Split(queueURL, ".")[1]
 	sqsClient, ok := client.sqsClients[region]
 	if !ok {
 		sqsClient = sqs.New(client.session, aws.NewConfig().WithRegion(region))
 		client.sqsClients[region] = sqsClient
 	}
-	return sqsClient, nil
+	return sqsClient
 }

--- a/internal/core/outputs_api/api/add_output_test.go
+++ b/internal/core/outputs_api/api/add_output_test.go
@@ -305,18 +305,18 @@ func TestAddOutputAsana(t *testing.T) {
 	mockOutputVerification := &mockOutputVerification{}
 	outputVerification = mockOutputVerification
 
-	mockOutputTable.On("GetOutputByName", aws.String("my-asana-task")).Return(nil, nil)
+	mockOutputTable.On("GetOutputByName", aws.String("my-asana-destination")).Return(nil, nil)
 	mockEncryptionKey.On("EncryptConfig", mock.Anything).Return(make([]byte, 1), nil)
 	mockOutputTable.On("PutOutput", mock.Anything).Return(nil)
 	mockOutputVerification.On("GetVerificationStatus", mock.Anything).Return(aws.String(models.VerificationStatusSuccess), nil)
 
 	input := &models.AddOutputInput{
 		UserID:      aws.String("userId"),
-		DisplayName: aws.String("asana-project"),
+		DisplayName: aws.String("my-asana-destination"),
 		OutputConfig: &models.OutputConfig{
 			Asana: &models.AsanaConfig{
-
-				QueueURL: aws.String("https://sqs.us-west-2.amazonaws.com/123456789012/test-output"),
+				PersonalAccessToken: aws.String("0/8c26ac5222d539ca0ad7000000000000"),
+				ProjectGids:         aws.StringSlice([]string{""}),
 			},
 		},
 	}
@@ -325,13 +325,14 @@ func TestAddOutputAsana(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := &models.AddOutputOutput{
-		DisplayName:    aws.String("my-queue"),
-		OutputType:     aws.String("sqs"),
+		DisplayName:    aws.String("my-asana-destination"),
+		OutputType:     aws.String("asana"),
 		LastModifiedBy: aws.String("userId"),
 		CreatedBy:      aws.String("userId"),
 		OutputConfig: &models.OutputConfig{
-			Sqs: &models.SqsConfig{
-				QueueURL: aws.String("https://sqs.us-west-2.amazonaws.com/123456789012/test-output"),
+			Asana: &models.AsanaConfig{
+				PersonalAccessToken: aws.String("0/8c26ac5222d539ca0ad7000000000000"),
+				ProjectGids:         aws.StringSlice([]string{""}),
 			},
 		},
 		OutputID:           result.OutputID,

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -104,6 +104,9 @@ func getOutputType(outputConfig *models.OutputConfig) (*string, error) {
 	if outputConfig.Sqs != nil {
 		return aws.String("sqs"), nil
 	}
+	if outputConfig.Asana != nil {
+		return aws.String("asana"), nil
+	}
 
 	return nil, errors.New("no valid output configuration specified for alert output")
 }

--- a/internal/core/outputs_api/validator/validator.go
+++ b/internal/core/outputs_api/validator/validator.go
@@ -37,7 +37,7 @@ func Validator() (*validator.Validate, error) {
 	return result, nil
 }
 
-var outputTypes = []string{"Slack", "Sns", "Email", "PagerDuty", "Github", "Jira", "Opsgenie", "MsTeams", "Sqs"}
+var outputTypes = []string{"Slack", "Sns", "Email", "PagerDuty", "Github", "Jira", "Opsgenie", "MsTeams", "Sqs", "Asana"}
 
 func ensureOneOutput(sl validator.StructLevel) {
 	input := sl.Current()

--- a/internal/core/outputs_api/validator/validator_test.go
+++ b/internal/core/outputs_api/validator/validator_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
 )
 
-const outputSet = "Slack|Sns|Email|PagerDuty|Github|Jira|Opsgenie|MsTeams|Sqs"
+const outputSet = "Slack|Sns|Email|PagerDuty|Github|Jira|Opsgenie|MsTeams|Sqs|Asana"
 
 func expectedMsg(structName string, fieldName string, tagName string) string {
 	return fmt.Sprintf(


### PR DESCRIPTION
## Background

Why are you making this change? Please provide a reference to any related issues and PRs

Related to https://github.com/panther-labs/panther/issues/70 . Supporting Asana as a destination. When a policy fails or a rule has a match, we will create a new Asana task in an Asana project. 
When users create an Asana destination, they need to add an access token and one (or many) projects that they want the task to associated with. 

Ref: https://developers.asana.com/docs/#create-a-task
## Changes

- Adding Asana as a destination
- Fixing an issue in the alert_delivery Lambda API - marking the `createdAt` field from an alert as required. It was a field always required by the code, just the API didn't have the appropriate mark. 
- Small cleanup here and there

## Testing

- Added unit test
- Created an Asana destination and fired a test rule. Seen a new task created in a project

![Screen Shot 2020-01-30 at 7 09 57 PM](https://user-images.githubusercontent.com/2652630/73477237-28fb4c80-4394-11ea-8b1a-c3adc86333f1.png)

