### PR TITLE
Add ability to list and remove users

### DIFF
--- a/api/lambda/users/models/api.go
+++ b/api/lambda/users/models/api.go
@@ -25,6 +25,8 @@ type LambdaInput struct {
 	GetUser                   *GetUserInput                   `json:"getUser"`
 	GetUserOrganizationAccess *GetUserOrganizationAccessInput `json:"getUserOrganizationAccess"`
 	InviteUser                *InviteUserInput                `json:"inviteUser"`
+	ListUsers                 *ListUsersInput                 `json:"listUsers"`
+	RemoveUser                *RemoveUserInput                `json:"removeUser"`
 	ResetUserPassword         *ResetUserPasswordInput         `json:"resetUserPassword"`
 	UpdateUser                *UpdateUserInput                `json:"updateUser"`
 }
@@ -56,12 +58,30 @@ type InviteUserInput struct {
 	FamilyName *string `json:"familyName" validate:"required,min=1"`
 	Email      *string `json:"email" validate:"required,email"`
 	UserPoolID *string `json:"userPoolId" validate:"required,min=1"`
-	Role       *string `json:"role" validate:"required,min=1"`
 }
 
 // InviteUserOutput returns the randomly generated user id.
 type InviteUserOutput struct {
 	ID *string `json:"id"`
+}
+
+// ListUsersInput lists all users in Panther.
+type ListUsersInput struct {
+	UserPoolID      *string `json:"userPoolId" validate:"required,min=1"`
+	Limit           *int64  `json:"limit" validate:"omitempty,min=1"`
+	PaginationToken *string `json:"paginationToken" validate:"omitempty,min=1"`
+}
+
+// ListUsersOutput returns a page of users.
+type ListUsersOutput struct {
+	Users           []*User `json:"users"`
+	PaginationToken *string `json:"paginationToken"`
+}
+
+// RemoveUserInput deletes a user.
+type RemoveUserInput struct {
+	ID         *string `json:"id" validate:"required,uuid4"`
+	UserPoolID *string `json:"userPoolId" validate:"required,min=1"`
 }
 
 // ResetUserPasswordInput resets the password for a user.

--- a/internal/core/users_api/api/invite_user.go
+++ b/internal/core/users_api/api/invite_user.go
@@ -19,7 +19,6 @@ package api
  */
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/users/models"
@@ -47,7 +46,7 @@ func (API) InviteUser(input *models.InviteUserInput) (*models.InviteUserOutput, 
 		return nil, err
 	}
 
-	if err = userGateway.AddUserToGroup(id, aws.String("Admin"), input.UserPoolID); err != nil {
+	if err = userGateway.AddUserToGroup(id, input.UserPoolID); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/users_api/api/invite_user_test.go
+++ b/internal/core/users_api/api/invite_user_test.go
@@ -80,7 +80,7 @@ func TestInviteUserAddToGroupErr(t *testing.T) {
 		Email:      input.Email,
 		UserPoolID: input.UserPoolID,
 	}).Return(userID, nil)
-	mockGateway.On("AddUserToGroup", userID, aws.String("Admin"), input.UserPoolID).Return(&genericapi.AWSError{})
+	mockGateway.On("AddUserToGroup", userID, input.UserPoolID).Return(&genericapi.AWSError{})
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)
@@ -175,7 +175,7 @@ func TestInviteUserHandle(t *testing.T) {
 		Email:      input.Email,
 		UserPoolID: input.UserPoolID,
 	}).Return(userID, nil)
-	mockGateway.On("AddUserToGroup", userID, aws.String("Admin"), input.UserPoolID).Return(nil)
+	mockGateway.On("AddUserToGroup", userID, input.UserPoolID).Return(nil)
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)

--- a/internal/core/users_api/api/invite_user_test.go
+++ b/internal/core/users_api/api/invite_user_test.go
@@ -35,7 +35,6 @@ var input = &models.InviteUserInput{
 	Email:      aws.String("joe.blow@panther.io"),
 	FamilyName: aws.String("Blow"),
 	UserPoolID: aws.String("fakePoolId"),
-	Role:       aws.String("Admin"),
 }
 var userID = aws.String("1234-5678-9012")
 
@@ -81,7 +80,7 @@ func TestInviteUserAddToGroupErr(t *testing.T) {
 		Email:      input.Email,
 		UserPoolID: input.UserPoolID,
 	}).Return(userID, nil)
-	mockGateway.On("AddUserToGroup", userID, input.Role, input.UserPoolID).Return(&genericapi.AWSError{})
+	mockGateway.On("AddUserToGroup", userID, aws.String("Admin"), input.UserPoolID).Return(&genericapi.AWSError{})
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)
@@ -176,7 +175,7 @@ func TestInviteUserHandle(t *testing.T) {
 		Email:      input.Email,
 		UserPoolID: input.UserPoolID,
 	}).Return(userID, nil)
-	mockGateway.On("AddUserToGroup", userID, input.Role, input.UserPoolID).Return(nil)
+	mockGateway.On("AddUserToGroup", userID, aws.String("Admin"), input.UserPoolID).Return(nil)
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)

--- a/internal/core/users_api/api/list_users.go
+++ b/internal/core/users_api/api/list_users.go
@@ -1,0 +1,44 @@
+package api
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "github.com/panther-labs/panther/api/lambda/users/models"
+
+// ListUsers lists details for each user in Panther.
+func (API) ListUsers(input *models.ListUsersInput) (*models.ListUsersOutput, error) {
+	listOutput, err := userGateway.ListUsers(input.Limit, input.PaginationToken, input.UserPoolID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range listOutput.Users {
+		groups, err := userGateway.ListGroupsForUser(user.ID, input.UserPoolID)
+		if err != nil {
+			return nil, err
+		}
+		if len(groups) > 0 {
+			user.Role = groups[0].Name
+		}
+	}
+
+	return &models.ListUsersOutput{
+		Users:           listOutput.Users,
+		PaginationToken: listOutput.PaginationToken,
+	}, nil
+}

--- a/internal/core/users_api/api/list_users_test.go
+++ b/internal/core/users_api/api/list_users_test.go
@@ -1,0 +1,105 @@
+package api
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/panther-labs/panther/api/lambda/users/models"
+	"github.com/panther-labs/panther/internal/core/users_api/gateway"
+	"github.com/panther-labs/panther/pkg/genericapi"
+)
+
+type mockGatewayListUsersClient struct {
+	gateway.API
+	listUserGatewayErr  bool
+	listGroupGatewayErr bool
+}
+
+func (m *mockGatewayListUsersClient) ListUsers(
+	limit *int64, paginationToken *string, userPoolID *string) (*gateway.ListUsersOutput, error) {
+
+	if m.listUserGatewayErr {
+		return nil, &genericapi.AWSError{}
+	}
+
+	return &gateway.ListUsersOutput{
+		Users: []*models.User{
+			{
+				GivenName:   aws.String("Joe"),
+				FamilyName:  aws.String("Blow"),
+				ID:          aws.String("user123"),
+				Email:       aws.String("joe@blow.com"),
+				PhoneNumber: aws.String("+1234567890"),
+				CreatedAt:   aws.Int64(1545442826),
+				Status:      aws.String("CONFIRMED"),
+			},
+		},
+		PaginationToken: paginationToken,
+	}, nil
+}
+
+func (m *mockGatewayListUsersClient) ListGroupsForUser(*string, *string) ([]*models.Group, error) {
+	if m.listGroupGatewayErr {
+		return nil, &genericapi.AWSError{}
+	}
+
+	return []*models.Group{
+		{
+			Description: aws.String("Roles Description"),
+			Name:        aws.String("Admins"),
+		},
+	}, nil
+}
+
+func TestListUsersGatewayErr(t *testing.T) {
+	userGateway = &mockGatewayListUsersClient{listUserGatewayErr: true}
+	result, err := (API{}).ListUsers(&models.ListUsersInput{
+		UserPoolID:      aws.String("fakePoolId"),
+		Limit:           aws.Int64(10),
+		PaginationToken: aws.String("paginationToken"),
+	})
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestListGroupsForUserGatewayErr(t *testing.T) {
+	userGateway = &mockGatewayListUsersClient{listGroupGatewayErr: true}
+	result, err := (API{}).ListUsers(&models.ListUsersInput{
+		UserPoolID:      aws.String("fakePoolId"),
+		Limit:           aws.Int64(10),
+		PaginationToken: aws.String("paginationToken"),
+	})
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestListUsersHandle(t *testing.T) {
+	userGateway = &mockGatewayListUsersClient{}
+	result, err := (API{}).ListUsers(&models.ListUsersInput{
+		UserPoolID:      aws.String("fakePoolId"),
+		Limit:           aws.Int64(10),
+		PaginationToken: aws.String("paginationToken"),
+	})
+	assert.NotNil(t, result)
+	assert.NoError(t, err)
+}

--- a/internal/core/users_api/api/remove_user.go
+++ b/internal/core/users_api/api/remove_user.go
@@ -19,37 +19,33 @@ package api
  */
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/users/models"
-	"github.com/panther-labs/panther/internal/core/users_api/gateway"
 )
 
-// InviteUser adds a new user to the Cognito user pool.
-func (API) InviteUser(input *models.InviteUserInput) (*models.InviteUserOutput, error) {
-	// Add user to org mapping in dynamo
-	if err := addUser(input.Email); err != nil {
-		return nil, err
-	}
-
-	// Create user in Cognito
-	id, err := userGateway.CreateUser(&gateway.CreateUserInput{
-		GivenName:  input.GivenName,
-		FamilyName: input.FamilyName,
-		Email:      input.Email,
-		UserPoolID: input.UserPoolID,
-	})
+// RemoveUser deletes a user from cognito.
+func (API) RemoveUser(input *models.RemoveUserInput) error {
+	// Get user sub from Cognito
+	user, err := userGateway.GetUser(input.ID, input.UserPoolID)
 	if err != nil {
-		if deleteErr := userTable.Delete(input.Email); deleteErr != nil {
-			zap.L().Error("error deleting user from dynamo after failed invitation", zap.Error(deleteErr))
-		}
-		return nil, err
+		zap.L().Error("error getting user from user pool", zap.Error(err))
+		return err
 	}
 
-	if err = userGateway.AddUserToGroup(id, aws.String("Admin"), input.UserPoolID); err != nil {
-		return nil, err
+	// Delete user from Cognito user pool
+	err = userGateway.DeleteUser(input.ID, input.UserPoolID)
+	if err != nil {
+		zap.L().Error("error deleting user from user pool", zap.Error(err))
+		return err
 	}
 
-	return &models.InviteUserOutput{ID: id}, nil
+	// Delete user from Dynamo
+	err = userTable.Delete(user.Email)
+	if err != nil {
+		zap.L().Error("error deleting user from dynamo", zap.Error(err))
+		return err
+	}
+
+	return nil
 }

--- a/internal/core/users_api/api/remove_user_test.go
+++ b/internal/core/users_api/api/remove_user_test.go
@@ -1,0 +1,119 @@
+package api
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/panther-labs/panther/api/lambda/users/models"
+	"github.com/panther-labs/panther/internal/core/users_api/gateway"
+	users "github.com/panther-labs/panther/internal/core/users_api/table"
+	"github.com/panther-labs/panther/pkg/genericapi"
+)
+
+var removeUserInput = &models.RemoveUserInput{
+	ID:         aws.String("user123"),
+	UserPoolID: aws.String("fakePoolId"),
+}
+
+func TestRemoveUserGetErr(t *testing.T) {
+	// create an instance of our test objects
+	mockGateway := &gateway.MockUserGateway{}
+	m := &users.MockTable{}
+	// replace the global variables with our mock objects
+	userGateway = mockGateway
+	userTable = m
+
+	mockGateway.On("GetUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(&models.User{}, &genericapi.AWSError{})
+
+	err := (API{}).RemoveUser(removeUserInput)
+	assert.Error(t, err)
+	assert.IsType(t, err, &genericapi.AWSError{})
+
+	mockGateway.AssertExpectations(t)
+	m.AssertExpectations(t)
+	mockGateway.AssertNotCalled(t, "DeleteUser")
+	m.AssertNotCalled(t, "Delete")
+}
+
+func TestRemoveUserCognitoErr(t *testing.T) {
+	// create an instance of our test objects
+	mockGateway := &gateway.MockUserGateway{}
+	m := &users.MockTable{}
+	// replace the global variables with our mock objects
+	userGateway = mockGateway
+	userTable = m
+
+	mockGateway.On("GetUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(&models.User{
+		Email: aws.String("email@email.com"),
+	}, nil)
+	mockGateway.On("DeleteUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(&genericapi.AWSError{})
+
+	err := (API{}).RemoveUser(removeUserInput)
+	assert.Error(t, err)
+	assert.IsType(t, err, &genericapi.AWSError{})
+
+	mockGateway.AssertExpectations(t)
+	m.AssertExpectations(t)
+	m.AssertNotCalled(t, "Delete")
+}
+
+func TestRemoveUserDynamoErr(t *testing.T) {
+	// create an instance of our test objects
+	mockGateway := &gateway.MockUserGateway{}
+	m := &users.MockTable{}
+	// replace the global variables with our mock objects
+	userGateway = mockGateway
+	userTable = m
+
+	mockGateway.On("GetUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(&models.User{
+		Email: aws.String("email@email.com"),
+	}, nil)
+	mockGateway.On("DeleteUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(nil)
+	m.On("Delete", aws.String("email@email.com")).Return(&genericapi.AWSError{})
+
+	err := (API{}).RemoveUser(removeUserInput)
+	assert.Error(t, err)
+	assert.IsType(t, err, &genericapi.AWSError{})
+
+	mockGateway.AssertExpectations(t)
+	m.AssertExpectations(t)
+}
+
+func TestRemoveUserHandle(t *testing.T) {
+	// create an instance of our test objects
+	mockGateway := &gateway.MockUserGateway{}
+	m := &users.MockTable{}
+	// replace the global variables with our mock objects
+	userGateway = mockGateway
+	userTable = m
+
+	mockGateway.On("GetUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(&models.User{
+		Email: aws.String("email@email.com"),
+	}, nil)
+	mockGateway.On("DeleteUser", removeUserInput.ID, removeUserInput.UserPoolID).Return(nil)
+	m.On("Delete", aws.String("email@email.com")).Return(nil)
+
+	assert.NoError(t, (API{}).RemoveUser(removeUserInput))
+	mockGateway.AssertExpectations(t)
+	m.AssertExpectations(t)
+}

--- a/internal/core/users_api/api/update_user_test.go
+++ b/internal/core/users_api/api/update_user_test.go
@@ -62,7 +62,7 @@ func (m *mockGatewayUpdateUserClient) RemoveUserFromGroup(*string, *string, *str
 	return nil
 }
 
-func (m *mockGatewayUpdateUserClient) AddUserToGroup(*string, *string, *string) error {
+func (m *mockGatewayUpdateUserClient) AddUserToGroup(*string, *string) error {
 	if m.removeErr {
 		return &genericapi.AWSError{}
 	}

--- a/internal/core/users_api/gateway/add_user_to_group.go
+++ b/internal/core/users_api/gateway/add_user_to_group.go
@@ -19,15 +19,20 @@ package gateway
  */
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
+// Panther free edition only has admin users.
+// Upgrade to enterprise for role-based access control (RBAC).
+const groupName = "Admin"
+
 // AddUserToGroup calls cognito api add a user to a specified group
-func (g *UsersGateway) AddUserToGroup(id *string, groupName *string, userPoolID *string) error {
+func (g *UsersGateway) AddUserToGroup(id *string, userPoolID *string) error {
 	if _, err := g.userPoolClient.AdminAddUserToGroup(&provider.AdminAddUserToGroupInput{
-		GroupName:  groupName,
+		GroupName:  aws.String(groupName),
 		Username:   id,
 		UserPoolId: userPoolID,
 	}); err != nil {

--- a/internal/core/users_api/gateway/add_user_to_group_test.go
+++ b/internal/core/users_api/gateway/add_user_to_group_test.go
@@ -43,7 +43,6 @@ func TestAddUserToGroup(t *testing.T) {
 
 	assert.NoError(t, gw.AddUserToGroup(
 		testAddUserToGroupInput.Username,
-		testAddUserToGroupInput.GroupName,
 		testAddUserToGroupInput.UserPoolId,
 	))
 	mockCognitoClient.AssertExpectations(t)
@@ -58,7 +57,6 @@ func TestAddUserToGroupFailure(t *testing.T) {
 
 	assert.Error(t, gw.AddUserToGroup(
 		testAddUserToGroupInput.Username,
-		testAddUserToGroupInput.GroupName,
 		testAddUserToGroupInput.UserPoolId,
 	))
 	mockCognitoClient.AssertExpectations(t)

--- a/internal/core/users_api/gateway/delete_user.go
+++ b/internal/core/users_api/gateway/delete_user.go
@@ -1,0 +1,37 @@
+package gateway
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+
+	"github.com/panther-labs/panther/pkg/genericapi"
+)
+
+// DeleteUser calls cognito api delete user from a user pool
+func (g *UsersGateway) DeleteUser(id *string, userPoolID *string) error {
+	if _, err := g.userPoolClient.AdminDeleteUser(&provider.AdminDeleteUserInput{
+		Username:   id,
+		UserPoolId: userPoolID,
+	}); err != nil {
+		return &genericapi.AWSError{Method: "cognito.AdminDeleteUser", Err: err}
+	}
+
+	return nil
+}

--- a/internal/core/users_api/gateway/delete_user_test.go
+++ b/internal/core/users_api/gateway/delete_user_test.go
@@ -1,0 +1,53 @@
+package gateway
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	providerI "github.com/aws/aws-sdk-go/service/cognitoidentityprovider/cognitoidentityprovideriface"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDeleteUserClient struct {
+	providerI.CognitoIdentityProviderAPI
+	serviceErr bool
+}
+
+func (m *mockDeleteUserClient) AdminDeleteUser(
+	*provider.AdminDeleteUserInput) (*provider.AdminDeleteUserOutput, error) {
+
+	if m.serviceErr {
+		return nil, errors.New("cognito does not exist")
+	}
+	return &provider.AdminDeleteUserOutput{}, nil
+}
+
+func TestDeleteUser(t *testing.T) {
+	gw := &UsersGateway{userPoolClient: &mockDeleteUserClient{}}
+	assert.NoError(t, gw.DeleteUser(aws.String("user123"), aws.String("userPoolId")))
+}
+
+func TestDeleteUserFailed(t *testing.T) {
+	gw := &UsersGateway{userPoolClient: &mockDeleteUserClient{serviceErr: true}}
+	assert.Error(t, gw.DeleteUser(aws.String("user123"), aws.String("userPoolId")))
+}

--- a/internal/core/users_api/gateway/mock_gateway.go
+++ b/internal/core/users_api/gateway/mock_gateway.go
@@ -35,8 +35,8 @@ type MockUserGateway struct {
 // and just record the activity, and returns what the Mock object tells it to.
 
 // AddUserToGroup mocks AddUserToGroup for testing
-func (m *MockUserGateway) AddUserToGroup(id *string, groupName *string, userPoolID *string) error {
-	args := m.Called(id, groupName, userPoolID)
+func (m *MockUserGateway) AddUserToGroup(id *string, userPoolID *string) error {
+	args := m.Called(id, userPoolID)
 	return args.Error(0)
 }
 

--- a/internal/core/users_api/gateway/mock_gateway.go
+++ b/internal/core/users_api/gateway/mock_gateway.go
@@ -46,6 +46,12 @@ func (m *MockUserGateway) CreateUser(input *CreateUserInput) (*string, error) {
 	return args.Get(0).(*string), args.Error(1)
 }
 
+// DeleteUser mocks DeleteUser for testing
+func (m *MockUserGateway) DeleteUser(id *string, userPoolID *string) error {
+	args := m.Called(id, userPoolID)
+	return args.Error(0)
+}
+
 // GetUser mocks GetUser for testing
 func (m *MockUserGateway) GetUser(id *string, userPoolID *string) (*models.User, error) {
 	args := m.Called(id, userPoolID)

--- a/internal/core/users_api/gateway/users_gateway.go
+++ b/internal/core/users_api/gateway/users_gateway.go
@@ -30,6 +30,7 @@ import (
 type API interface {
 	AddUserToGroup(id *string, groupName *string, userPoolID *string) error
 	CreateUser(input *CreateUserInput) (*string, error)
+	DeleteUser(id *string, userPoolID *string) error
 	GetUser(id *string, userPoolID *string) (*models.User, error)
 	ListGroupsForUser(id *string, userPoolID *string) ([]*models.Group, error)
 	ListUsers(limit *int64, paginationToken *string, userPoolID *string) (*ListUsersOutput, error)

--- a/internal/core/users_api/gateway/users_gateway.go
+++ b/internal/core/users_api/gateway/users_gateway.go
@@ -28,7 +28,7 @@ import (
 
 // API defines the interface for the user gateway which can be used for mocking.
 type API interface {
-	AddUserToGroup(id *string, groupName *string, userPoolID *string) error
+	AddUserToGroup(id *string, userPoolID *string) error
 	CreateUser(input *CreateUserInput) (*string, error)
 	DeleteUser(id *string, userPoolID *string) error
 	GetUser(id *string, userPoolID *string) (*models.User, error)

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -389,7 +389,6 @@ func setupOrganization(awsSession *session.Session, userPoolID string) error {
 			FamilyName: &lastName,
 			Email:      &email,
 			UserPoolID: &userPoolID,
-			Role:       aws.String("Admin"),
 		},
 	}
 	if err := invokeLambda(awsSession, "panther-users-api", input); err != nil {


### PR DESCRIPTION
## Background

Add ListUsers and RemoveUser endpoints for #90 

## Changes

- Add `ListUsers` and `RemoveUser` endpoints, as we had them originally
- Remove `Role` from `InviteUser` input struct - only one role is actually supported

I left the "userPoolID" as part of the request. Since we only have one user pool, the `users-api` could look it up, but for simplicity I just left it how we had it before. The users-api and organization-api could use a more thorough redesign for the open-source single-tenant model to address tech debt like that.

## Testing

- `mage test:ci`

Haven't had a chance to deploy it and invoke it in my test account, but wanted to get the PR up for @3nvi to work with
