### PR TITLE
Support errorReportingConsent

### DIFF
--- a/api/lambda/organization/models/api.go
+++ b/api/lambda/organization/models/api.go
@@ -38,11 +38,12 @@ type CompleteActionOutput struct {
 
 // CreateOrganizationInput creates a new Panther customer account.
 type CreateOrganizationInput struct {
-	AlertReportFrequency *string    `json:"alertReportFrequency" validate:"omitempty,oneof=P1D P1W"`
-	AwsConfig            *AwsConfig `json:"awsConfig"`
-	DisplayName          *string    `json:"displayName" validate:"required,min=1"`
-	Email                *string    `genericapi:"redact" json:"email" validate:"required,email"`
-	Phone                *string    `genericapi:"redact" json:"phone"`
+	AlertReportFrequency  *string    `json:"alertReportFrequency" validate:"omitempty,oneof=P1D P1W"`
+	AwsConfig             *AwsConfig `json:"awsConfig"`
+	DisplayName           *string    `json:"displayName" validate:"required,min=1"`
+	Email                 *string    `genericapi:"redact" json:"email" validate:"required,email"`
+	ErrorReportingConsent *bool      `json:"errorReportingConsent"`
+	Phone                 *string    `genericapi:"redact" json:"phone"`
 }
 
 // CreateOrganizationOutput returns the newly created organization.

--- a/api/lambda/organization/models/table.go
+++ b/api/lambda/organization/models/table.go
@@ -28,13 +28,14 @@ const (
 
 // Organization defines the fields in the table row.
 type Organization struct {
-	AlertReportFrequency *string    `json:"alertReportFrequency"`
-	AwsConfig            *AwsConfig `json:"awsConfig"`
-	CompletedActions     []*Action  `dynamodbav:"completedActions,omitempty,stringset" json:"completedActions"`
-	CreatedAt            *string    `json:"createdAt"`
-	DisplayName          *string    `json:"displayName"`
-	Email                *string    `json:"email"`
-	Phone                *string    `json:"phone"`
+	AlertReportFrequency  *string    `json:"alertReportFrequency"`
+	AwsConfig             *AwsConfig `json:"awsConfig"`
+	CompletedActions      []*Action  `dynamodbav:"completedActions,omitempty,stringset" json:"completedActions"`
+	CreatedAt             *string    `json:"createdAt"`
+	DisplayName           *string    `json:"displayName"`
+	Email                 *string    `json:"email"`
+	ErrorReportingConsent *bool      `json:"errorReportingConsent"`
+	Phone                 *string    `json:"phone"`
 }
 
 // AwsConfig defines metadata related to AWS infrastructure for the organization

--- a/internal/core/organization_api/api/create_organization.go
+++ b/internal/core/organization_api/api/create_organization.go
@@ -27,19 +27,18 @@ import (
 )
 
 // CreateOrganization generates a new organization ID.
-//
-// TODO - populate the rules table for new customers
 func (API) CreateOrganization(
 	input *models.CreateOrganizationInput) (*models.CreateOrganizationOutput, error) {
 
 	// Then write the new org to the Dynamo table
 	org := &models.Organization{
-		AlertReportFrequency: input.AlertReportFrequency,
-		AwsConfig:            input.AwsConfig,
-		CreatedAt:            aws.String(time.Now().Format(time.RFC3339)),
-		DisplayName:          input.DisplayName,
-		Email:                input.Email,
-		Phone:                input.Phone,
+		AlertReportFrequency:  input.AlertReportFrequency,
+		AwsConfig:             input.AwsConfig,
+		CreatedAt:             aws.String(time.Now().Format(time.RFC3339)),
+		DisplayName:           input.DisplayName,
+		Email:                 input.Email,
+		ErrorReportingConsent: input.ErrorReportingConsent,
+		Phone:                 input.Phone,
 	}
 
 	if err := orgTable.Put(org); err != nil {

--- a/internal/core/organization_api/api/update_organization.go
+++ b/internal/core/organization_api/api/update_organization.go
@@ -25,11 +25,12 @@ func (API) UpdateOrganization(
 	input *models.UpdateOrganizationInput) (*models.UpdateOrganizationOutput, error) {
 
 	updated, err := orgTable.Update(&models.Organization{
-		AlertReportFrequency: input.AlertReportFrequency,
-		AwsConfig:            input.AwsConfig,
-		DisplayName:          input.DisplayName,
-		Email:                input.Email,
-		Phone:                input.Phone,
+		AlertReportFrequency:  input.AlertReportFrequency,
+		AwsConfig:             input.AwsConfig,
+		DisplayName:           input.DisplayName,
+		Email:                 input.Email,
+		ErrorReportingConsent: input.ErrorReportingConsent,
+		Phone:                 input.Phone,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/core/organization_api/api/update_organization_test.go
+++ b/internal/core/organization_api/api/update_organization_test.go
@@ -49,14 +49,15 @@ func TestUpdateOrganizationError(t *testing.T) {
 func TestUpdateOrganization(t *testing.T) {
 	m := &mockTable{}
 	output := &models.Organization{
-		DisplayName:          aws.String("panther-labs"),
 		AlertReportFrequency: aws.String("P1W"),
-		Email:                aws.String("fake@email.com"),
 		AwsConfig: &models.AwsConfig{
 			UserPoolID:     aws.String("userPool"),
 			AppClientID:    aws.String("appClient"),
 			IdentityPoolID: aws.String("identityPool"),
 		},
+		DisplayName:           aws.String("panther-labs"),
+		Email:                 aws.String("fake@email.com"),
+		ErrorReportingConsent: aws.Bool(true),
 	}
 	m.On("Update", mock.Anything).Return(output, nil)
 	orgTable = m

--- a/internal/core/organization_api/main/integration_test.go
+++ b/internal/core/organization_api/main/integration_test.go
@@ -124,13 +124,14 @@ func createOrg(t *testing.T) {
 
 	assert.NotNil(t, org.CreatedAt)
 	expected := &models.Organization{
-		AlertReportFrequency: input.CreateOrganization.AlertReportFrequency,
-		AwsConfig:            input.CreateOrganization.AwsConfig,
-		CompletedActions:     []*string{},
-		CreatedAt:            org.CreatedAt,
-		DisplayName:          input.CreateOrganization.DisplayName,
-		Email:                input.CreateOrganization.Email,
-		Phone:                input.CreateOrganization.Phone,
+		AlertReportFrequency:  input.CreateOrganization.AlertReportFrequency,
+		AwsConfig:             input.CreateOrganization.AwsConfig,
+		CompletedActions:      []*string{},
+		CreatedAt:             org.CreatedAt,
+		DisplayName:           input.CreateOrganization.DisplayName,
+		Email:                 input.CreateOrganization.Email,
+		ErrorReportingConsent: nil,
+		Phone:                 input.CreateOrganization.Phone,
 	}
 	assert.Equal(t, expected, org)
 }
@@ -158,9 +159,10 @@ func updateOrg(t *testing.T) {
 				AppClientID:    aws.String("appClient"),
 				IdentityPoolID: aws.String("identityPool"),
 			},
-			DisplayName: aws.String("panther-org-api-integration-test-update"),
-			Email:       aws.String("eng-update@runpanther.io"),
-			Phone:       aws.String("111-222-3456"),
+			DisplayName:           aws.String("panther-org-api-integration-test-update"),
+			Email:                 aws.String("eng-update@runpanther.io"),
+			ErrorReportingConsent: aws.Bool(true),
+			Phone:                 aws.String("111-222-3456"),
 		},
 	}}
 	var output models.UpdateOrganizationOutput
@@ -168,13 +170,14 @@ func updateOrg(t *testing.T) {
 
 	expected := models.UpdateOrganizationOutput{
 		Organization: &models.Organization{
-			CompletedActions:     org.CompletedActions,
-			CreatedAt:            org.CreatedAt,
-			AlertReportFrequency: input.UpdateOrganization.AlertReportFrequency,
-			AwsConfig:            input.UpdateOrganization.AwsConfig,
-			DisplayName:          input.UpdateOrganization.DisplayName,
-			Email:                input.UpdateOrganization.Email,
-			Phone:                input.UpdateOrganization.Phone,
+			CompletedActions:      org.CompletedActions,
+			CreatedAt:             org.CreatedAt,
+			AlertReportFrequency:  input.UpdateOrganization.AlertReportFrequency,
+			AwsConfig:             input.UpdateOrganization.AwsConfig,
+			DisplayName:           input.UpdateOrganization.DisplayName,
+			Email:                 input.UpdateOrganization.Email,
+			ErrorReportingConsent: input.UpdateOrganization.ErrorReportingConsent,
+			Phone:                 input.UpdateOrganization.Phone,
 		},
 	}
 	require.Equal(t, expected, output)

--- a/internal/core/organization_api/table/update.go
+++ b/internal/core/organization_api/table/update.go
@@ -37,6 +37,7 @@ func (table *OrganizationsTable) Update(org *models.Organization) (*models.Organ
 		Set(expression.Name("awsConfig"), expression.Value(org.AwsConfig)).
 		Set(expression.Name("displayName"), expression.Value(org.DisplayName)).
 		Set(expression.Name("email"), expression.Value(org.Email)).
+		Set(expression.Name("errorReportingConsent"), expression.Value(org.ErrorReportingConsent)).
 		Set(expression.Name("phone"), expression.Value(org.Phone))
 	return table.doUpdate(update)
 }

--- a/internal/core/organization_api/table/update_test.go
+++ b/internal/core/organization_api/table/update_test.go
@@ -95,6 +95,7 @@ func TestUpdate(t *testing.T) {
 		Set(expression.Name("awsConfig"), expression.Value(org.AwsConfig)).
 		Set(expression.Name("displayName"), expression.Value(org.DisplayName)).
 		Set(expression.Name("email"), expression.Value(org.Email)).
+		Set(expression.Name("errorReportingConsent"), expression.Value(org.ErrorReportingConsent)).
 		Set(expression.Name("phone"), expression.Value(org.Phone))
 	expectedCondition := expression.AttributeExists(expression.Name("id"))
 	expectedExpression, _ := expression.NewBuilder().WithCondition(expectedCondition).WithUpdate(expectedUpdate).Build()

--- a/tools/mage/deploy_frontend.go
+++ b/tools/mage/deploy_frontend.go
@@ -108,7 +108,7 @@ func buildAndPushImageFromSource(awsSession *session.Session, imageRegistry stri
 	}
 
 	logger.Info("deploy: pushing docker image to remote repo")
-	if err := sh.RunV("docker", "push", remoteImage); err != nil {
+	if err := sh.Run("docker", "push", remoteImage); err != nil {
 		return "", fmt.Errorf("docker push failed: %v", err)
 	}
 


### PR DESCRIPTION
## Background
Provides backend support for users to opt into error reporting.

Closes #152 

## Changes

- Support `errorReportingConsent` in the org database
    - I wanted to put "consent" in the name so it was explicitly clear that the field is populated by user consent
    - This is just for frontend errors logs, right? We could in theory also send backend error logs, but that would take more work. Should the same consent flag apply to both? I don't see why not
- Hide `docker push` output by default (per @3nvi suggestion), which is more consistent with the rest of the deploy process

## Testing

- Unit tests
- Deploy + integration test
