### PR TITLE
Clear rules on update

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -37,9 +37,7 @@ import (
 
 const (
 	// sessionDurationSeconds is the duration in seconds of the STS session the S3 client uses
-	sessionDurationSeconds = 3600
-	// sessionExternalID is external ID that will be used when getting credentials from STS
-	sessionExternalID       = "panther"
+	sessionDurationSeconds  = 3600
 	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole"
 )
 
@@ -138,6 +136,5 @@ func getAwsCredentials(awsAccountID string) *credentials.Credentials {
 
 	return stscreds.NewCredentials(common.Session, roleArn, func(p *stscreds.AssumeRoleProvider) {
 		p.Duration = time.Duration(sessionDurationSeconds) * time.Second
-		p.ExternalID = aws.String(sessionExternalID)
 	})
 }

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -45,6 +45,9 @@ class Engine:
         self.logger.info('Retrieved {} rules in {} seconds'.format(len(rules), end - start))
         start = default_timer()
 
+        # Clear old rules
+        self._log_type_to_rules.clear()
+
         # Importing common module. This module MAY hold code common to some rules and if it exists, it must be imported before other rules.
         # However, the presence of this rule is optional.
         for raw_rule in rules:


### PR DESCRIPTION
## Background
Rules were not being cleared on update and were accumulating. Disabled/deleted rules would continue to run.

## Changes
Clear dict before update.

## Testing
Tested in dev account where disabled rules continued to run, after change they did not.
