### PR TITLE
Make CFN post-processing more resilient

### DIFF
--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -324,20 +324,23 @@ func fixPackageTemplateURL(line string) string {
 	// This code transforms:
 	// TemplateURL: https://s3.region.amazonaws.com/bucket/panther-app/1.template
 	// into:
-	// TemplateURL: https://bucket.s3.amazonaws.com/panther-app/1.template
+	// TemplateURL: https://s3.amazonaws.com/bucket/panther-app/1.template
+	// Unless that is the format the URL was already in.
 	if strings.HasPrefix(strings.TrimSpace(line), "TemplateURL: ") {
 		// Break the line down to the pieces we need
 		lineParts := strings.Split(line, "https://")
 		uriParts := strings.Split(lineParts[1], "/")
 		prefixParts := strings.Split(uriParts[0], ".")
 
-		// Build the new URI
-		prefixParts[1] = prefixParts[0]
-		prefixParts[0] = uriParts[1]
+		// Check if the format is already correct
+		if prefixParts[1] == "amazonaws" {
+			return line
+		}
 
-		// Rebuild the line
-		newURIPrefix := strings.Join(prefixParts, ".")
-		newURIParts := append([]string{newURIPrefix}, uriParts[2:]...)
+		// Build the new URI
+		prefixParts[1] = "s3"
+		newURIPrefix := strings.Join(prefixParts[1:], ".")
+		newURIParts := append([]string{newURIPrefix}, uriParts[1:]...)
 		lineParts[1] = strings.Join(newURIParts, "/")
 		line = strings.Join(lineParts, "https://")
 	}

--- a/tools/mage/deploy_test.go
+++ b/tools/mage/deploy_test.go
@@ -27,16 +27,21 @@ import (
 func TestFixTemplateURL(t *testing.T) {
 	// Basic example
 	originalTemplate := "TemplateURL: https://s3.region.amazonaws.com/bucket/panther-app/1.template"
-	expectedTemplate := "TemplateURL: https://bucket.s3.amazonaws.com/panther-app/1.template"
+	expectedTemplate := "TemplateURL: https://s3.amazonaws.com/bucket/panther-app/1.template"
 	assert.Equal(t, expectedTemplate, fixPackageTemplateURL(originalTemplate))
 
 	// Maintains leading whitespace
 	originalTemplate = "   TemplateURL: https://s3.region.amazonaws.com/bucket/panther-app/1.template"
-	expectedTemplate = "   TemplateURL: https://bucket.s3.amazonaws.com/panther-app/1.template"
+	expectedTemplate = "   TemplateURL: https://s3.amazonaws.com/bucket/panther-app/1.template"
 	assert.Equal(t, expectedTemplate, fixPackageTemplateURL(originalTemplate))
 
 	// Don't change things that are not TemplateURLs
 	originalTemplate = "https://s3.region.amazonaws.com/bucket/panther-app/1.template"
 	expectedTemplate = "https://s3.region.amazonaws.com/bucket/panther-app/1.template"
+	assert.Equal(t, expectedTemplate, fixPackageTemplateURL(originalTemplate))
+
+	// Don't change things that are not already in global format
+	originalTemplate = "https://s3.amazonaws.com/bucket/panther-app/1.template"
+	expectedTemplate = "https://s3.amazonaws.com/bucket/panther-app/1.template"
 	assert.Equal(t, expectedTemplate, fixPackageTemplateURL(originalTemplate))
 }


### PR DESCRIPTION
## Background

@rleighton reported an issue where deployments in `us-east-1` would fail. This was corroborated by another user is `us-east-2`. I was not able to reproduce in `us-west-2`.

It turns out the s3 global endpoint format we were converting to is not viable in certain regions, and also the regional endpoint we were trying to convert from was actually a global endpoint in some regions. It appears the `aws cli` is region aware when producing these template URLs, so we need to be more resilient in handling them.

## Changes

- Changed format of transformed template URLs to match globally supported format suggested by @kostaspap 
- Added checks to not change the URL if it is already a global endpoint

## Testing

- deployed in `us-west-2`, `us-east-1`, `us-east-2`, and `eu-west-1`
