### PR TITLE
[Bugfix] Allow `eventsLastEvaluatedKey` to accept `null` values

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -72,7 +72,7 @@ type AlertDetails {
   lastEventMatched: AWSDateTime!
   eventsMatched: Int!
   events: [AWSJSON!]!
-  eventsLastEvaluatedKey: String!
+  eventsLastEvaluatedKey: String
 }
 
 type ListAlertsResponse {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -43,7 +43,7 @@ export type AlertDetails = {
   lastEventMatched: Scalars['AWSDateTime'];
   eventsMatched: Scalars['Int'];
   events: Array<Scalars['AWSJSON']>;
-  eventsLastEvaluatedKey: Scalars['String'];
+  eventsLastEvaluatedKey?: Maybe<Scalars['String']>;
 };
 
 export enum AlertReportFrequencyEnum {


### PR DESCRIPTION
## Background

Why are you making this change? Please provide a reference to any related issues and PRs
This PR fixes #93 by allowing `eventsLastEvaluatedKey` to take `null` values

## Changes

- Allow `eventsLastEvaluatedKey` to be `null`

## Testing

This fix hasn't been tested E2E due to lack of reproducibility. The instructions on #93 were not reproducible. The reported issue though is definitely a bug according to the [related api](https://github.com/panther-labs/panther/blob/1ba51ff74fdb09f9e6c40106fb0926cac48ebe28/api/lambda/alerts/models/api.go#L113), thus this PR is considered safe
