### PR TITLE
Fix undefined TOTP label

### DIFF
--- a/web/src/components/forms/signin-form/index.tsx
+++ b/web/src/components/forms/signin-form/index.tsx
@@ -50,7 +50,7 @@ const SignInForm: React.FC = () => {
       validationSchema={validationSchema}
       onSubmit={async ({ username, password }, { setErrors }) =>
         signIn({
-          username,
+          email: username,
           password,
           onError: ({ message }) =>
             setErrors({

--- a/web/src/components/utils/auth-context.tsx
+++ b/web/src/components/utils/auth-context.tsx
@@ -215,6 +215,9 @@ const AuthProvider: React.FC = ({ children }) => {
       try {
         const signedInUser = await Auth.signIn(email, password);
 
+        // We are forcing an attribute email, since Cognito doesn't return the email of the user
+        // until they pass the MFA challenge.
+        signedInUser.attributes = { email };
         setAuthUser(signedInUser);
 
         onSuccess();

--- a/web/src/components/utils/auth-context.tsx
+++ b/web/src/components/utils/auth-context.tsx
@@ -77,7 +77,7 @@ interface SignOutParams {
 }
 
 interface SignInParams {
-  username: string;
+  email: string;
   password: string;
   onSuccess?: () => void;
   onError?: (err: AuthError) => void;
@@ -174,7 +174,7 @@ const AuthProvider: React.FC = ({ children }) => {
    */
   const userInfo = React.useMemo<UserInfo>(() => {
     // if a user is present, derive the user info from him
-    if (authUser) {
+    if (authUser?.attributes) {
       return {
         ...authUser.attributes,
         roles: authUser?.signInUserSession?.accessToken.payload['cognito:groups'] || [],
@@ -211,9 +211,10 @@ const AuthProvider: React.FC = ({ children }) => {
    *
    */
   const signIn = React.useCallback(
-    async ({ username, password, onSuccess = () => {}, onError = () => {} }: SignInParams) => {
+    async ({ email, password, onSuccess = () => {}, onError = () => {} }: SignInParams) => {
       try {
-        const signedInUser = await Auth.signIn(username, password);
+        const signedInUser = await Auth.signIn(email, password);
+
         setAuthUser(signedInUser);
 
         onSuccess();


### PR DESCRIPTION
## Background

This PR makes sure that the label part of the OTP url  is not `undefined`, but contains the associated user's email.

Closes #187 

## Changes

- Rename `username` to `email` on the signin flow params
- Pro-actively add `email` attribute on cognito user 

## Testing

- Locally & Remotely
- With same & new user
- Safari, Mozilla & Chrome
