### PR TITLE
Fix regression dealing with empty sets in panther log

### DIFF
--- a/internal/log_analysis/log_processor/parsers/pantherlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog_test.go
@@ -32,7 +32,7 @@ func TestAnyStringMarshal(t *testing.T) {
 	var any PantherAnyString
 
 	// nil case
-	expectedJSON := ``
+	expectedJSON := `[]`
 	actualJSON, err := jsoniter.Marshal(&any)
 	require.NoError(t, err)
 	require.Equal(t, expectedJSON, string(actualJSON))

--- a/internal/log_analysis/log_processor/parsers/patherlog.go
+++ b/internal/log_analysis/log_processor/parsers/patherlog.go
@@ -60,7 +60,7 @@ func NewPantherAnyString() *PantherAnyString {
 }
 
 func (any *PantherAnyString) MarshalJSON() ([]byte, error) {
-	if any != nil && len(any.set) > 0 { // copy to slice
+	if any != nil { // copy to slice
 		values := make([]string, len(any.set))
 		i := 0
 		for k := range any.set {


### PR DESCRIPTION
## Background
Previously I changed the "set" serialization to emit nothing when set is empty. This was wrong because the set is "non-nil" and the omit empty tag will still emit the  field which results in incorrect json.

This only happens when we parse something like: "arn": "" . We skip blank strings populating the set BUT the set gets made (non-nil) but empty. A corner case.

## Changes
Emit a [] when set is empty.

## Testing
mage test:ci
ran in dev account
