### PR TITLE
Fix issue with persistent compliance filters

### DIFF
--- a/web/src/components/utils/table-compliance-filter-control.tsx
+++ b/web/src/components/utils/table-compliance-filter-control.tsx
@@ -17,32 +17,22 @@
  */
 
 import React from 'react';
-import { PoliciesForResourceInput, ResourcesForPolicyInput } from 'Generated/schema';
 import { Text, TextProps, defaultTheme } from 'pouncejs';
 
-type Filters = PoliciesForResourceInput & ResourcesForPolicyInput;
-
-interface TableComplianceFilterControlProps<FilterKey extends keyof Filters>
-  extends Omit<TextProps, 'size'> {
+interface TableComplianceFilterControlProps extends Omit<TextProps, 'size'> {
   text: string;
-  updateFilter: (filters: { [key: string]: Filters[FilterKey] }) => void;
-  filterKey: FilterKey;
-  filterValue: Filters[FilterKey];
-  activeFilterValue?: Filters[FilterKey];
+  isActive: boolean;
   count?: number;
   countColor?: keyof typeof defaultTheme.colors;
 }
 
-function TableComplianceFilterControl<FilterKey extends keyof Filters>({
-  filterKey,
-  filterValue,
-  updateFilter,
-  activeFilterValue,
+const TableComplianceFilterControl: React.FC<TableComplianceFilterControlProps> = ({
   text,
   count,
   countColor,
+  isActive,
   ...rest
-}: TableComplianceFilterControlProps<FilterKey>): React.ReactElement {
+}) => {
   return (
     <Text
       {...rest}
@@ -51,8 +41,7 @@ function TableComplianceFilterControl<FilterKey extends keyof Filters>({
       color="grey300"
       is="button"
       borderRadius="medium"
-      onClick={() => updateFilter({ [filterKey]: filterValue })}
-      backgroundColor={filterValue === activeFilterValue ? 'grey50' : undefined}
+      backgroundColor={isActive ? 'grey50' : undefined}
     >
       {text}{' '}
       <Text size="medium" color={countColor} is="span">
@@ -60,6 +49,6 @@ function TableComplianceFilterControl<FilterKey extends keyof Filters>({
       </Text>
     </Text>
   );
-}
+};
 
 export default TableComplianceFilterControl;

--- a/web/src/pages/policy-details/index.tsx
+++ b/web/src/pages/policy-details/index.tsx
@@ -178,41 +178,43 @@ const PolicyDetailsPage = () => {
           title="Resources"
           actions={
             <Box ml={6} mr="auto">
-              <TableComplianceFilterControl<'status'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="status"
-                filterValue={undefined}
-                activeFilterValue={requestParams.status}
-                updateFilter={setRequestParamsAndResetPaging}
                 count={getComplianceItemsTotalCount(totalCounts)}
                 text="All"
+                isActive={!requestParams.status && !requestParams.suppressed}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({ status: undefined, suppressed: undefined })
+                }
               />
-              <TableComplianceFilterControl<'status'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="status"
-                filterValue={ComplianceStatusEnum.Fail}
-                activeFilterValue={requestParams.status}
-                updateFilter={setRequestParamsAndResetPaging}
                 count={totalCounts.active.fail}
                 countColor="red300"
                 text="Failing"
+                isActive={requestParams.status === ComplianceStatusEnum.Fail}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({
+                    status: ComplianceStatusEnum.Fail,
+                    suppressed: undefined,
+                  })
+                }
               />
-              <TableComplianceFilterControl<'status'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="status"
-                filterValue={ComplianceStatusEnum.Pass}
-                activeFilterValue={requestParams.status}
-                updateFilter={setRequestParamsAndResetPaging}
                 countColor="green300"
                 count={totalCounts.active.pass}
                 text="Passing"
+                isActive={requestParams.status === ComplianceStatusEnum.Pass}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({
+                    status: ComplianceStatusEnum.Pass,
+                    suppressed: undefined,
+                  })
+                }
               />
-              <TableComplianceFilterControl<'suppressed'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="suppressed"
-                filterValue={true}
-                activeFilterValue={requestParams.suppressed}
-                updateFilter={setRequestParamsAndResetPaging}
                 countColor="orange300"
                 count={
                   totalCounts.suppressed.fail +
@@ -220,6 +222,13 @@ const PolicyDetailsPage = () => {
                   totalCounts.suppressed.error
                 }
                 text="Ignored"
+                isActive={!requestParams.status && requestParams.suppressed}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({
+                    status: undefined,
+                    suppressed: true,
+                  })
+                }
               />
             </Box>
           }

--- a/web/src/pages/resource-details/index.tsx
+++ b/web/src/pages/resource-details/index.tsx
@@ -175,41 +175,43 @@ const ResourceDetailsPage = () => {
           title="Policies"
           actions={
             <Box ml={6} mr="auto">
-              <TableComplianceFilterControl<'status'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="status"
-                updateFilter={setRequestParamsAndResetPaging}
-                filterValue={undefined}
-                activeFilterValue={requestParams.status}
                 count={getComplianceItemsTotalCount(totalCounts)}
                 text="All"
+                isActive={!requestParams.status && !requestParams.suppressed}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({ status: undefined, suppressed: undefined })
+                }
               />
-              <TableComplianceFilterControl<'status'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="status"
-                updateFilter={setRequestParamsAndResetPaging}
-                filterValue={ComplianceStatusEnum.Fail}
-                activeFilterValue={requestParams.status}
                 count={totalCounts.active.fail}
                 countColor="red300"
                 text="Failing"
+                isActive={requestParams.status === ComplianceStatusEnum.Fail}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({
+                    status: ComplianceStatusEnum.Fail,
+                    suppressed: undefined,
+                  })
+                }
               />
-              <TableComplianceFilterControl<'status'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="status"
-                filterValue={ComplianceStatusEnum.Pass}
-                activeFilterValue={requestParams.status}
-                updateFilter={setRequestParamsAndResetPaging}
                 countColor="green300"
                 count={totalCounts.active.pass}
                 text="Passing"
+                isActive={requestParams.status === ComplianceStatusEnum.Pass}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({
+                    status: ComplianceStatusEnum.Pass,
+                    suppressed: undefined,
+                  })
+                }
               />
-              <TableComplianceFilterControl<'suppressed'>
+              <TableComplianceFilterControl
                 mr={1}
-                filterKey="suppressed"
-                filterValue={true}
-                activeFilterValue={requestParams.suppressed}
-                updateFilter={setRequestParamsAndResetPaging}
                 countColor="orange300"
                 count={
                   totalCounts.suppressed.fail +
@@ -217,6 +219,13 @@ const ResourceDetailsPage = () => {
                   totalCounts.suppressed.error
                 }
                 text="Ignored"
+                isActive={!requestParams.status && requestParams.suppressed}
+                onClick={() =>
+                  setRequestParamsAndResetPaging({
+                    status: undefined,
+                    suppressed: true,
+                  })
+                }
               />
             </Box>
           }


### PR DESCRIPTION
## Background

This PR fixes #92 by making sure that `status` and `ignored` filters are mutually exclusive and don't overlap with one another

## Changes

- Make sure that when `ignored` is toggled, then `status` is disabled and vice versa

## Testing

> How did you test your change?
Locally
