### PR TITLE
ECS Cluster Scanning Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9 // indirect
-	golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 // indirect
+	golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/russross/blackfriday.v2 v2.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9 // indirect
-	golang.org/x/tools v0.0.0-20200204230316-67a4523381ef // indirect
+	golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/russross/blackfriday.v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200204230316-67a4523381ef h1:mdhEDFpO1Tfj7PXIflIuP1tbXt4rJgHIvbzdh62SARw=
 golang.org/x/tools v0.0.0-20200204230316-67a4523381ef/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 h1:a/Fd23DJvg1CaeDH0dYHahE+hCI0v9rFgxSNIThoUcM=
+golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ golang.org/x/tools v0.0.0-20200204230316-67a4523381ef h1:mdhEDFpO1Tfj7PXIflIuP1t
 golang.org/x/tools v0.0.0-20200204230316-67a4523381ef/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 h1:a/Fd23DJvg1CaeDH0dYHahE+hCI0v9rFgxSNIThoUcM=
 golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7 h1:SWKaJjEEnIUqoSX43gli3maUBM+1QSfJVGHfmeeQlFg=
+golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/compliance/aws_event_processor/processor/classify.go
+++ b/internal/compliance/aws_event_processor/processor/classify.go
@@ -49,6 +49,7 @@ var classifiers = map[string]func(gjson.Result, string) []*resourceChange{
 	"config.amazonaws.com":               classifyConfig,
 	"dynamodb.amazonaws.com":             classifyDynamoDB,
 	"ec2.amazonaws.com":                  classifyEC2,
+	"ecs.amazonaws.com":                  classifyECS,
 	"elasticloadbalancing.amazonaws.com": classifyELBV2,
 	"guardduty.amazonaws.com":            classifyGuardDuty,
 	"iam.amazonaws.com":                  classifyIAM,

--- a/internal/compliance/aws_event_processor/processor/ec2.go
+++ b/internal/compliance/aws_event_processor/processor/ec2.go
@@ -316,7 +316,7 @@ func classifyEC2(detail gjson.Result, accountID string) []*resourceChange {
 		// security group scan.
 		return []*resourceChange{{
 			AwsAccountID: ec2ARN.AccountID,
-			Delete:       deleteResource,
+			Delete:       false,
 			EventName:    eventName,
 			Region:       region,
 			ResourceType: ec2Type,
@@ -332,7 +332,7 @@ func classifyEC2(detail gjson.Result, accountID string) []*resourceChange {
 		// VPC Sub resources
 		return []*resourceChange{{
 			AwsAccountID: ec2ARN.AccountID,
-			Delete:       deleteResource,
+			Delete:       false,
 			EventName:    eventName,
 			Region:       region,
 			ResourceType: aws.Ec2VpcSchema,
@@ -341,7 +341,7 @@ func classifyEC2(detail gjson.Result, accountID string) []*resourceChange {
 		// Volume sub resources
 		return []*resourceChange{{
 			AwsAccountID: ec2ARN.AccountID,
-			Delete:       deleteResource,
+			Delete:       false,
 			EventName:    eventName,
 			Region:       region,
 			ResourceType: aws.Ec2VolumeSchema,
@@ -350,7 +350,7 @@ func classifyEC2(detail gjson.Result, accountID string) []*resourceChange {
 		// Instance sub resources
 		return []*resourceChange{{
 			AwsAccountID: ec2ARN.AccountID,
-			Delete:       deleteResource,
+			Delete:       false,
 			EventName:    eventName,
 			Region:       region,
 			ResourceType: aws.Ec2InstanceSchema,
@@ -366,7 +366,7 @@ func classifyEC2(detail gjson.Result, accountID string) []*resourceChange {
 			// currently so we do a region wide EC2 VPC scan.
 			return []*resourceChange{{
 				AwsAccountID: ec2ARN.AccountID,
-				Delete:       deleteResource,
+				Delete:       false,
 				EventName:    eventName,
 				Region:       region,
 				ResourceType: aws.Ec2VpcSchema,
@@ -379,7 +379,7 @@ func classifyEC2(detail gjson.Result, accountID string) []*resourceChange {
 		// EC2 VPC scan.
 		return []*resourceChange{{
 			AwsAccountID: ec2ARN.AccountID,
-			Delete:       deleteResource,
+			Delete:       false,
 			EventName:    eventName,
 			ResourceType: aws.Ec2VpcSchema,
 		}}

--- a/internal/compliance/aws_event_processor/processor/ecs.go
+++ b/internal/compliance/aws_event_processor/processor/ecs.go
@@ -19,10 +19,10 @@ package processor
  */
 
 import (
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 

--- a/internal/compliance/aws_event_processor/processor/ecs.go
+++ b/internal/compliance/aws_event_processor/processor/ecs.go
@@ -19,6 +19,7 @@ package processor
  */
 
 import (
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -62,6 +63,7 @@ func classifyECS(detail gjson.Result, accountID string) []*resourceChange {
 				"ecs: unable to parse resource ARN",
 				zap.String("eventName", eventName),
 				zap.String("resource ARN", clusterARN),
+				zap.Error(errors.WithStack(err)),
 			)
 			return nil
 		}

--- a/internal/compliance/aws_event_processor/processor/ecs.go
+++ b/internal/compliance/aws_event_processor/processor/ecs.go
@@ -1,0 +1,102 @@
+package processor
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+
+	schemas "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
+)
+
+func classifyECS(detail gjson.Result, accountID string) []*resourceChange {
+	eventName := detail.Get("eventName").Str
+
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awscertificatemanager.html
+	if eventName == "READONLY" {
+		zap.L().Debug("ecs: ignoring event", zap.String("eventName", eventName))
+		return nil
+	}
+
+	var clusterARN string
+	switch eventName {
+	case "CreateTaskSet", "DeleteCluster", "DeleteTaskSet", "UpdateServicePrimaryTaskSet", "UpdateTaskSet":
+		clusterARN = detail.Get("requestParameters.cluster").Str
+	case "CreateService", "DeleteAttributes", "DeleteService", "DeregisterContainerInstance", "PutAttributes",
+		"RegisterContainerInstance", "RunTask", "StartTask", "StopTask", "SubmitAttachmentStateChanges", "SubmitContainerStateChange",
+		"SubmitTaskStateChange", "UpdateContainerInstancesState", "UpdateService":
+		// These API calls understand an absent cluster value to mean the default cluster.
+		//
+		// Sadly we can't differentiate between a failed extraction (rare), and a request to modify the
+		// default cluster. We will just default to scanning the default cluster.
+		clusterARN = detail.Get("requestParameters.cluster").Str
+		if clusterARN == "" {
+			clusterARN = "default"
+		}
+	case "CreateCluster":
+		clusterARN = detail.Get("responseElements.cluster.clusterArn").Str
+	case "TagResource", "UntagResource":
+		// This is the same child resource issue we've encountered many times (see EC2 for an example)
+		// Since we don't know who the parent resource is that changed, we have to scan all resources
+
+		// In the case of clusters at least we can continue
+		clusterARN = detail.Get("requestParameters.resourceArn").Str
+		parsed, err := arn.Parse(clusterARN)
+		if err != nil {
+			zap.L().Error(
+				"ecs: unable to parse resource ARN",
+				zap.String("eventName", eventName),
+				zap.String("resource ARN", clusterARN),
+			)
+			return nil
+		}
+		if strings.HasPrefix("cluster", parsed.Resource) {
+			break
+		}
+
+		// It wasn't a cluster, so we have to scan the whole region.
+		return []*resourceChange{{
+			AwsAccountID: accountID,
+			Delete:       false,
+			EventName:    eventName,
+			Region:       detail.Get("awsRegion").Str,
+			ResourceType: schemas.EcsClusterSchema,
+		}}
+	case "DeleteAccountSetting", "DeregisterTaskDefinition", "PutAccountSetting", "PutAccountSettingDefault",
+		"RegisterTaskDefinition", "UpdateContainerAgent":
+		// Nothing to do here
+		//
+		// If we add an ECS account wide resource or an ECS TaskDefinition resource we can use these
+		return nil
+	default:
+		zap.L().Warn("ecs: encountered unknown event name", zap.String("eventName", eventName))
+		return nil
+	}
+
+	return []*resourceChange{{
+		AwsAccountID: accountID,
+		Delete:       eventName == "DeleteCluster",
+		EventName:    eventName,
+		ResourceID:   clusterARN,
+		ResourceType: schemas.EcsClusterSchema,
+	}}
+}

--- a/internal/compliance/snapshot_poller/models/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/models/aws/ecs_cluster.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/go-openapi/strfmt"
+)
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const (
+	EcsClusterSchema = "AWS.ECS.Cluster"
+)
+
+// EcsCluster contains all the information about an ACM certificate
+type EcsCluster struct {
+	// Generic resource fields
+	GenericAWSResource
+	GenericResource
+
+	// Fields embedded from ecs.Cluster
+	ActiveServicesCount               *int64
+	Attachments                       []*ecs.Attachment
+	AttachmentsStatus                 *string
+	CapacityProviders                 []*string
+	DefaultCapacityProviderStrategy   []*ecs.CapacityProviderStrategyItem
+	PendingTasksCount                 *int64
+	RegisteredContainerInstancesCount *int64
+	RunningTasksCount                 *int64
+	Settings                          []*ecs.ClusterSetting
+	Statistics                        []*ecs.KeyValuePair
+	Status                            *string
+
+	// Additional fields
+	Services []*EcsService
+	Tasks    []*EcsTask
+}
+
+type EcsService struct {
+	// Generic resource fields
+	//
+	// This is not a full resource, but it does have an ARN, Tags, and a name.
+	GenericAWSResource
+
+	// Fields embedded from ecs.Service
+	CapacityProviderStrategy []*ecs.CapacityProviderStrategyItem
+	// Normalized name for CreatedAt
+	TimeCreated                   *strfmt.DateTime
+	CreatedBy                     *string
+	DeploymentConfiguration       *ecs.DeploymentConfiguration
+	DeploymentController          *ecs.DeploymentController
+	Deployments                   []*ecs.Deployment
+	DesiredCount                  *int64
+	EnableECSManagedTags          *bool
+	Events                        []*ecs.ServiceEvent
+	HealthCheckGracePeriodSeconds *int64
+	LaunchType                    *string
+	LoadBalancers                 []*ecs.LoadBalancer
+	NetworkConfiguration          *ecs.NetworkConfiguration
+	PendingCount                  *int64
+	PlacementConstraints          []*ecs.PlacementConstraint
+	PlacementStrategy             []*ecs.PlacementStrategy
+	PlatformVersion               *string
+	PropagateTags                 *string
+	RoleArn                       *string
+	RunningCount                  *int64
+	SchedulingStrategy            *string
+	ServiceRegistries             []*ecs.ServiceRegistry
+	Status                        *string
+	TaskDefinition                *string
+	TaskSets                      []*ecs.TaskSet
+}
+
+type EcsTask struct {
+	// Generic resource fields
+	//
+	// This is not a full resource, but it does have an ARN and Tags.
+	GenericAWSResource
+
+	// Fields embedded from ecs.Task
+	Attachments          []*ecs.Attachment
+	Attributes           []*ecs.Attribute
+	AvailabilityZone     *string
+	CapacityProviderName *string
+	Connectivity         *string
+	ConnectivityAt       *strfmt.DateTime
+	ContainerInstanceArn *string
+	Containers           []*ecs.Container
+	Cpu                  *string
+	// Normalized name for CreatedAt
+	TimeCreated           *strfmt.DateTime
+	DesiredStatus         *string
+	ExecutionStoppedAt    *strfmt.DateTime
+	Group                 *string
+	HealthStatus          *string
+	InferenceAccelerators []*ecs.InferenceAccelerator
+	LastStatus            *string
+	LaunchType            *string
+	Memory                *string
+	Overrides             *ecs.TaskOverride
+	PlatformVersion       *string
+	PullStartedAt         *strfmt.DateTime
+	PullStoppedAt         *strfmt.DateTime
+	StartedAt             *strfmt.DateTime
+	StartedBy             *string
+	StopCode              *string
+	StoppedAt             *strfmt.DateTime
+	StoppedReason         *string
+	StoppingAt            *strfmt.DateTime
+	TaskDefinitionArn     *string
+	Version               *int64
+}

--- a/internal/compliance/snapshot_poller/models/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/models/aws/ecs_cluster.go
@@ -27,7 +27,7 @@ const (
 	EcsClusterSchema = "AWS.ECS.Cluster"
 )
 
-// EcsCluster contains all the information about an ACM certificate
+// EcsCluster contains all the information about an ECS Cluster
 type EcsCluster struct {
 	// Generic resource fields
 	GenericAWSResource
@@ -51,6 +51,7 @@ type EcsCluster struct {
 	Tasks    []*EcsTask
 }
 
+// EcsService contains all the information about an ECS Service, for embedding into the EcsCluster resource
 type EcsService struct {
 	// Generic resource fields
 	//
@@ -86,6 +87,7 @@ type EcsService struct {
 	TaskSets                      []*ecs.TaskSet
 }
 
+// EcsTask contains all the information about an ECS Task, for embedding into the EcsCluster resource
 type EcsTask struct {
 	// Generic resource fields
 	//

--- a/internal/compliance/snapshot_poller/pollers/aws/acm_certificate.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/acm_certificate.go
@@ -85,7 +85,7 @@ func describeCertificate(acmSvc acmiface.ACMAPI, arn *string) (*acm.CertificateD
 	return out.Certificate, nil
 }
 
-// listTagsForCertificate provides detailed information for a given ACM certificate
+// listTagsForCertificate returns the tags for an ACM certificate
 func listTagsForCertificate(acmSvc acmiface.ACMAPI, arn *string) ([]*acm.Tag, error) {
 	out, err := acmSvc.ListTagsForCertificate(&acm.ListTagsForCertificateInput{CertificateArn: arn})
 	if err != nil {

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/ecs.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/ecs.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// Example ACM API return values
+// Example ECS API return values
 var (
 	ExampleClusterArn = aws.String("arn:aws:ecs:us-west-2:123456789012:cluster/example-cluster")
 	ExampleTaskArn    = aws.String("arn:aws:ecs:us-west-2:123456789012:task/1111-2222")

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/ecs.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/ecs.go
@@ -1,0 +1,332 @@
+package awstest
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"github.com/stretchr/testify/mock"
+)
+
+// Example ACM API return values
+var (
+	ExampleClusterArn = aws.String("arn:aws:ecs:us-west-2:123456789012:cluster/example-cluster")
+	ExampleTaskArn    = aws.String("arn:aws:ecs:us-west-2:123456789012:task/1111-2222")
+	ExampleServiceArn = aws.String("arn:aws:ecs:us-west-2:123456789012:service/example-service")
+
+	ExampleListClusters = &ecs.ListClustersOutput{
+		ClusterArns: []*string{
+			ExampleClusterArn,
+		},
+	}
+
+	ExampleListTasks = &ecs.ListTasksOutput{
+		TaskArns: []*string{
+			ExampleTaskArn,
+		},
+	}
+
+	ExampleListServices = &ecs.ListServicesOutput{
+		ServiceArns: []*string{
+			ExampleServiceArn,
+		},
+	}
+
+	ExampleEcsDescribeClustersOutput = &ecs.DescribeClustersOutput{
+		Clusters: []*ecs.Cluster{
+			{
+				ClusterArn:                        ExampleClusterArn,
+				ClusterName:                       aws.String("example-cluster"),
+				Status:                            aws.String("ACTIVE"),
+				RegisteredContainerInstancesCount: aws.Int64(0),
+				RunningTasksCount:                 aws.Int64(1),
+				PendingTasksCount:                 aws.Int64(0),
+				ActiveServicesCount:               aws.Int64(1),
+				Statistics:                        []*ecs.KeyValuePair{},
+				Tags: []*ecs.Tag{
+					{
+						Key:   aws.String("Key1"),
+						Value: aws.String("Value1"),
+					},
+				},
+				Settings: []*ecs.ClusterSetting{
+					{
+						Name:  aws.String("containerInsights"),
+						Value: aws.String("disabled"),
+					},
+				},
+				CapacityProviders:               []*string{},
+				DefaultCapacityProviderStrategy: []*ecs.CapacityProviderStrategyItem{},
+			},
+		},
+	}
+
+	ExampleEcsDescribeTasksOutput = &ecs.DescribeTasksOutput{
+		Failures: nil,
+		Tasks: []*ecs.Task{
+			{
+				Attachments: []*ecs.Attachment{
+					{
+						Id:     aws.String("1111-222"),
+						Type:   aws.String("ElasticNetworkInterface"),
+						Status: aws.String("ATTACHED"),
+						Details: []*ecs.KeyValuePair{
+							{
+								Name:  aws.String("subnetId"),
+								Value: aws.String("subnet-111"),
+							},
+						},
+					},
+				},
+				AvailabilityZone: aws.String("us-west-2b"),
+				ClusterArn:       aws.String("arn:aws:ecs:us-west-2:123456789012:cluster/example-cluster"),
+				Connectivity:     aws.String("CONNECTED"),
+				Containers: []*ecs.Container{
+					{
+						ContainerArn: aws.String("arn:aws:ecs:us-west-2:123456789012:container/1111"),
+						TaskArn:      aws.String("arn:aws:ecs:us-west-2:123456789012:task/2222"),
+						Name:         aws.String("example"),
+					},
+				},
+				Cpu:             aws.String("512"),
+				DesiredStatus:   aws.String("RUNNING"),
+				Group:           aws.String("service:example"),
+				PlatformVersion: aws.String("1.3.0"),
+				StartedBy:       aws.String("ecs-svc/1111"),
+				Tags:            []*ecs.Tag{},
+				Version:         aws.Int64(3),
+			},
+		},
+	}
+
+	ExampleEcsDescribeServicesOutput = &ecs.DescribeServicesOutput{
+		Services: []*ecs.Service{
+			{
+				ServiceArn:  aws.String("arn:aws:ecs:us-west-2:123456789012:service/example"),
+				ServiceName: aws.String("example"),
+				ClusterArn:  aws.String("arn:aws:ecs:us-west-2:123456789012:cluster/example-cluster"),
+				LoadBalancers: []*ecs.LoadBalancer{
+					{
+						TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/example/1111"),
+						ContainerName:  aws.String("example"),
+						ContainerPort:  aws.Int64(80),
+					},
+				},
+				RunningCount: aws.Int64(1),
+				PendingCount: aws.Int64(0),
+				DeploymentConfiguration: &ecs.DeploymentConfiguration{
+					MaximumPercent:        aws.Int64(200),
+					MinimumHealthyPercent: aws.Int64(50),
+				},
+				RoleArn: aws.String("arn:aws:iam::123456789012:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"),
+				Events: []*ecs.ServiceEvent{
+					{
+						Id:        aws.String("2222"),
+						CreatedAt: aws.Time(time.Unix(1581379785, 0)),
+						Message:   aws.String("(service example) has reached a steady state."),
+					},
+					{
+						Id:        aws.String("1111"),
+						CreatedAt: aws.Time(time.Unix(1581379764, 0)),
+						Message:   aws.String("(service example) has stopped 1 running tasks: (task 1111)."),
+					},
+				},
+				CreatedAt: aws.Time(time.Unix(1579896067, 0)),
+			},
+		},
+	}
+
+	svcEcsSetupCalls = map[string]func(*MockEcs){
+		"ListClustersPages": func(svc *MockEcs) {
+			svc.On("ListClustersPages", mock.Anything).
+				Return(nil)
+		},
+		"ListTasksPages": func(svc *MockEcs) {
+			svc.On("ListTasksPages", mock.Anything).
+				Return(nil)
+		},
+		"ListServicesPages": func(svc *MockEcs) {
+			svc.On("ListServicesPages", mock.Anything).
+				Return(nil)
+		},
+		"DescribeClusters": func(svc *MockEcs) {
+			svc.On("DescribeClusters", mock.Anything).
+				Return(ExampleEcsDescribeClustersOutput, nil)
+		},
+		"DescribeTasks": func(svc *MockEcs) {
+			svc.On("DescribeTasks", mock.Anything).
+				Return(ExampleEcsDescribeTasksOutput, nil)
+		},
+		"DescribeServices": func(svc *MockEcs) {
+			svc.On("DescribeServices", mock.Anything).
+				Return(ExampleEcsDescribeServicesOutput, nil)
+		},
+	}
+
+	svcEcsSetupCallsError = map[string]func(*MockEcs){
+		"ListClustersPages": func(svc *MockEcs) {
+			svc.On("ListClustersPages", mock.Anything).
+				Return(errors.New("ECS.ListListClustersPages error"))
+		},
+		"ListTasksPages": func(svc *MockEcs) {
+			svc.On("ListTaskPages", mock.Anything).
+				Return(errors.New("ECS.ListTaskPages error"))
+		},
+		"ListServicesPages": func(svc *MockEcs) {
+			svc.On("ListServicesPages", mock.Anything).
+				Return(errors.New("ECS.ListServicesPages error"))
+		},
+		"DescribeClusters": func(svc *MockEcs) {
+			svc.On("DescribeClusters", mock.Anything).
+				Return(&ecs.DescribeClustersOutput{},
+					errors.New("ECS.DescribeClusters error"),
+				)
+		},
+		"DescribeTasks": func(svc *MockEcs) {
+			svc.On("DescribeTasks", mock.Anything).
+				Return(&ecs.DescribeTasksOutput{},
+					errors.New("ECS.DescribeTasks error"),
+				)
+		},
+		"DescribeServices": func(svc *MockEcs) {
+			svc.On("DescribeServices", mock.Anything).
+				Return(&ecs.DescribeServicesOutput{},
+					errors.New("ECS.DescribeServices error"),
+				)
+		},
+	}
+
+	MockEcsForSetup = &MockEcs{}
+)
+
+// ECS mock
+
+// SetupMockEcs is used to override the ECS Client initializer
+func SetupMockEcs(_ *session.Session, _ *aws.Config) interface{} {
+	return MockEcsForSetup
+}
+
+// MockEcs is a mock ECS client
+type MockEcs struct {
+	ecsiface.ECSAPI
+	mock.Mock
+}
+
+// BuildMockEcsSvc builds and returns a MockEcs struct
+//
+// Additionally, the appropriate calls to On and Return are made based on the strings passed in
+func BuildMockEcsSvc(funcs []string) (mockSvc *MockEcs) {
+	mockSvc = &MockEcs{}
+	for _, f := range funcs {
+		svcEcsSetupCalls[f](mockSvc)
+	}
+	return
+}
+
+// BuildMockEcsSvcError builds and returns a MockEcs struct with errors set
+//
+// Additionally, the appropriate calls to On and Return are made based on the strings passed in
+func BuildMockEcsSvcError(funcs []string) (mockSvc *MockEcs) {
+	mockSvc = &MockEcs{}
+	for _, f := range funcs {
+		svcEcsSetupCallsError[f](mockSvc)
+	}
+	return
+}
+
+// BuildEcsServiceSvcAll builds and returns a MockEcs struct
+//
+// Additionally, the appropriate calls to On and Return are made for all possible function calls
+func BuildMockEcsSvcAll() (mockSvc *MockEcs) {
+	mockSvc = &MockEcs{}
+	for _, f := range svcEcsSetupCalls {
+		f(mockSvc)
+	}
+	return
+}
+
+// BuildMockEcsSvcAllError builds and returns a MockEcs struct with errors set
+//
+// Additionally, the appropriate calls to On and Return are made for all possible function calls
+func BuildMockEcsSvcAllError() (mockSvc *MockEcs) {
+	mockSvc = &MockEcs{}
+	for _, f := range svcEcsSetupCallsError {
+		f(mockSvc)
+	}
+	return
+}
+
+func (m *MockEcs) ListClustersPages(
+	in *ecs.ListClustersInput,
+	paginationFunction func(*ecs.ListClustersOutput, bool) bool,
+) error {
+
+	args := m.Called(in)
+	if args.Error(0) != nil {
+		return args.Error(0)
+	}
+	paginationFunction(ExampleListClusters, true)
+	return args.Error(0)
+}
+
+func (m *MockEcs) ListServicesPages(
+	in *ecs.ListServicesInput,
+	paginationFunction func(*ecs.ListServicesOutput, bool) bool,
+) error {
+
+	args := m.Called(in)
+	if args.Error(0) != nil {
+		return args.Error(0)
+	}
+	paginationFunction(ExampleListServices, true)
+	return args.Error(0)
+}
+
+func (m *MockEcs) ListTasksPages(
+	in *ecs.ListTasksInput,
+	paginationFunction func(*ecs.ListTasksOutput, bool) bool,
+) error {
+
+	args := m.Called(in)
+	if args.Error(0) != nil {
+		return args.Error(0)
+	}
+	paginationFunction(ExampleListTasks, true)
+	return args.Error(0)
+}
+
+func (m *MockEcs) DescribeClusters(in *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error) {
+	args := m.Called(in)
+	return args.Get(0).(*ecs.DescribeClustersOutput), args.Error(1)
+}
+
+func (m *MockEcs) DescribeServices(in *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
+	args := m.Called(in)
+	return args.Get(0).(*ecs.DescribeServicesOutput), args.Error(1)
+}
+
+func (m *MockEcs) DescribeTasks(in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+	args := m.Called(in)
+	return args.Get(0).(*ecs.DescribeTasksOutput), args.Error(1)
+}

--- a/internal/compliance/snapshot_poller/pollers/aws/clients.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/clients.go
@@ -53,6 +53,7 @@ var clientFuncs = map[string]func(session2 *session.Session, config *aws.Config)
 	"configservice":          ConfigServiceClientFunc,
 	"dynamodb":               DynamoDBClientFunc,
 	"ec2":                    EC2ClientFunc,
+	"ecs":                    EcsClientFunc,
 	"elbv2":                  Elbv2ClientFunc,
 	"guardduty":              GuardDutyClientFunc,
 	"iam":                    IAMClientFunc,

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_volume.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_volume.go
@@ -156,7 +156,7 @@ func buildEc2VolumeSnapshot(ec2Svc ec2iface.EC2API, volume *ec2.Volume) *awsmode
 
 	snapshots := describeSnapshots(ec2Svc, volume.VolumeId)
 	if snapshots != nil {
-		ec2Volume.Snapshots = make([]*awsmodels.Ec2Snapshot, len(snapshots))
+		ec2Volume.Snapshots = make([]*awsmodels.Ec2Snapshot, 0, len(snapshots))
 		for _, snapshot := range snapshots {
 			volumeSnapshot := &awsmodels.Ec2Snapshot{Snapshot: snapshot}
 			volumeAttribute, err := describeSnapshotAttribute(ec2Svc, snapshot.SnapshotId)

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -33,9 +33,7 @@ import (
 )
 
 // Set as variables to be overridden in testing
-var (
-	EcsClientFunc = setupEcsClient
-)
+var EcsClientFunc = setupEcsClient
 
 func setupEcsClient(sess *session.Session, cfg *aws.Config) interface{} {
 	cfg.MaxRetries = aws.Int(MaxRetries)
@@ -106,6 +104,11 @@ func getClusterTasks(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodels.E
 	if err != nil {
 		utils.LogAWSError("ECS.ListTasksPages", err)
 		return nil, err
+	}
+
+	// If there are no tasks stop here
+	if len(taskArns) == 0 {
+		return nil, nil
 	}
 
 	// Describe tasks
@@ -182,6 +185,11 @@ func getClusterServices(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodel
 		return nil, err
 	}
 
+	// If there are no services stop here
+	if len(serviceArns) == 0 {
+		return nil, nil
+	}
+
 	// Describe services
 	//
 	// Oddly, the DescribeServices API call does not have a version with builtin paging like the list
@@ -193,6 +201,7 @@ func getClusterServices(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodel
 		Include:  []*string{aws.String("TAGS")},
 		Services: serviceArns,
 	})
+
 	if err != nil {
 		utils.LogAWSError("ECS.DescribeServices", err)
 		return nil, err

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -76,7 +76,10 @@ func listClusters(ecsSvc ecsiface.ECSAPI) (clusters []*string) {
 
 // describeCluster provides detailed information for a given ECS cluster
 func describeCluster(ecsSvc ecsiface.ECSAPI, arn *string) (*ecs.Cluster, error) {
-	out, err := ecsSvc.DescribeClusters(&ecs.DescribeClustersInput{Clusters: []*string{arn}})
+	out, err := ecsSvc.DescribeClusters(&ecs.DescribeClustersInput{
+		Clusters: []*string{arn},
+		Include:  []*string{aws.String("TAGS")},
+	})
 	if err != nil {
 		utils.LogAWSError("ECS.DescribeClusters", err)
 		return nil, err
@@ -121,7 +124,7 @@ func getClusterTasks(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodels.E
 		return nil, err
 	}
 
-	tasks := make([]*awsmodels.EcsTask, len(rawTasks.Tasks))
+	tasks := make([]*awsmodels.EcsTask, 0, len(rawTasks.Tasks))
 	for _, task := range rawTasks.Tasks {
 		tasks = append(tasks, &awsmodels.EcsTask{
 			GenericAWSResource: awsmodels.GenericAWSResource{
@@ -195,7 +198,7 @@ func getClusterServices(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodel
 		return nil, err
 	}
 
-	services := make([]*awsmodels.EcsService, len(rawServices.Services))
+	services := make([]*awsmodels.EcsService, 0, len(rawServices.Services))
 	for _, service := range rawServices.Services {
 		services = append(services, &awsmodels.EcsService{
 			GenericAWSResource: awsmodels.GenericAWSResource{

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	apimodels "github.com/panther-labs/panther/api/gateway/resources/models"
@@ -306,7 +307,7 @@ func PollEcsClusters(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.A
 				"unable to create aws session",
 				zap.String("region", *regionID),
 				zap.String("service", "ecs"),
-				zap.Error(err),
+				zap.Error(errors.WithStack(err)),
 			)
 			continue
 		}
@@ -318,7 +319,7 @@ func PollEcsClusters(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.A
 				"unable to create aws client",
 				zap.String("region", *regionID),
 				zap.String("service", "ecs"),
-				zap.Error(err),
+				zap.Error(errors.WithStack(err)),
 			)
 			continue
 		}

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -1,0 +1,336 @@
+package aws
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"go.uber.org/zap"
+
+	apimodels "github.com/panther-labs/panther/api/gateway/resources/models"
+	awsmodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
+	pollermodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/poller"
+	"github.com/panther-labs/panther/internal/compliance/snapshot_poller/pollers/utils"
+)
+
+// Set as variables to be overridden in testing
+var (
+	EcsClientFunc = setupEcsClient
+)
+
+func setupEcsClient(sess *session.Session, cfg *aws.Config) interface{} {
+	cfg.MaxRetries = aws.Int(MaxRetries)
+	return ecs.New(sess, cfg)
+}
+
+// PollECSCluster polls a single ECS cluster resource
+func PollECSCluster(
+	pollerInput *awsmodels.ResourcePollerInput,
+	resourceARN arn.ARN,
+	scanRequest *pollermodels.ScanEntry,
+) interface{} {
+
+	client := getClient(pollerInput, "ecs", resourceARN.Region).(ecsiface.ECSAPI)
+
+	snapshot := buildEcsClusterSnapshot(client, scanRequest.ResourceID)
+	if snapshot == nil {
+		return nil
+	}
+	snapshot.Region = aws.String(resourceARN.Region)
+	snapshot.AccountID = aws.String(resourceARN.AccountID)
+
+	return snapshot
+}
+
+// listClusters returns all ECS clusters in the account
+func listClusters(ecsSvc ecsiface.ECSAPI) (clusters []*string) {
+	err := ecsSvc.ListClustersPages(&ecs.ListClustersInput{},
+		func(page *ecs.ListClustersOutput, lastPage bool) bool {
+			clusters = append(clusters, page.ClusterArns...)
+			return true
+		})
+	if err != nil {
+		utils.LogAWSError("ECS.ListClustersPages", err)
+	}
+	return
+}
+
+// describeCluster provides detailed information for a given ECS cluster
+func describeCluster(ecsSvc ecsiface.ECSAPI, arn *string) (*ecs.Cluster, error) {
+	out, err := ecsSvc.DescribeClusters(&ecs.DescribeClustersInput{Clusters: []*string{arn}})
+	if err != nil {
+		utils.LogAWSError("ECS.DescribeClusters", err)
+		return nil, err
+	}
+
+	if len(out.Clusters) != 1 {
+		zap.L().Error("ecs.DescribeClusters did not return exactly one result", zap.Int("number of results", len(out.Clusters)))
+		return nil, nil
+	}
+
+	return out.Clusters[0], nil
+}
+
+// getClusterTasks enumerates and then describes all active tasks of a cluster
+func getClusterTasks(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodels.EcsTask, error) {
+	// Enumerate tasks
+	var taskArns []*string
+	err := ecsSvc.ListTasksPages(&ecs.ListTasksInput{Cluster: clusterArn},
+		func(page *ecs.ListTasksOutput, lastPage bool) bool {
+			taskArns = append(taskArns, page.TaskArns...)
+			return true
+		})
+
+	if err != nil {
+		utils.LogAWSError("ECS.ListTasksPages", err)
+		return nil, err
+	}
+
+	// Describe tasks
+	//
+	// Oddly, the DescribeTasks API call does not have a version with builtin paging like the list
+	// API call does. If we run into issues here we may need to implement paging ourselves.
+	rawTasks, err := ecsSvc.DescribeTasks(&ecs.DescribeTasksInput{
+		Cluster: clusterArn,
+		// This only accepts one argument, which is the string TAGS
+		// Indicates that we want to included the task tags
+		Include: []*string{aws.String("TAGS")},
+		Tasks:   taskArns,
+	})
+	if err != nil {
+		utils.LogAWSError("ECS.DescribeTasks", err)
+		return nil, err
+	}
+
+	tasks := make([]*awsmodels.EcsTask, len(rawTasks.Tasks))
+	for _, task := range rawTasks.Tasks {
+		tasks = append(tasks, &awsmodels.EcsTask{
+			GenericAWSResource: awsmodels.GenericAWSResource{
+				ARN:  task.TaskArn,
+				Tags: utils.ParseTagSlice(task.Tags),
+			},
+			Attachments:           task.Attachments,
+			Attributes:            task.Attributes,
+			AvailabilityZone:      task.AvailabilityZone,
+			CapacityProviderName:  task.CapacityProviderName,
+			Connectivity:          task.Connectivity,
+			ConnectivityAt:        utils.DateTimeFormat(aws.TimeValue(task.ConnectivityAt)),
+			ContainerInstanceArn:  task.ContainerInstanceArn,
+			Containers:            task.Containers,
+			Cpu:                   task.Cpu,
+			TimeCreated:           utils.DateTimeFormat(aws.TimeValue(task.CreatedAt)),
+			DesiredStatus:         task.DesiredStatus,
+			ExecutionStoppedAt:    utils.DateTimeFormat(aws.TimeValue(task.ExecutionStoppedAt)),
+			Group:                 task.Group,
+			HealthStatus:          task.HealthStatus,
+			InferenceAccelerators: task.InferenceAccelerators,
+			LastStatus:            task.LastStatus,
+			LaunchType:            task.LaunchType,
+			Memory:                task.Memory,
+			Overrides:             task.Overrides,
+			PlatformVersion:       task.PlatformVersion,
+			PullStartedAt:         utils.DateTimeFormat(aws.TimeValue(task.PullStartedAt)),
+			PullStoppedAt:         utils.DateTimeFormat(aws.TimeValue(task.PullStoppedAt)),
+			StartedAt:             utils.DateTimeFormat(aws.TimeValue(task.StartedAt)),
+			StartedBy:             task.StartedBy,
+			StopCode:              task.StopCode,
+			StoppedAt:             utils.DateTimeFormat(aws.TimeValue(task.StoppedAt)),
+			StoppedReason:         task.StoppedReason,
+			StoppingAt:            utils.DateTimeFormat(aws.TimeValue(task.StoppingAt)),
+			TaskDefinitionArn:     task.TaskDefinitionArn,
+			Version:               task.Version,
+		})
+	}
+
+	return tasks, nil
+}
+
+// getClusterServices enumerates and then describes all active services of a cluster
+func getClusterServices(ecsSvc ecsiface.ECSAPI, clusterArn *string) ([]*awsmodels.EcsService, error) {
+	// Enumerate services
+	var serviceArns []*string
+	err := ecsSvc.ListServicesPages(&ecs.ListServicesInput{Cluster: clusterArn},
+		func(page *ecs.ListServicesOutput, lastPage bool) bool {
+			serviceArns = append(serviceArns, page.ServiceArns...)
+			return true
+		})
+
+	if err != nil {
+		utils.LogAWSError("ECS.ListServicesPages", err)
+		return nil, err
+	}
+
+	// Describe services
+	//
+	// Oddly, the DescribeServices API call does not have a version with builtin paging like the list
+	// API call does. If we run into issues here we may need to implement paging ourselves.
+	rawServices, err := ecsSvc.DescribeServices(&ecs.DescribeServicesInput{
+		Cluster: clusterArn,
+		// This only accepts one argument, which is the string TAGS
+		// Indicates that we want to included the task tags
+		Include:  []*string{aws.String("TAGS")},
+		Services: serviceArns,
+	})
+	if err != nil {
+		utils.LogAWSError("ECS.DescribeServices", err)
+		return nil, err
+	}
+
+	services := make([]*awsmodels.EcsService, len(rawServices.Services))
+	for _, service := range rawServices.Services {
+		services = append(services, &awsmodels.EcsService{
+			GenericAWSResource: awsmodels.GenericAWSResource{
+				ARN:  service.ServiceArn,
+				Name: service.ServiceName,
+				Tags: utils.ParseTagSlice(service.Tags),
+			},
+			CapacityProviderStrategy:      service.CapacityProviderStrategy,
+			TimeCreated:                   utils.DateTimeFormat(aws.TimeValue(service.CreatedAt)),
+			CreatedBy:                     service.CreatedBy,
+			DeploymentConfiguration:       service.DeploymentConfiguration,
+			DeploymentController:          service.DeploymentController,
+			Deployments:                   service.Deployments,
+			DesiredCount:                  service.DesiredCount,
+			EnableECSManagedTags:          service.EnableECSManagedTags,
+			Events:                        service.Events,
+			HealthCheckGracePeriodSeconds: service.HealthCheckGracePeriodSeconds,
+			LaunchType:                    service.LaunchType,
+			LoadBalancers:                 service.LoadBalancers,
+			NetworkConfiguration:          service.NetworkConfiguration,
+			PendingCount:                  service.PendingCount,
+			PlacementConstraints:          service.PlacementConstraints,
+			PlacementStrategy:             service.PlacementStrategy,
+			PlatformVersion:               service.PlatformVersion,
+			PropagateTags:                 service.PropagateTags,
+			RoleArn:                       service.RoleArn,
+			RunningCount:                  service.RunningCount,
+			SchedulingStrategy:            service.SchedulingStrategy,
+			ServiceRegistries:             service.ServiceRegistries,
+			Status:                        service.Status,
+			TaskDefinition:                service.TaskDefinition,
+			TaskSets:                      service.TaskSets,
+		})
+	}
+
+	return services, nil
+}
+
+// buildEcsClusterSnapshot returns a complete snapshot of an ECS cluster
+func buildEcsClusterSnapshot(ecsSvc ecsiface.ECSAPI, clusterArn *string) *awsmodels.EcsCluster {
+	if clusterArn == nil {
+		return nil
+	}
+
+	details, err := describeCluster(ecsSvc, clusterArn)
+	if err != nil {
+		return nil
+	}
+
+	ecsCluster := &awsmodels.EcsCluster{
+		GenericAWSResource: awsmodels.GenericAWSResource{
+			ARN:  details.ClusterArn,
+			Name: details.ClusterName,
+			Tags: utils.ParseTagSlice(details.Tags),
+		},
+		GenericResource: awsmodels.GenericResource{
+			ResourceID:   clusterArn,
+			ResourceType: aws.String(awsmodels.EcsClusterSchema),
+		},
+		ActiveServicesCount:               details.ActiveServicesCount,
+		Attachments:                       details.Attachments,
+		AttachmentsStatus:                 details.AttachmentsStatus,
+		CapacityProviders:                 details.CapacityProviders,
+		DefaultCapacityProviderStrategy:   details.DefaultCapacityProviderStrategy,
+		PendingTasksCount:                 details.PendingTasksCount,
+		RegisteredContainerInstancesCount: details.RegisteredContainerInstancesCount,
+		RunningTasksCount:                 details.RunningTasksCount,
+		Settings:                          details.Settings,
+		Statistics:                        details.Statistics,
+		Status:                            details.Status,
+	}
+
+	ecsCluster.Tasks, err = getClusterTasks(ecsSvc, details.ClusterArn)
+	if err != nil {
+		return nil
+	}
+
+	ecsCluster.Services, err = getClusterServices(ecsSvc, details.ClusterArn)
+	if err != nil {
+		return nil
+	}
+
+	return ecsCluster
+}
+
+// PollEcsCluster gathers information on each ECS Cluster for an AWS account.
+func PollEcsClusters(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.AddResourceEntry, error) {
+	zap.L().Debug("starting ECS Cluster resource poller")
+	ecsClusterSnapshots := make(map[string]*awsmodels.EcsCluster)
+
+	for _, regionID := range utils.GetServiceRegions(pollerInput.Regions, "ecs") {
+		sess := session.Must(session.NewSession(&aws.Config{Region: regionID}))
+
+		creds, err := AssumeRoleFunc(pollerInput, sess)
+		if err != nil {
+			return nil, err
+		}
+
+		ecsSvc := EcsClientFunc(sess, &aws.Config{Credentials: creds}).(ecsiface.ECSAPI)
+
+		// Start with generating a list of all clusters
+		clusters := listClusters(ecsSvc)
+		if len(clusters) == 0 {
+			zap.L().Debug("no ECS clusters found", zap.String("region", *regionID))
+			continue
+		}
+
+		for _, clusterArn := range clusters {
+			ecsClusterSnapshot := buildEcsClusterSnapshot(ecsSvc, clusterArn)
+			if ecsClusterSnapshot == nil {
+				continue
+			}
+			ecsClusterSnapshot.AccountID = aws.String(pollerInput.AuthSourceParsedARN.AccountID)
+			ecsClusterSnapshot.Region = regionID
+
+			if _, ok := ecsClusterSnapshots[*ecsClusterSnapshot.ARN]; ok {
+				zap.L().Info(
+					"overwriting existing ECS Certificate snapshot",
+					zap.String("resourceId", *ecsClusterSnapshot.ARN),
+				)
+			}
+			ecsClusterSnapshots[*ecsClusterSnapshot.ARN] = ecsClusterSnapshot
+		}
+	}
+
+	resources := make([]*apimodels.AddResourceEntry, 0, len(ecsClusterSnapshots))
+	for resourceID, ecsSnapshot := range ecsClusterSnapshots {
+		resources = append(resources, &apimodels.AddResourceEntry{
+			Attributes:      ecsSnapshot,
+			ID:              apimodels.ResourceID(resourceID),
+			IntegrationID:   apimodels.IntegrationID(*pollerInput.IntegrationID),
+			IntegrationType: apimodels.IntegrationTypeAws,
+			Type:            awsmodels.EcsClusterSchema,
+		})
+	}
+
+	return resources, nil
+}

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster_test.go
@@ -1,0 +1,121 @@
+package aws
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	awsmodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
+	"github.com/panther-labs/panther/internal/compliance/snapshot_poller/pollers/aws/awstest"
+)
+
+func TestEcsClusterList(t *testing.T) {
+	mockSvc := awstest.BuildMockEcsSvc([]string{"ListClustersPages"})
+
+	out := listClusters(mockSvc)
+	assert.NotEmpty(t, out)
+}
+
+func TestEcsClusterListError(t *testing.T) {
+	mockSvc := awstest.BuildMockEcsSvcError([]string{"ListClustersPages"})
+
+	out := listClusters(mockSvc)
+	assert.Nil(t, out)
+}
+
+func TestEcsClusterDescribe(t *testing.T) {
+	mockSvc := awstest.BuildMockEcsSvc([]string{"DescribeClusters"})
+
+	out, err := describeCluster(mockSvc, awstest.ExampleClusterArn)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out)
+}
+
+func TestEcsClusterDescribeError(t *testing.T) {
+	mockSvc := awstest.BuildMockEcsSvcError([]string{"DescribeClusters"})
+
+	out, err := describeCluster(mockSvc, awstest.ExampleClusterArn)
+	require.Error(t, err)
+	assert.Nil(t, out)
+}
+
+func TestEcsClusterBuildSnapshot(t *testing.T) {
+	mockSvc := awstest.BuildMockEcsSvcAll()
+
+	clusterSnapshot := buildEcsClusterSnapshot(
+		mockSvc,
+		awstest.ExampleListClusters.ClusterArns[0],
+	)
+
+	assert.NotEmpty(t, clusterSnapshot.ARN)
+	assert.Equal(t, "Value1", *clusterSnapshot.Tags["Key1"])
+}
+
+func TestEcsClusterBuildSnapshotErrors(t *testing.T) {
+	mockSvc := awstest.BuildMockEcsSvcAllError()
+
+	certSnapshot := buildEcsClusterSnapshot(
+		mockSvc,
+		awstest.ExampleListClusters.ClusterArns[0],
+	)
+
+	assert.Nil(t, certSnapshot)
+}
+
+func TestEcsClusterPoller(t *testing.T) {
+	awstest.MockEcsForSetup = awstest.BuildMockEcsSvcAll()
+
+	AssumeRoleFunc = awstest.AssumeRoleMock
+	EcsClientFunc = awstest.SetupMockEcs
+
+	resources, err := PollEcsClusters(&awsmodels.ResourcePollerInput{
+		AuthSource:          &awstest.ExampleAuthSource,
+		AuthSourceParsedARN: awstest.ExampleAuthSourceParsedARN,
+		IntegrationID:       awstest.ExampleIntegrationID,
+		Regions:             awstest.ExampleRegions,
+		Timestamp:           &awstest.ExampleTime,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, *awstest.ExampleClusterArn, string(resources[0].ID))
+	assert.NotEmpty(t, resources)
+}
+
+func TestEcsClusterPollerError(t *testing.T) {
+	awstest.MockEcsForSetup = awstest.BuildMockEcsSvcAllError()
+
+	AssumeRoleFunc = awstest.AssumeRoleMock
+	EcsClientFunc = awstest.SetupMockEcs
+
+	resources, err := PollEcsClusters(&awsmodels.ResourcePollerInput{
+		AuthSource:          &awstest.ExampleAuthSource,
+		AuthSourceParsedARN: awstest.ExampleAuthSourceParsedARN,
+		IntegrationID:       awstest.ExampleIntegrationID,
+		Regions:             awstest.ExampleRegions,
+		Timestamp:           &awstest.ExampleTime,
+	})
+
+	require.NoError(t, err)
+	for _, event := range resources {
+		assert.Nil(t, event.Attributes)
+	}
+}

--- a/internal/compliance/snapshot_poller/pollers/aws/poll.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll.go
@@ -295,7 +295,7 @@ func Poll(scanRequest *pollermodels.ScanEntry) (
 	if scanRequest.ScanAllResources != nil && *scanRequest.ScanAllResources {
 		zap.L().Warn("DEPRECATED: processing full account scan, this operation should not occur during normal operations." +
 			"Either input was malformed or someone has manually initiated this scan.")
-		allPollers := make([]resourcePoller, len(ServicePollers))
+		allPollers := make([]resourcePoller, 0, len(ServicePollers))
 		for _, poller := range ServicePollers {
 			allPollers = append(allPollers, poller)
 		}

--- a/internal/compliance/snapshot_poller/pollers/aws/poll.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll.go
@@ -88,6 +88,7 @@ var (
 		awsmodels.Ec2SecurityGroupSchema:    PollEC2SecurityGroup,
 		awsmodels.Ec2VolumeSchema:           PollEC2Volume,
 		awsmodels.Ec2VpcSchema:              PollEC2VPC,
+		awsmodels.EcsClusterSchema:          PollECSCluster,
 		awsmodels.Elbv2LoadBalancerSchema:   PollELBV2LoadBalancer,
 		awsmodels.IAMGroupSchema:            PollIAMGroup,
 		awsmodels.IAMPolicySchema:           PollIAMPolicy,
@@ -122,6 +123,7 @@ var (
 		awsmodels.Ec2SecurityGroupSchema:    {"EC2SecurityGroup", PollEc2SecurityGroups},
 		awsmodels.Ec2VolumeSchema:           {"EC2Volume", PollEc2Volumes},
 		awsmodels.Ec2VpcSchema:              {"EC2VPC", PollEc2Vpcs},
+		awsmodels.EcsClusterSchema:          {"ECSCluster", PollEcsClusters},
 		awsmodels.Elbv2LoadBalancerSchema:   {"ELBV2LoadBalancer", PollElbv2ApplicationLoadBalancers},
 		awsmodels.KmsKeySchema:              {"KMSKey", PollKmsKeys},
 		awsmodels.S3BucketSchema:            {"S3Bucket", PollS3Buckets},
@@ -141,44 +143,6 @@ var (
 		awsmodels.PasswordPolicySchema:  {"PasswordPolicy", PollPasswordPolicy},
 		awsmodels.RDSInstanceSchema:     {"RDSInstance", PollRDSInstances},
 		awsmodels.RedshiftClusterSchema: {"RedshiftCluster", PollRedshiftClusters},
-	}
-
-	// ServicePollersOrdered is an ordered list of the resource pollers
-	// to allow for optimizations in account-wide scans.
-	ServicePollersOrdered = []resourcePoller{
-		//
-		// These pollers have optimization options by running after other pollers
-		//
-		// EC2AMI has a optimization possibility after EC2Instance
-		{"EC2Instance", PollEc2Instances},
-		{"EC2AMI", PollEc2Amis},
-		//
-		// The pollers below have no dependencies
-		//
-		{"EC2NetworkACL", PollEc2NetworkAcls},
-		{"EC2SecurityGroup", PollEc2SecurityGroups},
-		{"EC2VPC", PollEc2Vpcs},
-		{"EC2Volume", PollEc2Volumes},
-		{"ACMCertificate", PollAcmCertificates},
-		{"ConfigService", PollConfigServices},
-		{"CloudFormationStack", PollCloudFormationStacks},
-		{"CloudTrail", PollCloudTrails},
-		{"CloudWatchLogsLogGroups", PollCloudWatchLogsLogGroups},
-		{"DynamoDBTable", PollDynamoDBTables},
-		{"ELBV2LoadBalancer", PollElbv2ApplicationLoadBalancers},
-		{"WAFRegionalWebAcl", PollWafRegionalWebAcls},
-		{"WAFWebAcl", PollWafWebAcls},
-		{"GuardDutyDetector", PollGuardDutyDetectors},
-		{"IAMGroups", PollIamGroups},
-		{"IAMPolicies", PollIamPolicies},
-		{"IAMRoles", PollIAMRoles},
-		{"IAMUser", PollIAMUsers},
-		{"KMSKey", PollKmsKeys},
-		{"LambdaFunctions", PollLambdaFunctions},
-		{"PasswordPolicy", PollPasswordPolicy},
-		{"RDSInstance", PollRDSInstances},
-		{"RedshiftCluster", PollRedshiftClusters},
-		{"S3Bucket", PollS3Buckets},
 	}
 )
 
@@ -329,8 +293,13 @@ func Poll(scanRequest *pollermodels.ScanEntry) (
 
 	// Full account scan
 	if scanRequest.ScanAllResources != nil && *scanRequest.ScanAllResources {
-		zap.L().Info("processing full account scan")
-		return serviceScan(ServicePollersOrdered, pollerResourceInput)
+		zap.L().Warn("DEPRECATED: processing full account scan, this operation should not occur during normal operations." +
+			"Either input was malformed or someone has manually initiated this scan.")
+		allPollers := make([]resourcePoller, len(ServicePollers))
+		for _, poller := range ServicePollers {
+			allPollers = append(allPollers, poller)
+		}
+		return serviceScan(allPollers, pollerResourceInput)
 
 		// Account wide resource type scan
 	} else if scanRequest.ResourceType != nil {
@@ -383,6 +352,7 @@ func singleResourceScan(
 
 	var resource interface{}
 
+	// TODO: does this accept short names?
 	if pollFunction, ok := IndividualResourcePollers[*scanRequest.ResourceType]; ok {
 		// Handle cases where the ResourceID is not an ARN
 		parsedResourceID := utils.ParseResourceID(*scanRequest.ResourceID)

--- a/internal/compliance/snapshot_poller/pollers/lambda_test.go
+++ b/internal/compliance/snapshot_poller/pollers/lambda_test.go
@@ -147,6 +147,9 @@ func TestHandler(t *testing.T) {
 	// Setup EC2 client and function mocks
 	awstest.MockEC2ForSetup = awstest.BuildMockEC2SvcAll()
 
+	// Setup ECS client and function mocks
+	awstest.MockEcsForSetup = awstest.BuildMockEcsSvcAll()
+
 	// Setup KMS client and function mocks
 	awstest.MockKmsForSetup = awstest.BuildMockKmsSvcAll()
 
@@ -198,6 +201,7 @@ func TestHandler(t *testing.T) {
 	awspollers.ConfigServiceClientFunc = awstest.SetupMockConfigService
 	awspollers.DynamoDBClientFunc = awstest.SetupMockDynamoDB
 	awspollers.EC2ClientFunc = awstest.SetupMockEC2
+	awspollers.EcsClientFunc = awstest.SetupMockEcs
 	awspollers.Elbv2ClientFunc = awstest.SetupMockElbv2
 	awspollers.GuardDutyClientFunc = awstest.SetupMockGuardDuty
 	awspollers.IAMClientFunc = awstest.SetupMockIAM

--- a/internal/compliance/snapshot_poller/pollers/utils/logging.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/logging.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -30,6 +31,7 @@ func LogAWSError(apiCall string, err error) {
 			apiCall,
 			zap.String("errorCode", awsErr.Code()),
 			zap.String("errorMessage", awsErr.Message()),
+			zap.Error(errors.Wrap(err, "AWS API call failed")),
 		)
 	}
 }

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -49,6 +49,7 @@ export const RESOURCE_TYPES = [
   'AWS.EC2.SecurityGroup',
   'AWS.EC2.Volume',
   'AWS.EC2.VPC',
+  'AWS.ECS.Cluster',
   'AWS.ELBV2.ApplicationLoadBalancer',
   'AWS.GuardDuty.Detector',
   'AWS.IAM.Group',


### PR DESCRIPTION
## Background

This change adds support for ECS Cluster scanning to the Cloud Security suite. Closes #166.

## Changes

- Updated the snapshot poller to be able to scan ECS Clusters
- Updated the aws event processor to be able to process ECS API calls
- Updated the frontend constants list to include `AWS.ECS.Cluster`
- A few minor tweaks of various inconsistencies on some unrelated aws event processor and snapshot poller code
- Removed the `ServicePollersOrdered` slice, it was just place we were duplicating work for a feature that has been deprecated (feature is still supported, it's just less efficient now but again its deprecated)

## Testing

- Manually tested in my dev account the following activities:
  - Tested with both long and short names (full ARNs and just the name)
  - Account wide ECS scans
  - Updating tags on an ECS Cluster
  - Updating the service associated to an ECS Cluster
  - Creating a new service for an ECS Cluster
  - Deleting a service for an ECS Cluster
  - Creating a cluster
- Unit testing of the snapshot poller