### PR TITLE
S3accesslogs do not require httpstatus

### DIFF
--- a/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access.go
@@ -46,7 +46,7 @@ type S3ServerAccess struct {
 	Operation          *string            `json:"operation,omitempty" description:"The operation listed here is declared as SOAP.operation, REST.HTTP_method.resource_type, WEBSITE.HTTP_method.resource_type, or BATCH.DELETE.OBJECT."`
 	Key                *string            `json:"key,omitempty" description:"The key part of the request, URL encoded, or NULL if the operation does not take a key parameter."`
 	RequestURI         *string            `json:"requesturi,omitempty" description:"The Request-URI part of the HTTP request message."`
-	HTTPStatus         *int               `json:"httpstatus,omitempty" validate:"required,max=600,min=100" description:"The numeric HTTP status code of the response."`
+	HTTPStatus         *int               `json:"httpstatus,omitempty" description:"The numeric HTTP status code of the response."`
 	ErrorCode          *string            `json:"errorcode,omitempty" description:"The Amazon S3 Error Code, or NULL if no error occurred."`
 	BytesSent          *int               `json:"bytessent,omitempty" description:"The number of response bytes sent, excluding HTTP protocol overhead, or NULL if zero."`
 	ObjectSize         *int               `json:"objectsize,omitempty" description:"The total size of the object in question."`

--- a/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access_test.go
@@ -171,6 +171,31 @@ func TestS3AccessLogPutHttpOKExtraFields(t *testing.T) {
 	checkS3AccessLog(t, log, expectedEvent)
 }
 
+func TestS3AccessLogExpireNoHttpStatusObject(t *testing.T) {
+	//nolint:lll
+	log := `e45ff2803a4a73e13cca79d315b9aed3cf228184ab5c07725da3feaca1db2c98 panther-s3-logs-012345678901-us-east-1 [06/Feb/2019:00:00:38 +0000] - AmazonS3 128E87669E4C15FA S3.EXPIRE.OBJECT panther-s3-logs-012345678901-us-east-1/2020-01-11-22-33-30-23B392B734E22958 "-" - - - 3922 - - "-" "-" DkKg9NTmHopKgqKMcgjFyf4oujClO4J1 JFLmDHDLlTpiqmG5NECMOIsZfzN2Mki0OqHGVbsP20tAVq3176HcY0/F8Y9ONTth - - - - -`
+
+	date := time.Unix(1549411238, 0).UTC()
+	expectedEvent := &S3ServerAccess{
+		BucketOwner: aws.String("e45ff2803a4a73e13cca79d315b9aed3cf228184ab5c07725da3feaca1db2c98"),
+		Bucket:      aws.String("panther-s3-logs-012345678901-us-east-1"),
+		Key:         aws.String("panther-s3-logs-012345678901-us-east-1/2020-01-11-22-33-30-23B392B734E22958"),
+		ObjectSize:  aws.Int(3922),
+		Time:        (*timestamp.RFC3339)(&date),
+		Requester:   aws.String("AmazonS3"),
+		RequestID:   aws.String("128E87669E4C15FA"),
+		Operation:   aws.String("S3.EXPIRE.OBJECT"),
+		HostID:      aws.String("JFLmDHDLlTpiqmG5NECMOIsZfzN2Mki0OqHGVbsP20tAVq3176HcY0/F8Y9ONTth"),
+		VersionID:   aws.String("DkKg9NTmHopKgqKMcgjFyf4oujClO4J1"),
+	}
+
+	// panther fields
+	expectedEvent.PantherLogType = aws.String("AWS.S3ServerAccess")
+	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&date)
+
+	checkS3AccessLog(t, log, expectedEvent)
+}
+
 func TestS3ServerAccessLogType(t *testing.T) {
 	parser := &S3ServerAccessParser{}
 	require.Equal(t, "AWS.S3ServerAccess", parser.LogType())

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -37,9 +37,7 @@ import (
 
 const (
 	// sessionDurationSeconds is the duration in seconds of the STS session the S3 client uses
-	sessionDurationSeconds = 3600
-	// sessionExternalID is external ID that will be used when getting credentials from STS
-	sessionExternalID       = "panther"
+	sessionDurationSeconds  = 3600
 	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole"
 )
 
@@ -138,6 +136,5 @@ func getAwsCredentials(awsAccountID string) *credentials.Credentials {
 
 	return stscreds.NewCredentials(common.Session, roleArn, func(p *stscreds.AssumeRoleProvider) {
 		p.Duration = time.Duration(sessionDurationSeconds) * time.Second
-		p.ExternalID = aws.String(sessionExternalID)
 	})
 }


### PR DESCRIPTION
## Background
Monitoring detected a failed log parse for s3 access logs. Looking into it a 'S3.EXPIRE.OBJECT' event was not able to be parsed because we require an http status code be set. This seems to be a backend triggered transaction that is logged that has no http associated attributes.

## Changes
Removed required validations for HttpStatus field.

## Testing
mage test:ci
deployed to dev account
