### PR TITLE
Removed MFA configuration that causes fresh deployments to fail

### DIFF
--- a/deployments/core/cognito.yml
+++ b/deployments/core/cognito.yml
@@ -44,7 +44,6 @@ Resources:
             <br />Panther - runpanther.io
             <br />
             <br /><small>Copyright © 2020 Panther Labs Inc. All rights reserved.</small>
-      MfaConfiguration: 'ON'
       AutoVerifiedAttributes: # Attributes you want the user to verify (poor naming choice by AWS)
         - email
       Policies:


### PR DESCRIPTION
## Background

I noticed while testing a previous deployment that it appears Panther currently fails to deploy on a fresh (no prior existing infrastructure) deployment due to the Cognito User pool configuration.

Note that MFA is re-enabled via API calls in the `enableTOTP` step of the deploy process.

## Changes

- Removed an unnecessary field from Cognito user pool causing deployments to fail

## Testing

- Deployed to a new region to test a fresh deployment
