### PR TITLE
[git] swap secret team for distinct usernames

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
-# The default owners for everything in the repo:
-* @panther-labs/eng
+#
+# Default Owners
+#
+* @3nvi @austinbyers @nhakmiller @kostaspap @jacknagz @rleighton
+
+#
+# Documentation
+#
+docs/ @3nvi @austinbyers @nhakmiller @kostaspap @jacknagz @rleighton @kartikeypan


### PR DESCRIPTION
## Background

Move to public GitHub usernames vs a Github team name

## Changes

- ^^

## Testing

- YOLO
