### PR TITLE
Reduce compliance caching

### DIFF
--- a/internal/compliance/resources_api/handlers/compliance.go
+++ b/internal/compliance/resources_api/handlers/compliance.go
@@ -27,7 +27,9 @@ import (
 	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
-const complianceCacheDuration = time.Minute
+// Cache pass/fail status for each policy for a few seconds so that ListResources can filter and
+// sort by compliance status without having to query the compliance-api for every resource.
+const complianceCacheDuration = 3 * time.Second
 
 type complianceCacheEntry struct {
 	ExpiresAt time.Time

--- a/internal/core/analysis_api/handlers/compliance.go
+++ b/internal/core/analysis_api/handlers/compliance.go
@@ -28,7 +28,9 @@ import (
 	compliancemodels "github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
-const complianceCacheDuration = time.Minute
+// Cache pass/fail status for each policy for a few seconds so that ListPolicies can filter and
+// sort by compliance status without having to query the compliance-api for every policy.
+const complianceCacheDuration = 3 * time.Second
 
 type complianceCacheEntry struct {
 	ExpiresAt time.Time
@@ -47,7 +49,7 @@ var complianceCache *complianceCacheEntry
 
 // Get the pass/fail compliance status for a particular policy.
 //
-// Each org's pass/fail information for all policies is cached for a minute.
+// Each org's pass/fail information for all policies is cached for a very short time.
 func getComplianceStatus(policyID models.ID) (*complianceStatus, error) {
 	entry, err := getOrgCompliance()
 	if err != nil {


### PR DESCRIPTION
## Background
Fixes #97 

The policy and resource overview pages include a summary of their compliance status - is this policy/resource PASS or FAIL (or ERROR) in aggregate?

That information is not explicitly stored anywhere - to determine overall pass/fail status, we have to scan the `compliance-api` to find all applicable (policy, resource) entries and compute the aggregate status.

Since this is a relatively expensive operation, the original idea was to cache the overall pass/fail status for every policy and resource to avoid constantly scanning the compliance table. However, this may have been a premature optimization and creates an unexpected user experience (#97)

I was going to remove the caching completely, but it turns out we do still need it in one place - `ListPolicies` and `ListResources` both allow you to sort and filter by compliance status, which is only possible if the `policy-api` and `resource-api`, respectively, remember at least for a short time their set of compliance information.

The fix, then, is to reduce the cache time to be as small as possible so that the list operations don't hammer `compliance-api` with queries but the overall status still updates very quickly for the user.

Better designs are possible that eliminate the caching completely, but require a much larger refactor.

## Changes

- Reduce compliance cache time from 60 seconds to 3

## Testing

- `mage test:ci`
