### PR TITLE
[Docs] Add segment for EC2 deployment

### DIFF
--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -84,6 +84,15 @@ Your AWS credentials _must_ be exported as environment variables for the docker 
 {% endhint %}
 
 {% hint style="info" %}
+Rather than deploying from your local machine, you can instead use an EC2 instance with Docker and
+git installed. This saves you the need of exporting your AWS credentials as environment variables, while benefiting
+from a potentially more performant machine for your deployment. Remember to make sure that the IAM role that the EC2
+instance assumes, has enough permissions for the creation of all Panther resources.
+
+The minimum requirements for an EC2 are 1 vCPU and 2GB of Memory. The lowest-cost instance that satisfies those requirements, is an EC2 `t2.small`.
+{% endhint %}
+
+{% hint style="info" %}
 Rather than deploying from within a docker container, you can instead configure your [development environment](development.md#manual-installation) locally. This will take more time initially but will lead to faster deployments.
 {% endhint %}
 

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -85,7 +85,7 @@ Your AWS credentials _must_ be exported as environment variables for the docker 
 
 {% hint style="info" %}
 Rather than deploying from your local machine, you can opt to use an EC2 instance with Docker and
-git installed. Instead of exporting your AWS credentials as environment variables, you will now need an IAM role (that your EC2 instance will assume) with enough permissions for the creation of all Panther resources.
+git installed. Instead of exporting your AWS credentials as environment variables, you will need to attach an IAM role to your EC2 instance profile, with enough permissions for the creation of all Panther resources.
 
 The minimum requirements for an EC2 machine are 1 vCPU and 2GB of Memory. The lowest-cost instance that satisfies those requirements, is an EC2 `t2.small`.
 {% endhint %}

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -84,12 +84,10 @@ Your AWS credentials _must_ be exported as environment variables for the docker 
 {% endhint %}
 
 {% hint style="info" %}
-Rather than deploying from your local machine, you can instead use an EC2 instance with Docker and
-git installed. This saves you the need of exporting your AWS credentials as environment variables, while benefiting
-from a potentially more performant machine for your deployment. Remember to make sure that the IAM role that the EC2
-instance assumes, has enough permissions for the creation of all Panther resources.
+Rather than deploying from your local machine, you can opt to use an EC2 instance with Docker and
+git installed. Instead of exporting your AWS credentials as environment variables, you will now need an IAM role (that your EC2 instance will assume) with enough permissions for the creation of all Panther resources.
 
-The minimum requirements for an EC2 are 1 vCPU and 2GB of Memory. The lowest-cost instance that satisfies those requirements, is an EC2 `t2.small`.
+The minimum requirements for an EC2 machine are 1 vCPU and 2GB of Memory. The lowest-cost instance that satisfies those requirements, is an EC2 `t2.small`.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -87,7 +87,7 @@ Your AWS credentials _must_ be exported as environment variables for the docker 
 Rather than deploying from your local machine, you can opt to use an EC2 instance with Docker and
 git installed. Instead of exporting your AWS credentials as environment variables, you will need to attach an IAM role to your EC2 instance profile, with enough permissions for the creation of all Panther resources.
 
-The minimum requirements for an EC2 machine are 1 vCPU and 2GB of Memory. The lowest-cost instance that satisfies those requirements, is an EC2 `t2.small`.
+The minimum requirements for an EC2 machine are 1 vCPU and 2GB of memory. The lowest-cost instance that satisfies those requirements is an EC2 `t2.small`.
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
## Background

> Why are you making this change? Please provide a reference to any related issues and PRs

This PR adds a section in the docs that has to do with using an EC2 instance as the deployment host (instead of a local machine). It also resolves #96 

## Changes

- Add section in `Get started`

## Testing

- How did you test your change?
Markdown checker
