### PR TITLE
Update AWS IAM Service principals

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
@@ -111,7 +111,7 @@ Resources:
           - Sid: CloudWatchEventsPublish
             Effect: Allow
             Principal:
-              Service: !Sub events.${AWS::URLSuffix}
+              Service: events.amazonaws.com
             Action: sns:Publish
             Resource: !Ref PantherEventsTopic
           - Sid: CrossAccountSubscription

--- a/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-infra.yml
@@ -80,13 +80,13 @@ Resources:
           - Sid: CloudTrailAclCheck
             Effect: Allow
             Principal:
-              Service: !Sub cloudtrail.${AWS::URLSuffix}
+              Service: cloudtrail.amazonaws.com
             Action: s3:GetBucketAcl
             Resource: !GetAtt LogProcessingBucket.Arn
           - Sid: CloudTrailWrite
             Effect: Allow
             Principal:
-              Service: !Sub cloudtrail.${AWS::URLSuffix}
+              Service: cloudtrail.amazonaws.com
             Action: s3:PutObject
             Resource: !Sub ${LogProcessingBucket.Arn}/*
             Condition:
@@ -105,13 +105,13 @@ Resources:
           - Sid: VPCFlowAclCheck
             Effect: Allow
             Principal:
-              Service: !Sub delivery.logs.${AWS::URLSuffix}
+              Service: delivery.logs.amazonaws.com
             Action: s3:GetBucketAcl
             Resource: !GetAtt LogProcessingBucket.Arn
           - Sid: VPCFlowWrite
             Effect: Allow
             Principal:
-              Service: !Sub delivery.logs.${AWS::URLSuffix}
+              Service: delivery.logs.amazonaws.com
             Action: s3:PutObject
             Resource: !Sub ${LogProcessingBucket.Arn}/*
             Condition:
@@ -136,7 +136,7 @@ Resources:
             Sid: S3NotificationPublish
             Effect: Allow
             Principal:
-              Service: !Sub s3.${AWS::URLSuffix}
+              Service: s3.amazonaws.com
             Action: sns:Publish
             Resource: !Ref LogProcessingNotificationsTopic
           - Sid: CrossAccountSubscription

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -76,13 +76,13 @@ Resources:
           - Sid: AllowS3EventNotifications
             Effect: Allow
             Principal:
-              Service: !Sub s3.${AWS::URLSuffix}
+              Service: s3.amazonaws.com
             Action: sns:Publish
             Resource: !Ref Topic
           - Sid: AllowCloudTrailNotification
             Effect: Allow
             Principal:
-              Service: !Sub cloudtrail.${AWS::URLSuffix}
+              Service: cloudtrail.amazonaws.com
             Action: sns:Publish
             Resource: !Ref Topic
           - Sid: AllowSubscriptionToPanther

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -32,7 +32,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: !Sub cloudformation.${AWS::URLSuffix}
+              Service: cloudformation.amazonaws.com
             Action: sts:AssumeRole
       Policies:
         - PolicyName: AssumeRolesInTargetAccounts

--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -70,7 +70,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: !Sub apigateway.${AWS::URLSuffix}
+              Service: apigateway.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
@@ -95,7 +95,7 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Principal:
-              Service: !Sub sns.${AWS::URLSuffix}
+              Service: sns.amazonaws.com
             Action:
               - kms:GenerateDataKey
               - kms:Decrypt

--- a/deployments/compliance/compliance_api.yml
+++ b/deployments/compliance/compliance_api.yml
@@ -108,7 +108,7 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref Function
-      Principal: !Sub apigateway..amazonaws.com
+      Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ComplianceTable:

--- a/deployments/compliance/compliance_api.yml
+++ b/deployments/compliance/compliance_api.yml
@@ -108,7 +108,7 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref Function
-      Principal: !Sub apigateway.${AWS::URLSuffix}
+      Principal: !Sub apigateway..amazonaws.com
       SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ComplianceTable:

--- a/deployments/compliance/remediation.yml
+++ b/deployments/compliance/remediation.yml
@@ -114,7 +114,7 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref ApiFunction
-      Principal: !Sub apigateway.${AWS::URLSuffix}
+      Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   Queue:

--- a/deployments/compliance/resources_api.yml
+++ b/deployments/compliance/resources_api.yml
@@ -108,7 +108,7 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref HandlerFunction
-      Principal: !Sub apigateway.${AWS::URLSuffix}
+      Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ##### API Lambda Handler #####

--- a/deployments/compliance/snapshot.yml
+++ b/deployments/compliance/snapshot.yml
@@ -189,7 +189,7 @@ Resources:
         Variables:
           DEBUG: !Ref Debug
           SNAPSHOT_POLLERS_QUEUE_URL: !Ref Queue
-          LOG_PROCESSOR_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/${LogAnalysisQueueName}
+          LOG_PROCESSOR_QUEUE_URL: !Sub https://sqs.${AWS::Region}..amazonaws.com/${AWS::AccountId}/${LogAnalysisQueueName}
           LOG_PROCESSOR_QUEUE_ARN: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${LogAnalysisQueueName}
           TABLE_NAME: !Ref IntegrationsTable
       FunctionName: panther-snapshot-api

--- a/deployments/compliance/snapshot.yml
+++ b/deployments/compliance/snapshot.yml
@@ -189,7 +189,7 @@ Resources:
         Variables:
           DEBUG: !Ref Debug
           SNAPSHOT_POLLERS_QUEUE_URL: !Ref Queue
-          LOG_PROCESSOR_QUEUE_URL: !Sub https://sqs.${AWS::Region}..amazonaws.com/${AWS::AccountId}/${LogAnalysisQueueName}
+          LOG_PROCESSOR_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${LogAnalysisQueueName}
           LOG_PROCESSOR_QUEUE_ARN: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${LogAnalysisQueueName}
           TABLE_NAME: !Ref IntegrationsTable
       FunctionName: panther-snapshot-api

--- a/deployments/core/admin_api.yml
+++ b/deployments/core/admin_api.yml
@@ -201,7 +201,7 @@ Resources:
     Properties:
       FunctionName: !GetAtt CustomMessageTriggerFunction.Arn
       Action: lambda:InvokeFunction
-      Principal: !Sub cognito-idp.${AWS::URLSuffix}
+      Principal: cognito-idp.amazonaws.com
       SourceArn: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*
 
   ##### Organization API #####

--- a/deployments/core/analysis_api.yml
+++ b/deployments/core/analysis_api.yml
@@ -81,7 +81,7 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref HandlerFunction
-      Principal: !Sub apigateway.${AWS::URLSuffix}
+      Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${GatewayApi}/*
 
   ##### API Lambda Handler #####

--- a/deployments/core/appsync.yml
+++ b/deployments/core/appsync.yml
@@ -64,7 +64,7 @@ Resources:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
-              Service: !Sub appsync.${AWS::URLSuffix}
+              Service: appsync.amazonaws.com
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs
       Policies:

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -245,9 +245,9 @@ Resources:
           RECENT_ALERTS_TABLE: !Ref RecentAlertsTable
           EVENTS_TABLE: !Ref EventsTable
           ALERTS_TABLE: !Ref AlertsTable
-          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}..amazonaws.com'
+          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           ANALYSIS_API_PATH: v1
-          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}..amazonaws.com/${AWS::AccountId}/panther-alerts
+          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-alerts
       Events:
         Queue:
           Type: SQS

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -245,9 +245,9 @@ Resources:
           RECENT_ALERTS_TABLE: !Ref RecentAlertsTable
           EVENTS_TABLE: !Ref EventsTable
           ALERTS_TABLE: !Ref AlertsTable
-          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
+          ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}..amazonaws.com'
           ANALYSIS_API_PATH: v1
-          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}.${AWS::URLSuffix}/${AWS::AccountId}/panther-alerts
+          ALERTING_QUEUE_URL: !Sub https://sqs.${AWS::Region}..amazonaws.com/${AWS::AccountId}/panther-alerts
       Events:
         Queue:
           Type: SQS

--- a/deployments/web/server.yml
+++ b/deployments/web/server.yml
@@ -150,7 +150,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: !Sub ecs-tasks.${AWS::URLSuffix}
+              Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
       Path: /
       Policies:


### PR DESCRIPTION
## Background

The following is a fix for an earlier PR #61 however it turns out AWS IAM service principals do not use the regional suffix. 

## Changes

- Update IAM Service principals to use hardcoded values.

## Testing

- Confirmed IAM SP within AWS CN. 