### PR TITLE
Autogenerate S3 bucket names

### DIFF
--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -384,6 +384,9 @@ Resources:
         Status: Enabled
 
 Outputs:
+  AnalysisVersionsBucket:
+    Description: Bucket where Python version histories are stored
+    Value: !GetAtt AnalysisAPI.Outputs.BucketName
   AthenaResultsBucket:
     Description: Bucket where Athena writes query results
     Value: !Ref AthenaResults

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -295,10 +295,10 @@ Resources:
   ProcessedDataBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub panther-processed-data-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub panther-processed-data-${AWS::StackId}
       LoggingConfiguration:
         DestinationBucketName: !ImportValue Panther-LogBucket
-        LogFilePrefix: !Sub panther-classified-data-${AWS::AccountId}-${AWS::Region}/
+        LogFilePrefix: !Sub panther-processed-data-${AWS::StackId}/
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -364,14 +364,14 @@ Resources:
   AthenaResultsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub panther-athena-results-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub panther-athena-results-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: 30
             Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !ImportValue Panther-LogBucket
-        LogFilePrefix: !Sub panther-athena-results-${AWS::AccountId}-${AWS::Region}/
+        LogFilePrefix: !Sub panther-athena-results-${AWS::StackId}/
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -292,13 +292,12 @@ Resources:
       TopicName: panther-processed-data-notifications
       KmsMasterKeyId: !Ref QueueEncryptionKey
 
-  ProcessedDataBucket:
+  ProcessedData:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub panther-processed-data-${AWS::StackId}
       LoggingConfiguration:
         DestinationBucketName: !ImportValue Panther-LogBucket
-        LogFilePrefix: !Sub panther-processed-data-${AWS::StackId}/
+        LogFilePrefix: !Sub panther-processed-data-${AWS::AccountId}-${AWS::Region}/
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -321,7 +320,7 @@ Resources:
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
         TracingMode: !Ref TracingMode
         SnsTopicArn: !Ref ProcessedDataNotifications
-        ProcessedDataBucket: !Ref ProcessedDataBucket
+        ProcessedDataBucket: !Ref ProcessedData
         SQSKeyId: !Ref QueueEncryptionKey
         PantherDatabase: !GetAtt GlueTables.Outputs.PantherTablesDatabase
       TemplateURL: log_analysis/log_processor.yml
@@ -350,7 +349,7 @@ Resources:
         AnalysisApiId: !GetAtt AnalysisAPI.Outputs.GatewayId
         SnsTopicArn: !Ref ProcessedDataNotifications
         SQSKeyId: !Ref QueueEncryptionKey
-        ProcessedDataBucket: !Ref ProcessedDataBucket
+        ProcessedDataBucket: !Ref ProcessedData
         PythonLayerArn: !If [CreatePythonLayer, !Ref PythonLayer, !Ref PythonLayerVersionArn]
       TemplateURL: log_analysis/rules_engine.yml
 
@@ -358,20 +357,19 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        ProcessedDataBucket: !Ref ProcessedDataBucket
+        ProcessedDataBucket: !Ref ProcessedData
       TemplateURL: ../out/deployments/log_analysis/gluetables.json
 
-  AthenaResultsBucket:
+  AthenaResults:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub panther-athena-results-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: 30
             Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !ImportValue Panther-LogBucket
-        LogFilePrefix: !Sub panther-athena-results-${AWS::StackId}/
+        LogFilePrefix: !Sub panther-athena-results-${AWS::AccountId}-${AWS::Region}/
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -388,7 +386,7 @@ Resources:
 Outputs:
   AthenaResultsBucket:
     Description: Bucket where Athena writes query results
-    Value: !Ref AthenaResultsBucket
+    Value: !Ref AthenaResults
   AnalysisApiEndpoint:
     Description: panther-analysis-api Gateway HTTPS endpoint
     Value: !Sub ${AnalysisAPI.Outputs.GatewayId}.execute-api.${AWS::Region}.${AWS::URLSuffix}

--- a/deployments/core/analysis_api.yml
+++ b/deployments/core/analysis_api.yml
@@ -186,14 +186,14 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub panther-analysis-versions-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub panther-analysis-versions-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           - NoncurrentVersionExpirationInDays: 365
             Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !Ref S3BucketAccessLogs
-        LogFilePrefix: !Sub panther-analysis-versions-${AWS::AccountId}-${AWS::Region}/
+        LogFilePrefix: !Sub panther-analysis-versions-${AWS::StackId}/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/deployments/core/analysis_api.yml
+++ b/deployments/core/analysis_api.yml
@@ -92,7 +92,7 @@ Resources:
       Description: Analysis API
       Environment:
         Variables:
-          BUCKET: !Ref Bucket
+          BUCKET: !Ref AnalysisVersions
           COMPLIANCE_API_HOST: !Sub '${ComplianceApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           COMPLIANCE_API_PATH: v1
           DEBUG: !Ref Debug
@@ -136,12 +136,12 @@ Resources:
                 - s3:DeleteObject # Does NOT grant permission to permanently delete versions
                 - s3:GetObject*
                 - s3:PutObject
-              Resource: !Sub arn:${AWS::Partition}:s3:::${Bucket}/*
+              Resource: !Sub arn:${AWS::Partition}:s3:::${AnalysisVersions}/*
             - Effect: Allow
               Action:
                 - s3:ListBucket
                 - s3:ListBucketVersions
-              Resource: !GetAtt Bucket.Arn
+              Resource: !GetAtt AnalysisVersions.Arn
         - Id: PublishToResourceQueue
           Version: 2012-10-17
           Statement:
@@ -179,21 +179,20 @@ Resources:
         SSEEnabled: True
       TableName: panther-analysis
 
-  Bucket:
+  AnalysisVersions:
     Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub panther-analysis-versions-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           - NoncurrentVersionExpirationInDays: 365
             Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !Ref S3BucketAccessLogs
-        LogFilePrefix: !Sub panther-analysis-versions-${AWS::StackId}/
+        LogFilePrefix: !Sub panther-analysis-versions-${AWS::AccountId}-${AWS::Region}/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -205,7 +204,7 @@ Resources:
 Outputs:
   BucketName:
     Description: The name of the S3 analysis bucket
-    Value: !Ref Bucket
+    Value: !Ref AnalysisVersions
   GatewayId:
     Description: API Gateway ID
     Value: !Ref GatewayApi

--- a/deployments/core/buckets.yml
+++ b/deployments/core/buckets.yml
@@ -37,7 +37,7 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub panther-s3-logs-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub panther-s3-logs-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           # Keep access logs for 1 year, permanently delete 30 days after they expire
@@ -45,8 +45,8 @@ Resources:
             NoncurrentVersionExpirationInDays: 30
             Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Sub panther-s3-logs-${AWS::AccountId}-${AWS::Region}
-        LogFilePrefix: !Sub panther-s3-logs-${AWS::AccountId}-${AWS::Region}/
+        DestinationBucketName: !Sub panther-s3-logs-${AWS::StackId}
+        LogFilePrefix: !Sub panther-s3-logs-${AWS::StackId}/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -63,7 +63,7 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub panther-source-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub panther-source-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           # Once a stack is deployed, its resources in S3 can be safely removed.
@@ -72,7 +72,7 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName:
           !If [CreateLogBucket, !Ref AccessLogsBucket, !Ref AccessLogsBucketName]
-        LogFilePrefix: !Sub panther-source-${AWS::AccountId}-${AWS::Region}/
+        LogFilePrefix: !Sub panther-source-${AWS::StackId}/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/deployments/core/buckets.yml
+++ b/deployments/core/buckets.yml
@@ -27,8 +27,7 @@ Conditions:
   CreateLogBucket: !Equals [!Ref AccessLogsBucketName, '']
 
 Resources:
-  # S3 bucket for Panther S3 access logs
-  AccessLogsBucket:
+  AccessLogs:
     Condition: CreateLogBucket
     Type: AWS::S3::Bucket
     Properties:
@@ -37,7 +36,6 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub panther-s3-logs-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           # Keep access logs for 1 year, permanently delete 30 days after they expire
@@ -45,8 +43,7 @@ Resources:
             NoncurrentVersionExpirationInDays: 30
             Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Sub panther-s3-logs-${AWS::StackId}
-        LogFilePrefix: !Sub panther-s3-logs-${AWS::StackId}/
+        LogFilePrefix: self/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -56,14 +53,13 @@ Resources:
         Status: Enabled
 
   # S3 bucket for CloudFormation to upload templates, Lambda source, etc
-  SourceBucket:
+  Source:
     Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub panther-source-${AWS::StackId}
       LifecycleConfiguration:
         Rules:
           # Once a stack is deployed, its resources in S3 can be safely removed.
@@ -71,8 +67,8 @@ Resources:
             Status: Enabled
       LoggingConfiguration:
         DestinationBucketName:
-          !If [CreateLogBucket, !Ref AccessLogsBucket, !Ref AccessLogsBucketName]
-        LogFilePrefix: !Sub panther-source-${AWS::StackId}/
+          !If [CreateLogBucket, !Ref AccessLogs, !Ref AccessLogsBucketName]
+        LogFilePrefix: !Sub panther-source-${AWS::AccountId}-${AWS::Region}/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -84,11 +80,11 @@ Resources:
 Outputs:
   LogBucketName:
     Description: S3 bucket name for Panther S3 access logs
-    Value: !If [CreateLogBucket, !Ref AccessLogsBucket, !Ref AccessLogsBucketName]
+    Value: !If [CreateLogBucket, !Ref AccessLogs, !Ref AccessLogsBucketName]
     Export:
       Name: Panther-LogBucket
   SourceBucketName:
     Description: S3 bucket name for Panther CloudFormation packaging
-    Value: !Ref SourceBucket
+    Value: !Ref Source
     Export:
       Name: Panther-SourceBucket

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -341,7 +341,7 @@ func goPkgIntegrationTest(pkg string) {
 	if mg.Verbose() {
 		args = append(args, "-v")
 	}
-	if err := sh.Run("go", args...); err != nil {
+	if err := sh.RunV("go", args...); err != nil {
 		logger.Fatalf("go test %s failed: %v", pkg, err)
 	}
 }


### PR DESCRIPTION
## Background
Fixes: #120

Panther currently creates five S3 buckets, which have names of the form "panther-(name)-(accountId)-(region)".  We chose this format because this is how AWS names default buckets: the accountId + region generally guarantee global uniqueness. However, there are security problems associated with a predictable name, especially one that includes an accountID (#120)

So what does an ideal bucket name look like?

- Must be globally unique (S3 is a global service)
- Must persist across deployments
- Should not leak any information about the account
- Should resist enumeration attacks (i.e. include randomness)

Fortunately, CloudFormation can autogenerate bucket names which satisfy all of the above requirements: `(stack)-(resource)-(random suffix)`

**This is a breaking change**, but we might as well do it now before v1. Existing deployments will have to start over or copy the data from the old to the new buckets.

## Changes

- Remove all `BucketName` properties - let CloudFormation name the buckets
    - Simplify resource names since they are part of the bucket name now
    - S3 access logs are still prefixed with accountID and region. This means access logs won't have the exact bucket name as a prefix, but it's still clear which bucket generated the logs.
- Fix `analysis-api` integration test (which has hardcoding bucket name)
    - Unrelated fix: always show output from integration tests

### Alternatives Considered
I considered using the [StackId pseudo parameter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-stackid), which is also random and persists across deployments. We could name buckets "(stackName)-(resourceName)-(stackId)", which would allow us to construct the bucket name for S3 access log prefixes as well, but then we would have to do string splitting to pull out just the UUID from the stack id/arn.

## Testing

- Deployed to dev account
- Signed in with a new user
- `mage test:integration`

Generated buckets:

![Screen Shot 2020-02-10 at 2 56 35 PM](https://user-images.githubusercontent.com/3608925/74198469-4e028180-4c16-11ea-9160-090b30aa84ef.png)
