### PR TITLE
[ENG-1469] Real-time source deletion

### DIFF
--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -92,6 +92,9 @@ const createApolloClient = (history: History<LocationErrorState>) =>
         AlertSummary: {
           keyFields: ['alertId'],
         },
+        Integration: {
+          keyFields: ['integrationId'],
+        },
       },
     }),
   });

--- a/web/src/pages/list-sources/subcomponents/infra-source-table.tsx
+++ b/web/src/pages/list-sources/subcomponents/infra-source-table.tsx
@@ -31,6 +31,7 @@ export const LIST_INFRA_SOURCES = gql`
         createdBy
         integrationId
         integrationLabel
+      integrationType
         scanEnabled
         scanIntervalMins
         scanStatus

--- a/web/src/pages/list-sources/subcomponents/infra-source-table.tsx
+++ b/web/src/pages/list-sources/subcomponents/infra-source-table.tsx
@@ -31,7 +31,7 @@ export const LIST_INFRA_SOURCES = gql`
         createdBy
         integrationId
         integrationLabel
-      integrationType
+        integrationType
         scanEnabled
         scanIntervalMins
         scanStatus

--- a/web/src/pages/list-sources/subcomponents/log-source-table.tsx
+++ b/web/src/pages/list-sources/subcomponents/log-source-table.tsx
@@ -30,6 +30,7 @@ export const LIST_LOG_SOURCES = gql`
       createdAtTime
       integrationId
       integrationLabel
+      integrationType
       s3Buckets
     }
   }


### PR DESCRIPTION
## Background

Why are you making this change? Please provide a reference to any related issues and PRs
This PR fixes a bug where a page refresh was needed in order to see the source you deleted. Now the source will be instantly removed from the table, without the need for a page refresh.

## Changes

- Add missing `integrationType` field
- Add apollo cache normalization to Integration types

## Testing

- How did you test your change?
Locally