### PR TITLE
Case-insensitive attribute sorting for analysis-api

### DIFF
--- a/internal/core/analysis_api/handlers/dynamo.go
+++ b/internal/core/analysis_api/handlers/dynamo.go
@@ -19,7 +19,6 @@ package handlers
  */
 
 import (
-	"sort"
 	"strings"
 	"time"
 
@@ -85,9 +84,9 @@ func (r *tableItem) addExtraFields() {
 
 // Sort string sets before converting to an external Rule/Policy model.
 func (r *tableItem) normalize() {
-	sort.Strings(r.ResourceTypes)
-	sort.Strings(r.Suppressions)
-	sort.Strings(r.Tags)
+	sortCaseInsensitive(r.ResourceTypes)
+	sortCaseInsensitive(r.Suppressions)
+	sortCaseInsensitive(r.Tags)
 }
 
 // Policy converts a Dynamo row into a Policy external model.

--- a/internal/core/analysis_api/handlers/util.go
+++ b/internal/core/analysis_api/handlers/util.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -237,4 +238,18 @@ func writeItem(item *tableItem, userID models.UserID, mustExist *bool) (int, err
 		// entire API call as a failure.
 	}
 	return changeType, nil
+}
+
+// Sort a slice of strings ignoring case when possible
+func sortCaseInsensitive(values []string) {
+	sort.Slice(values, func(i, j int) bool {
+		first, second := strings.ToLower(values[i]), strings.ToLower(values[j])
+		if first == second {
+			// Same lowercase value, fallback to default sort
+			return values[i] < values[j]
+		}
+
+		// Compare the lowercase version of the strings
+		return first < second
+	})
 }

--- a/internal/core/analysis_api/handlers/util_test.go
+++ b/internal/core/analysis_api/handlers/util_test.go
@@ -97,3 +97,15 @@ func TestPoliciesEqual(t *testing.T) {
 	assert.False(t, equal)
 	assert.NoError(t, err)
 }
+
+func TestSortCaseInsensitive(t *testing.T) {
+	input := []string{"AWS.EC2.VPC", "AWS.EC2.Volume"}
+	sortCaseInsensitive(input)
+	assert.Equal(t, []string{"AWS.EC2.Volume", "AWS.EC2.VPC"}, input)
+
+	// Sort by case if lowercase versions are equal
+	input = []string{"panther", "Panther", "Panna Cotta", "panna cotta"}
+	sortCaseInsensitive(input)
+	expected := []string{"Panna Cotta", "panna cotta", "Panther", "panther"}
+	assert.Equal(t, expected, input)
+}


### PR DESCRIPTION
## Background
Fixes: #159 

Standard string sorting depends on capitalization, which leads to unexpected results. For example, `AWS.EC2.Volume` comes before `AWS.EC2.VPC` in the resource type dropdown in the policy editor, but the response from the backend is sorted in the other order.

## Changes

- Sort policy/rule tags, resource types, and suppressions case-insensitive

## Testing

- Added unit tests for case-insensitive sorting
- Deployed to dev account, verified EC2 example has been fixed:

![Screen Shot 2020-02-10 at 3 51 49 PM](https://user-images.githubusercontent.com/3608925/74201321-3e873680-4c1e-11ea-977e-22ec93d210fa.png)
