### PR TITLE
Generic URL suffix + AWS partition

### DIFF
--- a/deployments/compliance/alert_processing.yml
+++ b/deployments/compliance/alert_processing.yml
@@ -114,11 +114,11 @@ Resources:
       Environment:
         Variables:
           DEBUG: !Ref Debug
-          REMEDIATION_SERVICE_HOST: !Sub '${RemediationApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          REMEDIATION_SERVICE_HOST: !Sub '${RemediationApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           REMEDIATION_SERVICE_PATH: v1
-          COMPLIANCE_SERVICE_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          COMPLIANCE_SERVICE_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           COMPLIANCE_SERVICE_PATH: v1
-          POLICY_SERVICE_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          POLICY_SERVICE_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           POLICY_SERVICE_PATH: v1
           TABLE_NAME: !Ref Table
       Events:
@@ -133,12 +133,8 @@ Resources:
       MemorySize: !Ref ProcessorMemorySizeMB
       Runtime: go1.x
       Timeout: !Ref ProcessorTimeoutSec
+      Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ReadFromSQS
           Version: 2012-10-17
           Statement:
@@ -163,9 +159,9 @@ Resources:
             - Effect: Allow
               Action: execute-api:Invoke
               Resource:
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RemediationApiId}/v1/POST/remediateasync
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ComplianceApiId}/v1/GET/status
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/policy
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${RemediationApiId}/v1/POST/remediateasync
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ComplianceApiId}/v1/GET/status
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/policy
 
   ##### Alert Forwarder #####
   Table:
@@ -202,7 +198,7 @@ Resources:
       Description: Forwards the alerts to the alert delivery mechanism
       Environment:
         Variables:
-          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-alerts
+          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-alerts
           DEBUG: !Ref Debug
       Events:
         DynamoDBEvent:
@@ -218,11 +214,6 @@ Resources:
       Layers: !If [AttachLayers, !Ref LayerVersionArns, !Ref 'AWS::NoValue']
       Timeout: !Ref ForwarderTimeoutSec
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ReadTableStreams
           Version: 2012-10-17
           Statement:

--- a/deployments/compliance/aws_event_processor.yml
+++ b/deployments/compliance/aws_event_processor.yml
@@ -88,7 +88,7 @@ Resources:
             Resource: '*'
             Condition:
               ArnLike:
-                aws:SourceArn: arn:aws:sns:*:*:*-PantherEventsTopic-*
+                aws:SourceArn: !Sub arn:${AWS::Partition}:sns:*:*:*-PantherEventsTopic-*
       Queues:
         - !Ref EventQueue
 
@@ -113,9 +113,9 @@ Resources:
       Environment:
         Variables:
           DEBUG: !Ref Debug
-          RESOURCES_API_FQDN: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          RESOURCES_API_FQDN: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           RESOURCES_API_PATH: v1
-          SNAPSHOT_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-snapshot-queue
+          SNAPSHOT_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-snapshot-queue
       Events:
         Queue:
           Type: SQS
@@ -130,11 +130,6 @@ Resources:
       Timeout: !Ref TimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: SendAndReceiveSqsMessages
           Version: 2012-10-17
           Statement:
@@ -159,16 +154,16 @@ Resources:
           Statement:
             - Effect: Allow
               Action: sns:ConfirmSubscription
-              Resource: arn:aws:sns:*:*:*-PantherEventsTopic-*
+              Resource: !Sub arn:${AWS::Partition}:sns:*:*:*-PantherEventsTopic-*
         - Id: DeleteResources
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: execute-api:Invoke
-              Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/POST/delete
+              Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/POST/delete
         - Id: InvokeSnapshotAPI
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: lambda:InvokeFunction
-              Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-snapshot-api
+              Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-snapshot-api

--- a/deployments/compliance/compliance_api.yml
+++ b/deployments/compliance/compliance_api.yml
@@ -83,11 +83,6 @@ Resources:
       Timeout: !Ref TimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: DynamoManageItems
           Version: 2012-10-17
           Statement:
@@ -113,8 +108,8 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref Function
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
+      Principal: !Sub apigateway.${AWS::URLSuffix}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ComplianceTable:
     Type: AWS::DynamoDB::Table

--- a/deployments/compliance/remediation.yml
+++ b/deployments/compliance/remediation.yml
@@ -114,8 +114,8 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref ApiFunction
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
+      Principal: !Sub apigateway.${AWS::URLSuffix}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   Queue:
     Type: AWS::SQS::Queue
@@ -145,9 +145,9 @@ Resources:
           DEBUG: !Ref Debug
           SQS_QUEUE_URL: !Ref Queue
           REMEDIATION_LAMBDA_ARN: !GetAtt RemediationFunction.Arn
-          POLICIES_SERVICE_HOSTNAME: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          POLICIES_SERVICE_HOSTNAME: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           POLICIES_SERVICE_PATH: v1
-          RESOURCES_SERVICE_HOSTNAME: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          RESOURCES_SERVICE_HOSTNAME: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           RESOURCES_SERVICE_PATH: v1
       FunctionName: panther-remediation-api
       Handler: main
@@ -157,11 +157,6 @@ Resources:
       Timeout: !Ref ApiTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: SendSqsMessages
           Version: 2012-10-17
           Statement:
@@ -181,8 +176,8 @@ Resources:
             - Effect: Allow
               Action: execute-api:Invoke
               Resource:
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/policy
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/GET/resource
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/policy
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/GET/resource
             - Effect: Allow
               Action: lambda:InvokeFunction
               Resource: !GetAtt RemediationFunction.Arn
@@ -209,9 +204,9 @@ Resources:
         Variables:
           DEBUG: !Ref Debug
           REMEDIATION_LAMBDA_ARN: !GetAtt RemediationFunction.Arn
-          POLICIES_SERVICE_HOSTNAME: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          POLICIES_SERVICE_HOSTNAME: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           POLICIES_SERVICE_PATH: v1
-          RESOURCES_SERVICE_HOSTNAME: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          RESOURCES_SERVICE_HOSTNAME: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           RESOURCES_SERVICE_PATH: v1
       Events:
         Queue:
@@ -226,11 +221,6 @@ Resources:
       Runtime: go1.x
       Timeout: !Ref ProcessorTimeoutSec
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ReceiveAndDeleteSQSMessages
           Version: 2012-10-17
           Statement:
@@ -246,8 +236,8 @@ Resources:
             - Effect: Allow
               Action: execute-api:Invoke
               Resource:
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/policy
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/GET/resource
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/policy
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/GET/resource
             - Effect: Allow
               Action: lambda:InvokeFunction
               Resource: !GetAtt RemediationFunction.Arn
@@ -283,17 +273,12 @@ Resources:
       Timeout: !Ref RemediationTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: AssumeRemediationRole
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: sts:AssumeRole
-              Resource: !Sub arn:aws:iam::*:role/${RemediationRoleName}
+              Resource: !Sub arn:${AWS::Partition}:iam::*:role/${RemediationRoleName}
 
 Outputs:
   GatewayId:

--- a/deployments/compliance/resources_api.yml
+++ b/deployments/compliance/resources_api.yml
@@ -108,8 +108,8 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref HandlerFunction
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
+      Principal: !Sub apigateway.${AWS::URLSuffix}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ##### API Lambda Handler #####
   HandlerFunction:
@@ -119,7 +119,7 @@ Resources:
       Description: Resources API
       Environment:
         Variables:
-          COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           COMPLIANCE_API_PATH: v1
           DEBUG: !Ref Debug
           RESOURCES_QUEUE_URL: !Ref InputQueue
@@ -132,19 +132,14 @@ Resources:
       Timeout: !Ref HandlerTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: AccessComplianceApi
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: execute-api:Invoke
               Resource:
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ComplianceApiId}/v1/GET/describe-org
-                - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ComplianceApiId}/v1/POST/delete
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ComplianceApiId}/v1/GET/describe-org
+                - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ComplianceApiId}/v1/POST/delete
         - Id: DynamoManageItems
           Version: 2012-10-17
           Statement:
@@ -226,14 +221,14 @@ Resources:
       Description: Scans recently modified resources
       Environment:
         Variables:
-          ALERT_QUEUE_URL: !Sub 'https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-alert-processor-queue'
+          ALERT_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-alert-processor-queue
           DEBUG: !Ref Debug
-          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           ANALYSIS_API_PATH: v1
           POLICY_ENGINE: panther-policy-engine
-          COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           COMPLIANCE_API_PATH: v1
-          RESOURCE_API_HOST: !Sub '${GatewayApi}.execute-api.${AWS::Region}.amazonaws.com'
+          RESOURCE_API_HOST: !Sub '${GatewayApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           RESOURCE_API_PATH: v1
       Events:
         Queue:
@@ -249,11 +244,6 @@ Resources:
       Timeout: !Ref QueueProcessorTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: SendAndReceiveSqsMessages
           Version: 2012-10-17
           Statement:
@@ -311,12 +301,6 @@ Resources:
       Runtime: python3.7
       Timeout: !Ref EngineTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
-      Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
 
   EngineLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deployments/compliance/snapshot.yml
+++ b/deployments/compliance/snapshot.yml
@@ -111,7 +111,7 @@ Resources:
         Variables:
           AUDIT_ROLE_NAME: !Ref AuditRoleName
           DEBUG: !Ref Debug
-          RESOURCES_API_FQDN: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          RESOURCES_API_FQDN: !Sub '${ResourcesApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           RESOURCES_API_PATH: v1
           SNAPSHOT_QUEUE_URL: !Ref Queue
       Events:
@@ -128,11 +128,6 @@ Resources:
       Timeout: !Ref PollerTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ManageSQSMessages
           Version: 2012-10-17
           Statement:
@@ -154,13 +149,13 @@ Resources:
           Statement:
             - Effect: Allow
               Action: execute-api:Invoke
-              Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/POST/resource
+              Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ResourcesApiId}/v1/POST/resource
         - Id: AssumePantherAuditRoles
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: sts:AssumeRole
-              Resource: !Sub arn:aws:iam::*:role/${AuditRoleName}
+              Resource: !Sub arn:${AWS::Partition}:iam::*:role/${AuditRoleName}
 
   PollerLogGroup:
     Type: AWS::Logs::LogGroup
@@ -194,8 +189,8 @@ Resources:
         Variables:
           DEBUG: !Ref Debug
           SNAPSHOT_POLLERS_QUEUE_URL: !Ref Queue
-          LOG_PROCESSOR_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${LogAnalysisQueueName}
-          LOG_PROCESSOR_QUEUE_ARN: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${LogAnalysisQueueName}
+          LOG_PROCESSOR_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/${LogAnalysisQueueName}
+          LOG_PROCESSOR_QUEUE_ARN: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${LogAnalysisQueueName}
           TABLE_NAME: !Ref IntegrationsTable
       FunctionName: panther-snapshot-api
       Handler: main
@@ -205,11 +200,6 @@ Resources:
       Timeout: !Ref ApiTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: IntegrationsTablePermissions
           Version: 2012-10-17
           Statement:
@@ -268,17 +258,12 @@ Resources:
       Timeout: !Ref SchedulerTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: InvokeSnapshotAPI
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: lambda:InvokeFunction
-              Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-snapshot-api
+              Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-snapshot-api
         - Id: SendSQSMessages
           Version: 2012-10-17
           Statement:

--- a/deployments/core/admin_api.yml
+++ b/deployments/core/admin_api.yml
@@ -121,11 +121,6 @@ Resources:
       Timeout: !Ref UsersTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: CognitoUserManagement
           Version: 2012-10-17
           Statement:
@@ -153,7 +148,7 @@ Resources:
                 - appsync:GetGraphqlApi
                 - appsync:ListGraphqlApis
                 - appsync:UpdateGraphqlApi
-              Resource: !Sub arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:*
+              Resource: !Sub arn:${AWS::Partition}:appsync:${AWS::Region}:${AWS::AccountId}:*
         - Id: InvokeOrganizationAPI
           Version: 2012-10-17
           Statement:
@@ -194,11 +189,6 @@ Resources:
       Timeout: !Ref UsersTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: GetCognitoUsers
           Version: 2012-10-17
           Statement:
@@ -211,7 +201,7 @@ Resources:
     Properties:
       FunctionName: !GetAtt CustomMessageTriggerFunction.Arn
       Action: lambda:InvokeFunction
-      Principal: cognito-idp.amazonaws.com
+      Principal: !Sub cognito-idp.${AWS::URLSuffix}
       SourceArn: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*
 
   ##### Organization API #####
@@ -254,11 +244,6 @@ Resources:
       Timeout: !Ref OrganizationTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ManageOrganizationTable
           Version: 2012-10-17
           Statement:

--- a/deployments/core/analysis_api.yml
+++ b/deployments/core/analysis_api.yml
@@ -81,7 +81,7 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref HandlerFunction
-      Principal: apigateway.amazonaws.com
+      Principal: !Sub apigateway.${AWS::URLSuffix}
       SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ##### API Lambda Handler #####
@@ -93,12 +93,12 @@ Resources:
       Environment:
         Variables:
           BUCKET: !Ref Bucket
-          COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           COMPLIANCE_API_PATH: v1
           DEBUG: !Ref Debug
           POLICY_ENGINE: panther-policy-engine
           RULES_ENGINE: panther-rules-engine
-          RESOURCE_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-resources
+          RESOURCE_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-resources
           TABLE: !Ref Table
       FunctionName: panther-analysis-api
       Handler: main
@@ -108,11 +108,6 @@ Resources:
       Timeout: !Ref HandlerTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: InvokeApis
           Version: 2012-10-17
           Statement:

--- a/deployments/core/appsync.yml
+++ b/deployments/core/appsync.yml
@@ -52,7 +52,7 @@ Resources:
     Type: AWS::AppSync::GraphQLSchema
     Properties:
       ApiId: !GetAtt GraphQLApi.ApiId
-      DefinitionS3Location: ../../api/graphql/schema.graphql
+      Definition: api/graphql/schema.graphql
 
   AppsyncServiceRole:
     Type: AWS::IAM::Role

--- a/deployments/core/appsync.yml
+++ b/deployments/core/appsync.yml
@@ -52,7 +52,7 @@ Resources:
     Type: AWS::AppSync::GraphQLSchema
     Properties:
       ApiId: !GetAtt GraphQLApi.ApiId
-      Definition: api/graphql/schema.graphql
+      DefinitionS3Location: ../../api/graphql/schema.graphql
 
   AppsyncServiceRole:
     Type: AWS::IAM::Role
@@ -64,9 +64,9 @@ Resources:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
-              Service: appsync.amazonaws.com
+              Service: !Sub appsync.${AWS::URLSuffix}
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs
       Policies:
         - PolicyName: InvokeLegacyApis
           PolicyDocument:

--- a/deployments/core/outputs.yml
+++ b/deployments/core/outputs.yml
@@ -178,11 +178,6 @@ Resources:
       Timeout: !Ref ApiFunctionTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: OutputsTables
           Version: 2012-10-17
           Statement:
@@ -268,11 +263,6 @@ Resources:
       Timeout: !Ref DeliveryFunctionTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: OutputsAPI
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -188,7 +188,7 @@ Resources:
           EVENTS_TABLE_NAME: !Ref EventsTable
           RULE_INDEX_NAME: ruleId-creationTime-index
           TIME_INDEX_NAME: timePartition-creationTime-index
-          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           ANALYSIS_API_PATH: v1
       FunctionName: panther-alerts-api
       Handler: main
@@ -198,11 +198,6 @@ Resources:
       Timeout: !Ref AlertsAPITimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ManageAlerts
           Version: 2012-10-17
           Statement:
@@ -221,7 +216,7 @@ Resources:
           Statement:
             - Effect: Allow
               Action: execute-api:Invoke
-              Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/rule
+              Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/rule
         - Id: ReadEvents
           Version: 2012-10-17
           Statement:
@@ -250,9 +245,9 @@ Resources:
           RECENT_ALERTS_TABLE: !Ref RecentAlertsTable
           EVENTS_TABLE: !Ref EventsTable
           ALERTS_TABLE: !Ref AlertsTable
-          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           ANALYSIS_API_PATH: v1
-          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-alerts
+          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-alerts
       Events:
         Queue:
           Type: SQS
@@ -267,17 +262,12 @@ Resources:
       Timeout: !Ref MergerTimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: InvokeGatewayApi
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: execute-api:Invoke
-              Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/rule
+              Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/rule
         - Id: SQS
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -145,7 +145,7 @@ Resources:
           Statement:
             - Effect: Allow
               Action: sts:AssumeRole
-              Resource: 'arn:aws:iam::*:role/PantherLogProcessingRole'
+              Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherLogProcessingRole
               Condition:
                 Bool:
                   aws:SecureTransport: true
@@ -167,6 +167,6 @@ Resources:
                 - glue:CreatePartition
                 - glue:GetTable
               Resource:
-                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${PantherDatabase}
-                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${PantherDatabase}/*
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${PantherDatabase}
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${PantherDatabase}/*

--- a/deployments/log_analysis/rules_engine.yml
+++ b/deployments/log_analysis/rules_engine.yml
@@ -135,7 +135,7 @@ Resources:
       Handler: src.main.lambda_handler
       Environment:
         Variables:
-          ANALYSIS_API_FQDN: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.amazonaws.com'
+          ANALYSIS_API_FQDN: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           ANALYSIS_API_PATH: v1
           DEBUG: !Ref Debug
           ALERTS_QUEUE: !Ref AlertsQueue
@@ -158,11 +158,6 @@ Resources:
       Timeout: !Ref TimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - !If [
-            TracingEnabled,
-            'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess',
-            !Ref 'AWS::NoValue',
-          ]
         - Id: ReceiveFromInputSqsQueue
           Version: 2012-10-17
           Statement:
@@ -201,4 +196,4 @@ Resources:
           Statement:
             - Effect: Allow
               Action: execute-api:Invoke
-              Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/enabled
+              Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/enabled

--- a/deployments/web/ecr.yml
+++ b/deployments/web/ecr.yml
@@ -49,4 +49,4 @@ Resources:
 Outputs:
   ImageRepo:
     Description: The name of the registry hosting the panther web image
-    Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ImageName}
+    Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${ImageName}

--- a/deployments/web/server.yml
+++ b/deployments/web/server.yml
@@ -150,7 +150,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: ecs-tasks.amazonaws.com
+              Service: !Sub ecs-tasks.${AWS::URLSuffix}
             Action: sts:AssumeRole
       Path: /
       Policies:


### PR DESCRIPTION
## Background

Following up from #61 to use a cfn psuedoparameter for all URL suffixes and AWS partitions

## Changes

- Replace `.amazonaws.com` with `.${AWS::URLSuffix}`
- Replace `:arn:aws:` with `:arn:${AWS::Partition}:`
- Remove the `Xray` policy we conditionally attach - SAM does this automatically (much like the `BasicExecutionRole` policy it attaches to all Lambda functions so they can generate logs)
    - Add missing TracingConfig from alert processor

## Testing

- Deployed to my dev account
