### PR TITLE
Update mage glue:sync to not require input of time range

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -37,9 +37,7 @@ import (
 
 const (
 	// sessionDurationSeconds is the duration in seconds of the STS session the S3 client uses
-	sessionDurationSeconds = 3600
-	// sessionExternalID is external ID that will be used when getting credentials from STS
-	sessionExternalID       = "panther"
+	sessionDurationSeconds  = 3600
 	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole"
 )
 
@@ -138,6 +136,5 @@ func getAwsCredentials(awsAccountID string) *credentials.Credentials {
 
 	return stscreds.NewCredentials(common.Session, roleArn, func(p *stscreds.AssumeRoleProvider) {
 		p.Duration = time.Duration(sessionDurationSeconds) * time.Second
-		p.ExternalID = aws.String(sessionExternalID)
 	})
 }


### PR DESCRIPTION
# Before
Users needed to pick a time range to update partitions. Users may not know the appropriate time range.

# After
The start time is taken from the CreateTime of the table and end time is the current time. This will ensure all partitions are bought current and the user need not specify.

## Testing
ran locally
mage test:ci

