### PR TITLE
Rulesengineoutput

### DIFF
--- a/deployments/log_analysis/rules_engine.yml
+++ b/deployments/log_analysis/rules_engine.yml
@@ -84,6 +84,10 @@ Resources:
       Region: !Ref AWS::Region
       TopicArn: !Ref SnsTopicArn
       RawMessageDelivery: true
+      # Receive notifications only for new log events
+      FilterPolicy:
+        type:
+          - LogData
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy
@@ -139,6 +143,8 @@ Resources:
           ANALYSIS_API_PATH: v1
           DEBUG: !Ref Debug
           ALERTS_QUEUE: !Ref AlertsQueue
+          S3_BUCKET: !Ref ProcessedDataBucket
+          SNS_TOPIC_ARN: !Ref SnsTopicArn
       MemorySize: !Ref MemorySizeMB
       Events:
         Queue:
@@ -176,11 +182,13 @@ Resources:
                 - sqs:SendMessage
                 - sqs:SendMessageBatch
               Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${AlertsQueue}
-        - Id: ReadFromS3
+        - Id: S3ReadWrite
           Version: 2012-10-17
           Statement:
             - Effect: Allow
-              Action: s3:GetObject
+              Action:
+                - s3:GetObject
+                - s3:PutObject
               Resource: !Sub arn:${AWS::Partition}:s3:::${ProcessedDataBucket}/*
         - Id: AccessKms
           Version: 2012-10-17

--- a/deployments/log_analysis/rules_engine.yml
+++ b/deployments/log_analysis/rules_engine.yml
@@ -124,6 +124,24 @@ Resources:
       MessageRetentionPeriod: 1209600 # Max duration - 14 days
       VisibilityTimeout: !Ref TimeoutSec
 
+
+  ##### Dynamo recent alerts table #####
+  AlertsDedup:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: panther-alert-dedup
+      AttributeDefinitions:
+        - AttributeName: partitionKey
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: partitionKey
+          KeyType: HASH
+      PointInTimeRecoverySpecification: # Create periodic table backups
+        PointInTimeRecoveryEnabled: True
+      SSESpecification: # Enable server-side encryption
+        SSEEnabled: True
+
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -145,6 +163,7 @@ Resources:
           ALERTS_QUEUE: !Ref AlertsQueue
           S3_BUCKET: !Ref ProcessedDataBucket
           SNS_TOPIC_ARN: !Ref SnsTopicArn
+          ALERTS_DEDUP_TABLE: !Ref AlertsDedup
       MemorySize: !Ref MemorySizeMB
       Events:
         Queue:
@@ -160,7 +179,7 @@ Resources:
             - '${base},${pip}'
             - { base: !Join [',', !Ref LayerVersionArns], pip: !Ref PythonLayerArn }
         - [!Ref PythonLayerArn]
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: !Ref TimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
@@ -190,6 +209,14 @@ Resources:
                 - s3:GetObject
                 - s3:PutObject
               Resource: !Sub arn:${AWS::Partition}:s3:::${ProcessedDataBucket}/*
+        - Id: DDBUpdate
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
+              Resource: !GetAtt AlertsDedup.Arn
         - Id: AccessKms
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/rules_engine.yml
+++ b/deployments/log_analysis/rules_engine.yml
@@ -162,7 +162,7 @@ Resources:
           DEBUG: !Ref Debug
           ALERTS_QUEUE: !Ref AlertsQueue
           S3_BUCKET: !Ref ProcessedDataBucket
-          SNS_TOPIC_ARN: !Ref SnsTopicArn
+          NOTIFICATIONS_TOPIC: !Ref SnsTopicArn
           ALERTS_DEDUP_TABLE: !Ref AlertsDedup
       MemorySize: !Ref MemorySizeMB
       Events:
@@ -179,7 +179,7 @@ Resources:
             - '${base},${pip}'
             - { base: !Join [',', !Ref LayerVersionArns], pip: !Ref PythonLayerArn }
         - [!Ref PythonLayerArn]
-      Runtime: python3.8
+      Runtime: python3.7
       Timeout: !Ref TimeoutSec
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
@@ -201,6 +201,13 @@ Resources:
                 - sqs:SendMessage
                 - sqs:SendMessageBatch
               Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${AlertsQueue}
+        - Id: SendToNotificationsTopic
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - sns:Publish
+              Resource: !Ref SnsTopicArn
         - Id: S3ReadWrite
           Version: 2012-10-17
           Statement:

--- a/internal/log_analysis/log_processor/common/common.go
+++ b/internal/log_analysis/log_processor/common/common.go
@@ -62,18 +62,18 @@ type S3DataStreamHints struct {
 // S3Notification is sent when new data is available in S3
 type S3Notification struct {
 	// S3Bucket is name of the S3 Bucket where data is available
-	S3Bucket *string `json:"s3Bucket"`
+	S3Bucket *string `json:"s3Bucket,omitempty"`
 	// S3ObjectKey is the key of the S3 object that contains the new data
-	S3ObjectKey *string `json:"s3ObjectKey"`
+	S3ObjectKey *string `json:"s3ObjectKey,omitempty"`
 	// Events is the number of events in the S3 object
-	Events *int `json:"events"`
+	Events *int `json:"events,omitempty"`
 	// Bytes is the uncompressed size in bytes of the S3 object
-	Bytes *int `json:"bytes"`
+	Bytes *int `json:"bytes,omitempty"`
 	// Type is the type of data available in the S3 object (LogData,RuleOutput)
-	Type *string `json:"type"`
+	Type *string `json:"type,omitempty"`
 	// ID is an identified for the data in the S3 object. In case of LogData this will be
 	// the Log Type, in case of RuleOutput data this will be the RuleID
-	ID *string `json:"id"`
+	ID *string `json:"id,omitempty"`
 }
 
 const (

--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -40,8 +40,15 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/registry"
 )
 
-// s3ObjectKeyFormat represents the format of the S3 object key
-const s3ObjectKeyFormat = "%s%s-%s.gz"
+const (
+	// s3ObjectKeyFormat represents the format of the S3 object key
+	s3ObjectKeyFormat = "%s%s-%s.gz"
+
+	logDataTypeAttributeName = "type"
+	logTypeAttributeName     = "id"
+
+	messageAttributeDataType = "String"
+)
 
 var (
 	maxFileSize = 100 * 1000 * 1000 // 100MB uncompressed file size, should result in ~10MB output file size
@@ -236,6 +243,16 @@ func (destination *S3Destination) sendSNSNotification(key, logType string, buffe
 	input := &sns.PublishInput{
 		TopicArn: aws.String(destination.snsTopicArn),
 		Message:  aws.String(marshalledNotification),
+		MessageAttributes: map[string]*sns.MessageAttributeValue{
+			logDataTypeAttributeName: {
+				StringValue: aws.String(common.LogData),
+				DataType: aws.String(messageAttributeDataType),
+			},
+			logTypeAttributeName:     {
+				StringValue: aws.String(logType),
+				DataType: aws.String(messageAttributeDataType),
+			},
+		},
 	}
 	if _, err = destination.snsClient.Publish(input); err != nil {
 		err = errors.Wrap(err, "failed to send notification to topic")

--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -246,11 +246,11 @@ func (destination *S3Destination) sendSNSNotification(key, logType string, buffe
 		MessageAttributes: map[string]*sns.MessageAttributeValue{
 			logDataTypeAttributeName: {
 				StringValue: aws.String(common.LogData),
-				DataType: aws.String(messageAttributeDataType),
+				DataType:    aws.String(messageAttributeDataType),
 			},
-			logTypeAttributeName:     {
+			logTypeAttributeName: {
 				StringValue: aws.String(logType),
-				DataType: aws.String(messageAttributeDataType),
+				DataType:    aws.String(messageAttributeDataType),
 			},
 		},
 	}

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -258,11 +258,11 @@ func TestSendDataToS3BeforeTerminating(t *testing.T) {
 		MessageAttributes: map[string]*sns.MessageAttributeValue{
 			"type": {
 				StringValue: aws.String(common.LogData),
-				DataType: aws.String("String"),
+				DataType:    aws.String("String"),
 			},
-			"id":   {
+			"id": {
 				StringValue: aws.String("testtype"),
-				DataType: aws.String("String"),
+				DataType:    aws.String("String"),
 			},
 		},
 	}

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -255,6 +255,16 @@ func TestSendDataToS3BeforeTerminating(t *testing.T) {
 	expectedSnsPublishInput := &sns.PublishInput{
 		Message:  aws.String(marshalledExpectedS3Notification),
 		TopicArn: aws.String("arn:aws:sns:us-west-2:123456789012:test"),
+		MessageAttributes: map[string]*sns.MessageAttributeValue{
+			"type": {
+				StringValue: aws.String(common.LogData),
+				DataType: aws.String("String"),
+			},
+			"id":   {
+				StringValue: aws.String("testtype"),
+				DataType: aws.String("String"),
+			},
+		},
 	}
 	require.Equal(t, expectedSnsPublishInput, publishInput)
 }

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -13,4 +13,25 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict
+
+
+@dataclass
+class AnalysisMatch:
+    rule_id: str
+    rule_version: str
+    log_type: str
+    dedup: str
+    event: Dict[str, Any]
+
+
+@dataclass
+class AlertInfo:
+    alert_id: str
+    alert_creation_time: datetime
+    alert_update_time: datetime
+
+
 

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -19,11 +19,10 @@ from typing import Any, Dict
 
 
 @dataclass
-class AnalysisMatch:
-    """The result of an event analysis"""
+class EventMatch:
+    """Represents an event that matched a rule"""
     rule_id: str
     rule_version: str
-    analysis_time: datetime
     log_type: str
     dedup: str
     event: Dict[str, Any]

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -20,6 +20,7 @@ from typing import Any, Dict
 
 @dataclass
 class AnalysisMatch:
+    """The result of an event analysis"""
     rule_id: str
     rule_version: str
     analysis_time: datetime
@@ -30,9 +31,19 @@ class AnalysisMatch:
 
 @dataclass
 class AlertInfo:
+    """Information about an alert"""
     alert_id: str
     alert_creation_time: datetime
     alert_update_time: datetime
 
 
+@dataclass
+class OutputNotification:
+    """Output notification"""
+    s3Bucket: str
+    s3ObjectKey: str
+    events: int
+    bytes: int
+    id: str
+    type: str = 'RuleOutput'
 

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -22,6 +22,7 @@ from typing import Any, Dict
 class AnalysisMatch:
     rule_id: str
     rule_version: str
+    analysis_time: datetime
     log_type: str
     dedup: str
     event: Dict[str, Any]

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -95,21 +95,21 @@ def _update_alerts_conditionally(match: AnalysisMatch) -> AlertInfo:
                 'S': _generate_key(match)
             }
         },
-        UpdateExpression='SET #1=:1, #2=:2, , #3=:3\nADD #4 :4',
+        UpdateExpression='SET #1=:1, #2=:2, #3=:3\nADD #4 :4',
         ConditionExpression='(#5 < :5) OR (attribute_not_exists(#6))',
         ExpressionAttributeNames={
             '#1': _ALERT_CREATION_TIME_ATTR_NAME,
             '#2': _ALERT_UPDATE_TIME_ATTR_NAME,
-            '#3': _ALERT_COUNT_ATTR_NAME,
-            '#4': _RULE_VERSION_ID_ATTR_NAME,
+            '#3': _RULE_VERSION_ID_ATTR_NAME,
+            '#4': _ALERT_COUNT_ATTR_NAME,
             '#5': _ALERT_CREATION_TIME_ATTR_NAME,
             '#6': _PARTITION_KEY_NAME,
         },
         ExpressionAttributeValues={
             ':1': {'N': match.analysis_time.strftime('%s')},
             ':2': {'N': match.analysis_time.strftime('%s')},
-            ':3': {'N': '1'},
-            ':4': {'S': match.rule_version},
+            ':3': {'S': match.rule_version},
+            ':4': {'N': '1'},
             ':5': {'N': '{}'.format(int(match.analysis_time.timestamp()) - _ALERT_MERGE_PERIOD_SECONDS)}
         },
         ReturnValues='ALL_NEW'

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -31,6 +31,7 @@ _ALERT_UPDATE_TIME_ATTR_NAME = 'alertUpdateTime'
 _ALERT_COUNT_ATTR_NAME = 'alertCount'
 _ALERT_EVENT_COUNT = 'eventCount'
 
+# TODO Once rules store alert merge period, retrieve it from there
 _ALERT_MERGE_PERIOD_SECONDS = 3600
 
 

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -19,9 +19,8 @@ from typing import Dict
 
 import boto3
 
-from .logging import get_logger
 from . import AlertInfo, AnalysisMatch
-from datetime import datetime
+from .logging import get_logger
 
 _ddb_table = os.environ['ALERTS_DEDUP_TABLE']
 _ddb_client = boto3.client('dynamodb')

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -1,0 +1,69 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+from typing import Dict
+
+import boto3
+
+from .logging import get_logger
+from . import AlertInfo, AnalysisMatch
+from datetime import datetime
+
+_ddb_table = os.environ['ALERTS_DEDUP_TABLE']
+_ddb_client = boto3.client('dynamodb')
+
+_PARTITION_KEY_NAME = 'partitionKey'
+_ALERT_CREATION_TIME_ATTR_NAME = 'alertCreationTime'
+_ALERT_UPDATE_TIME_ATTR_NAME = 'alertUpdateTime'
+_ALERT_COUNT_ATTR_NAME = 'alertCount'
+_RULE_VERSION_ID_ATTR_NAME = 'ruleVersionId'
+
+_ALERT_MERGE_PERIOD_SECONDS = 3600
+
+
+def _generate_key(match: AnalysisMatch) -> str:
+    return match.rule_id + '-' + match.dedup
+
+
+class Merger:
+
+    def __init__(self):
+        self.rule_to_alert_id: Dict[str, AlertInfo] = {}
+        self.logger = get_logger()
+
+    def merge_alert(self, match: AnalysisMatch, processing_time: datetime) -> AlertInfo:
+        dict_key = _generate_key(match)
+        alert_info = self.rule_to_alert_id.get(dict_key)
+        if alert_info:
+            return alert_info
+
+        return AlertInfo(
+            alert_id="1",
+            alert_update_time=processing_time,
+            alert_creation_time=processing_time
+
+        )
+        # _ddb_client.update_item(
+        #     TableName=_ddb_table,
+        #     Key={
+        #         _PARTITION_KEY_NAME: {
+        #             'S': match.rule_id + '-' + match.dedup
+        #         }
+        #     },
+        #
+        # )
+        # return None

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -25,7 +25,6 @@ from .logging import get_logger
 from .rule import Rule, COMMON_MODULE_RULE_ID
 
 _RULES_CACHE_DURATION = timedelta(minutes=5)
-_ANALYSIS_CLIENT = AnalysisAPIClient()
 
 
 class Engine:

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -92,10 +92,13 @@ def log_analysis(event: Dict[str, Any]) -> Dict[str, Any]:
         for data_stream in data_streams:
             for data in data_stream:
                 try:  # Bad json data can cause exceptions to be thrown. Best effort: log and continue
-                    for analysis_result in rules_engine.analyze(log_type, json.loads(data)):
-                        output.add_match(analysis_result)
+                    json_data = json.loads(data)
                 except Exception as err:  # pylint: disable=broad-except
                     logger.error("Error during matching: {}".format(err))  # do not log data!
+
+                for analysis_result in rules_engine.analyze(log_type,json_data ):
+                    output.add_match(analysis_result)
+
 
     if len(matched) > 0:
         logger.info("sending {} matches".format(len(matched)))

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -27,7 +27,7 @@ from .engine import Engine
 from .logging import get_logger
 from .rule import Rule
 from .sqs import send_to_sqs
-from .output import EventsBuffer
+from .output import MatchedEventsBuffer
 
 s3_client = boto3.client('s3')
 logger = get_logger()
@@ -87,7 +87,7 @@ def log_analysis(event: Dict[str, Any]) -> Dict[str, Any]:
 
     # List containing tuple of (rule_id, event) for matched events
     matched: List = []
-    output_buffer = EventsBuffer()
+    output_buffer = MatchedEventsBuffer()
     for log_type, data_streams in log_type_to_data.items():
         for data_stream in data_streams:
             for data in data_stream:

--- a/internal/log_analysis/rules_engine/src/notifications.py
+++ b/internal/log_analysis/rules_engine/src/notifications.py
@@ -1,8 +1,0 @@
-import os
-from dataclasses import dataclass
-
-import boto3
-
-
-
-

--- a/internal/log_analysis/rules_engine/src/notifications.py
+++ b/internal/log_analysis/rules_engine/src/notifications.py
@@ -1,0 +1,8 @@
+import os
+from dataclasses import dataclass
+
+import boto3
+
+
+
+

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -53,14 +53,14 @@ def _dict_key_to_log_type_rule_id(key: str) -> (str, str):
     return values[0], values[1]
 
 
-class Output:
+class EventsBuffer:
     def __init__(self):
         self.merger = Merger()
         self.rule_id_to_data: Dict[str, OutputInfo] = {}
         self.logger = get_logger()
 
     def add_match(self, match: AnalysisMatch) -> None:
-        """"""
+        """Adds a match to the buffer"""
         dict_key = _generate_dict_key(match.log_type, match.rule_id)
         output_info = self.rule_id_to_data.get(match.rule_id)
         if not output_info:
@@ -73,7 +73,7 @@ class Output:
         output_info.writer.write(serialized_data.encode('utf-8'))
 
     def flush(self):
-        """"""
+        """Flushes the buffer and writes data in S3"""
         for dict_key, output_info in self.rule_id_to_data.items():
             output_uuid = uuid.uuid4()
             output_info.writer.close()

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -1,0 +1,75 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import collections
+from typing import Dict, Any
+
+import boto3
+import json
+from .logging import get_logger
+from io import BytesIO
+import datetime
+import uuid
+import os
+
+import gzip
+
+_key_format = "rules/{}/year={}/month={}/day={}/hour={}/rule_id={}/{}.gz"
+_s3_bucket = os.environ['S3_BUCKET']
+_s3_client = boto3.client('s3')
+
+
+class Output:
+    def __init__(self):
+        self.rule_id_to_data: Dict[str, gzip.GzipFile] = collections.defaultdict()
+        self.logger = get_logger()
+
+    def matched_event(self, log_type: str, rule_id: str, event: Dict[str, Any]):
+        dict_key = self._generate_dict_key(log_type, rule_id)
+        compressed_stream = self.rule_id_to_data.get(rule_id)
+        if not compressed_stream:
+            data_stream = BytesIO()
+            compressed_stream = gzip.GzipFile(fileobj=data_stream, mode='wb')
+            self.rule_id_to_data[dict_key] = compressed_stream
+        data = json.dumps(event).encode('utf-8')
+        compressed_stream.write(data)
+
+    def complete(self):
+        current_time = datetime.datetime.utcnow()
+        for dict_key, compressed_stream in self.rule_id_to_data.items():
+            output_uuid = uuid.uuid4()
+            compressed_stream.flush()
+            log_type, rule_id = self._dict_key_to_log_type_rule_id(dict_key)
+            object_key = _key_format.format(
+                log_type,
+                current_time.year,
+                current_time.month,
+                current_time.day,
+                current_time.hour,
+                rule_id,
+                output_uuid)
+            _s3_client.put_object(
+                Bucket=_s3_bucket,
+                ContentType='gzip',
+                Body=compressed_stream.fileobj,
+                Key=object_key)
+
+    def _generate_dict_key(self, log_type: str, rule_id: str) -> str:
+        return log_type + "-" + rule_id
+
+    def _dict_key_to_log_type_rule_id(self, key: str) -> (str, str):
+        values = key.split("-", 1)
+        return values[0], values[1]

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -1,4 +1,4 @@
-# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ # Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
 # Copyright (C) 2020 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -41,12 +41,13 @@ class Rule:
     """Panther rule metadata and imported module."""
     logger = get_logger()
 
-    def __init__(self, rule_id: str, rule_body: str, rule_version: str):
+    def __init__(self, rule_id: str, rule_body: str, rule_version: str = 'default'):
         """Import rule contents from disk.
 
         Args:
             rule_id: Unique rule identifier
             rule_body: The rule body
+            rule_version: The version of the rule
         """
         self.rule_id = rule_id
         self.rule_version = rule_version

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -110,4 +110,5 @@ class Rule:
             e = Exception('rule returned {}, expected bool'.format(type(matched).__name__))
             return RuleResult(exception=e)
 
+        # Todo calculate the dedup string
         return RuleResult(matched=matched, dedup="default")


### PR DESCRIPTION
## Background

Modifying Rules Engine to output to S3. The Rules Engine does now the following things: 
1. Buffer the events that match rules
2. When processing has finished, write events to S3. The events are written in the S3 bucket that contains the processed logs but under a different top-level folder: `rules/<log_type>/year=<year>/month=<month>/day=<day>/hour=<hour>/YYYYmmDDHHMMSS-uuid.gz`
3. We send a notification to SNS topic 

## Changes

- Added SNS Message Attributes when sending a notification to SNS topic. The message attributes are "type" (rule output, log output) and "id" (rule ID or log type)
- Changed SNS->SQS subscription of Rules Engine to SNS topic to filter for LogData. We don't want (yet) the Rules Engine to process output from itself (rule chaining)
- Added DDB table that will be used for grouping of events to an alert. Grouping will be done based on a dedup string and time period. 
- 

## Testing

- Running on my dev account

## TODO (before draft PR becomes PR)

- Add dedup string calculation
- Add unit tests

