### PR TITLE
Deployment role and doc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ keys/
 
 # MacOS files
 .DS_Store
+
+# Terraform
+.terraform
+terraform.tfstate*

--- a/deployments/auxiliary/README.md
+++ b/deployments/auxiliary/README.md
@@ -5,4 +5,4 @@ A collection of files used to create auxiliary infrastructure in support of a pa
 ## Formats
 
 - CloudFormation: Deploy AWS Infrastructure with AWS CloudFormation templates
-- Terraform: Deploy infrastructure with Terraform templates (coming soon!)
+- Terraform: Deploy infrastructure with Terraform templates

--- a/deployments/auxiliary/cloudformation/Makefile
+++ b/deployments/auxiliary/cloudformation/Makefile
@@ -1,0 +1,16 @@
+region = us-west-2
+bucket = panther-public-cloudformation-templates
+
+upload-all:
+	for template in `find . -iname 'panther-*.yml'`; do \
+		$(MAKE) upload-single template=$$(basename $$template) | grep 'upload'; \
+	done
+
+upload-single:
+	version=`egrep 'Version: v' $(template)  | tr -s ' ' | cut -d ' ' -f 3`; \
+	templateDisplayName=`echo $(template) | cut -d'.' -f1`; \
+	if [[ $$version != "" ]]; then \
+		aws s3 cp $(template) s3://$(bucket)/$$templateDisplayName/$$version/template.yml --acl public-read; \
+	fi; \
+	aws s3 cp $(template) s3://$(bucket)/$$templateDisplayName/latest/template.yml --acl public-read; \
+

--- a/deployments/auxiliary/cloudformation/README.md
+++ b/deployments/auxiliary/cloudformation/README.md
@@ -1,13 +1,16 @@
 # Panther's CloudFormation Templates
 
-A collection of CloudFormation templates to configure data collection and remediation with multiple satellite accounts.
+A collection of CloudFormation templates to configure auxiliary Panther infrastructure. These templates are also available in a public S3 bucket for your convenience:
 
-## Templates
+`https://panther-public-cloudformation-templates.s3-us-west-2.amazonaws.com/TEMPLATE-NAME/VERSION/template.yml`
 
-- `panther-aws-compliance-iam`: The IAM Roles used in conjunction with the compliance features.
-- `panther-remediations-iam`: The IAM Role used for Automatic Remediation in the satellite accounts.
-- `panther-cloudwatch-events`: Configures AWS CloudWatch Events to send to SNS/SQS.
-- `panther-stackset-iam-admin-role`: The IAM Role orchestrating the StackSet creation.
-- `panther-log-processing-iam`: The IAM Roles used in conjunction with the log processing features.
-- `panther-log-processing-infra`: A configuration for log processing in a satellite account.
-- `panther-log-processing-notifications` A minimal configuration for log processing in a satellite account.
+VERSION can be `latest` or a specific version number from the template metadata.
+
+## Makefile
+
+Panther team members can upload templates with the provided `Makefile`:
+
+```
+make upload-single template=panther-deployment-role.yml
+make upload-all
+```

--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -21,153 +21,126 @@ Metadata:
   Version: v1.0.0
 
 Resources:
-  AuditRole:
+  DeploymentRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: PantherDeploymentRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              Bool:
+                aws:SecureTransport: true
       Description: IAM role for deploying Panther
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/SecurityAudit
-      Policies:
-        - PolicyName: CloudFormation
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - cloudformation:DetectStackDrift
-                  - cloudformation:DetectStackResourceDrift
-                Resource: '*'
       Tags:
         - Key: Application
           Value: Panther
 
-#  {
-#    "Version": "2012-10-17",
-#    "Statement": [
-#    {
-#      "Effect": "Allow",
-#      "Action": "cloudformation:*",
-#      "Resource": [
-#        "arn:aws:cloudformation:us-east-1:101802775469:stack/panther-*",
-#        "arn:aws:cloudformation:us-east-1:aws:transform/Serverless-2016-10-31"
-#      ]
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "dynamodb:*",
-#      "Resource": "arn:aws:dynamodb:us-east-1:101802775469:table/panther-*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": [
-#        "ec2:AssociateRouteTable",
-#        "ec2:AssociateSubnetCidrBlock",
-#        "ec2:AssociateVpcCidrBlock",
-#        "ec2:AuthorizeSecurityGroupEgress",
-#        "ec2:AuthorizeSecurityGroupIngress",
-#        "ec2:AttachInternetGateway",
-#        "ec2:CreateInternetGateway",
-#        "ec2:CreateRoute",
-#        "ec2:CreateRouteTable",
-#        "ec2:CreateSecurityGroup",
-#        "ec2:CreateSubnet",
-#        "ec2:CreateTags",
-#        "ec2:CreateVpc",
-#        "ec2:DeleteInternetGateway",
-#        "ec2:DeleteRoute",
-#        "ec2:DeleteRouteTable",
-#        "ec2:DeleteSecurityGroup",
-#        "ec2:DeleteSubnet",
-#        "ec2:DeleteTags",
-#        "ec2:DeleteVpc",
-#        "ec2:Describe*",
-#        "ec2:DetachInternetGateway",
-#        "ec2:DisassociateRouteTable",
-#        "ec2:DisassociateSubnetCidrBlock",
-#        "ec2:ModifySubnetAttribute",
-#        "ec2:ModifyVpcAttribute",
-#        "ec2:ReplaceRoute",
-#        "ec2:ReplaceRouteTableAssociation",
-#        "ec2:RevokeSecurityGroupEgress",
-#        "ec2:RevokeSecurityGroupIngress",
-#        "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
-#        "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
-#        "elasticloadbalancing:*"
-#      ],
-#      "Resource": "*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "ecr:*",
-#      "Resource": "arn:aws:ecr:us-east-1:101802775469:repository/panther-*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "execute-api:Invoke",
-#      "Resource": "arn:aws:execute-api:us-east-1:101802775469:*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "iam:*",
-#      "Resource": "arn:aws:iam::101802775469:role/panther-*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "kms:*",
-#      "Resource": [
-#        "arn:aws:kms:us-east-1:101802775469:alias/panther-*",
-#        "arn:aws:kms:us-east-1:101802775469:key/*"
-#      ]
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "lambda:*",
-#      "Resource": [
-#        "arn:aws:lambda:us-east-1:101802775469:event-source-mapping:*",
-#        "arn:aws:lambda:us-east-1:101802775469:function:panther-*",
-#        "arn:aws:lambda:us-east-1:101802775469:layer:panther-*"
-#      ]
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "s3:*",
-#      "Resource": "arn:aws:s3:::panther-*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "sns:*",
-#      "Resource": "arn:aws:sns:us-east-1:101802775469:panther-*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": "sqs:*",
-#      "Resource": "arn:aws:sqs:us-east-1:101802775469:panther-*"
-#    },
-#    {
-#      "Effect": "Allow",
-#      "Action": [
-#        "acm:*",
-#        "apigateway:*",
-#        "appsync:*",
-#        "athena:*",
-#        "cloudformation:List*",
-#        "cloudwatch:*",
-#        "cognito-idp:*",
-#        "dynamodb:List*",
-#        "ecr:GetAuthorizationToken",
-#        "ecs:*",
-#        "events:*",
-#        "glue:*",
-#        "kms:CreateKey",
-#        "kms:List*",
-#        "lambda:*EventSourceMapping",
-#        "lambda:List*",
-#        "logs:*",
-#        "sns:List*",
-#        "sqs:List*"
-#      ],
-#      "Resource": "*"
-#    }
-#    ]
-#  }
+  DeploymentPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: PantherDeployment
+      Roles:
+        - !Ref DeploymentRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:  # permissions which can't be restricted to specific resources
+              - acm:*
+              - apigateway:*
+              - appsync:*
+              - athena:*
+              - cloudformation:List*
+              - cloudwatch:*
+              - cognito-idp:*
+              - dynamodb:List*
+              - ecr:GetAuthorizationToken
+              - ecs:*
+              - events:*
+              - glue:*
+              - kms:CreateKey
+              - kms:List*
+              - lambda:*EventSourceMapping
+              - lambda:List*
+              - logs:*
+              - sns:List*
+              - sqs:List*
+            Resource: '*'
+          - Effect: Allow
+            Action: cloudformation:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/panther-*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
+          - Effect: Allow
+            Action: dynamodb:*
+            Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/panther-*
+          - Effect: Allow
+            Action:
+              - ec2:AssociateRouteTable
+              - ec2:AssociateSubnetCidrBlock
+              - ec2:AssociateVpcCidrBlock
+              - ec2:AuthorizeSecurityGroupEgress
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:AttachInternetGateway
+              - ec2:CreateInternetGateway
+              - ec2:CreateRoute
+              - ec2:CreateRouteTable
+              - ec2:CreateSecurityGroup
+              - ec2:CreateSubnet
+              - ec2:CreateTags
+              - ec2:CreateVpc
+              - ec2:DeleteInternetGateway
+              - ec2:DeleteRoute
+              - ec2:DeleteRouteTable
+              - ec2:DeleteSecurityGroup
+              - ec2:DeleteSubnet
+              - ec2:DeleteTags
+              - ec2:DeleteVpc
+              - ec2:Describe*
+              - ec2:DetachInternetGateway
+              - ec2:DisassociateRouteTable
+              - ec2:DisassociateSubnetCidrBlock
+              - ec2:ModifySubnetAttribute
+              - ec2:ModifyVpcAttribute
+              - ec2:ReplaceRoute
+              - ec2:ReplaceRouteTableAssociation
+              - ec2:RevokeSecurityGroupEgress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:UpdateSecurityGroupRuleDescriptionsEgress
+              - ec2:UpdateSecurityGroupRuleDescriptionsIngress
+              - elasticloadbalancing:*
+            Resource: '*'
+          - Effect: Allow
+            Action: ecr:*
+            Resource: !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/panther-*
+          - Effect: Allow
+            Action: execute-api:Invoke
+            Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:*
+          - Effect: Allow
+            Action: iam:*
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/panther-*
+          - Effect: Allow
+            Action: kms:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/panther-*
+              - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+          - Effect: Allow
+            Action: lambda:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:event-source-mapping:*
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-*
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:panther-*
+          - Effect: Allow
+            Action: s3:*
+            Resource: !Sub arn:${AWS::Partition}:s3:::panther-*
+          - Effect: Allow
+            Action: sns:*
+            Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:panther-*
+          - Effect: Allow
+            Action: sqs:*
+            Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-*

--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -1,0 +1,173 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM role for deploying Panther
+
+Metadata:
+  Version: v1.0.0
+
+Resources:
+  AuditRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PantherDeploymentRole
+      Description: IAM role for deploying Panther
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/SecurityAudit
+      Policies:
+        - PolicyName: CloudFormation
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DetectStackDrift
+                  - cloudformation:DetectStackResourceDrift
+                Resource: '*'
+      Tags:
+        - Key: Application
+          Value: Panther
+
+#  {
+#    "Version": "2012-10-17",
+#    "Statement": [
+#    {
+#      "Effect": "Allow",
+#      "Action": "cloudformation:*",
+#      "Resource": [
+#        "arn:aws:cloudformation:us-east-1:101802775469:stack/panther-*",
+#        "arn:aws:cloudformation:us-east-1:aws:transform/Serverless-2016-10-31"
+#      ]
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "dynamodb:*",
+#      "Resource": "arn:aws:dynamodb:us-east-1:101802775469:table/panther-*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": [
+#        "ec2:AssociateRouteTable",
+#        "ec2:AssociateSubnetCidrBlock",
+#        "ec2:AssociateVpcCidrBlock",
+#        "ec2:AuthorizeSecurityGroupEgress",
+#        "ec2:AuthorizeSecurityGroupIngress",
+#        "ec2:AttachInternetGateway",
+#        "ec2:CreateInternetGateway",
+#        "ec2:CreateRoute",
+#        "ec2:CreateRouteTable",
+#        "ec2:CreateSecurityGroup",
+#        "ec2:CreateSubnet",
+#        "ec2:CreateTags",
+#        "ec2:CreateVpc",
+#        "ec2:DeleteInternetGateway",
+#        "ec2:DeleteRoute",
+#        "ec2:DeleteRouteTable",
+#        "ec2:DeleteSecurityGroup",
+#        "ec2:DeleteSubnet",
+#        "ec2:DeleteTags",
+#        "ec2:DeleteVpc",
+#        "ec2:Describe*",
+#        "ec2:DetachInternetGateway",
+#        "ec2:DisassociateRouteTable",
+#        "ec2:DisassociateSubnetCidrBlock",
+#        "ec2:ModifySubnetAttribute",
+#        "ec2:ModifyVpcAttribute",
+#        "ec2:ReplaceRoute",
+#        "ec2:ReplaceRouteTableAssociation",
+#        "ec2:RevokeSecurityGroupEgress",
+#        "ec2:RevokeSecurityGroupIngress",
+#        "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+#        "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+#        "elasticloadbalancing:*"
+#      ],
+#      "Resource": "*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "ecr:*",
+#      "Resource": "arn:aws:ecr:us-east-1:101802775469:repository/panther-*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "execute-api:Invoke",
+#      "Resource": "arn:aws:execute-api:us-east-1:101802775469:*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "iam:*",
+#      "Resource": "arn:aws:iam::101802775469:role/panther-*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "kms:*",
+#      "Resource": [
+#        "arn:aws:kms:us-east-1:101802775469:alias/panther-*",
+#        "arn:aws:kms:us-east-1:101802775469:key/*"
+#      ]
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "lambda:*",
+#      "Resource": [
+#        "arn:aws:lambda:us-east-1:101802775469:event-source-mapping:*",
+#        "arn:aws:lambda:us-east-1:101802775469:function:panther-*",
+#        "arn:aws:lambda:us-east-1:101802775469:layer:panther-*"
+#      ]
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "s3:*",
+#      "Resource": "arn:aws:s3:::panther-*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "sns:*",
+#      "Resource": "arn:aws:sns:us-east-1:101802775469:panther-*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": "sqs:*",
+#      "Resource": "arn:aws:sqs:us-east-1:101802775469:panther-*"
+#    },
+#    {
+#      "Effect": "Allow",
+#      "Action": [
+#        "acm:*",
+#        "apigateway:*",
+#        "appsync:*",
+#        "athena:*",
+#        "cloudformation:List*",
+#        "cloudwatch:*",
+#        "cognito-idp:*",
+#        "dynamodb:List*",
+#        "ecr:GetAuthorizationToken",
+#        "ecs:*",
+#        "events:*",
+#        "glue:*",
+#        "kms:CreateKey",
+#        "kms:List*",
+#        "lambda:*EventSourceMapping",
+#        "lambda:List*",
+#        "logs:*",
+#        "sns:List*",
+#        "sqs:List*"
+#      ],
+#      "Resource": "*"
+#    }
+#    ]
+#  }

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -88,7 +88,7 @@ Resources:
           - Sid: AllowSubscriptionToPanther
             Effect: Allow
             Principal:
-              AWS: !Sub arn:{AWS::Partition}:iam::${MasterAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sns:Subscribe
             Resource: !Ref Topic
       Topics:
@@ -98,7 +98,7 @@ Resources:
   Subscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Sub arn:{AWS::Partition}:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications
+      Endpoint: !Sub arn:${AWS::Partition}:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications
       Protocol: sqs
       RawMessageDelivery: false
       TopicArn: !Ref Topic

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -41,7 +41,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: arn:{AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole
+                Resource: arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole
 
 Outputs:
   CloudFormationStackSetAdminRoleArn:

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -41,7 +41,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole
+                Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole
 
 Outputs:
   CloudFormationStackSetAdminRoleArn:

--- a/deployments/auxiliary/terraform/README.md
+++ b/deployments/auxiliary/terraform/README.md
@@ -1,7 +1,3 @@
 # Panther's Terraform Templates
 
-A collection of Terraform Templates to interact with Panther.
-
-## Templates
-
-- Coming soon!
+Terraform versions of Panther's auxiliary templates!

--- a/deployments/auxiliary/terraform/panther-deployment-role.tf
+++ b/deployments/auxiliary/terraform/panther-deployment-role.tf
@@ -1,0 +1,187 @@
+provider "aws" {
+  version = "~> 2.0"
+}
+
+variable "aws_partition" {
+  type    = string
+  default = "aws"
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_account_id" {
+  type = string
+}
+
+resource "aws_iam_role" "deployment" {
+  name        = "PantherDeployment2"
+  description = "IAM role for deploying Panther"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "arn:${var.aws_partition}:iam::${var.aws_account_id}:root"
+      },
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": true
+        }
+      }
+    }
+  ]
+}
+EOF
+
+  tags = {
+    Application = "Panther"
+  }
+}
+
+resource "aws_iam_policy" "deployment" {
+  name        = "PantherDeployment2"
+  description = "IAM policy for deploying Panther"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "acm:*",
+        "apigateway:*",
+        "appsync:*",
+        "athena:*",
+        "cloudformation:List*",
+        "cloudwatch:*",
+        "cognito-idp:*",
+        "dynamodb:List*",
+        "ecr:GetAuthorizationToken",
+        "ecs:*",
+        "events:*",
+        "glue:*",
+        "kms:CreateKey",
+        "kms:List*",
+        "lambda:*EventSourceMapping",
+        "lambda:List*",
+        "logs:*",
+        "sns:List*",
+        "sqs:List*"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "cloudformation:*",
+      "Resource": [
+        "arn:${var.aws_partition}:cloudformation:${var.aws_region}:${var.aws_account_id}:stack/panther-*",
+        "arn:${var.aws_partition}:cloudformation:${var.aws_region}:aws:transform/Serverless-2016-10-31"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": "dynamodb:*",
+      "Resource": "arn:${var.aws_partition}:dynamodb:${var.aws_region}:${var.aws_account_id}:table/panther-*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "ec2:AssociateRouteTable",
+        "ec2:AssociateSubnetCidrBlock",
+        "ec2:AssociateVpcCidrBlock",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AttachInternetGateway",
+        "ec2:CreateInternetGateway",
+        "ec2:CreateRoute",
+        "ec2:CreateRouteTable",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateSubnet",
+        "ec2:CreateTags",
+        "ec2:CreateVpc",
+        "ec2:DeleteInternetGateway",
+        "ec2:DeleteRoute",
+        "ec2:DeleteRouteTable",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteSubnet",
+        "ec2:DeleteTags",
+        "ec2:DeleteVpc",
+        "ec2:Describe*",
+        "ec2:DetachInternetGateway",
+        "ec2:DisassociateRouteTable",
+        "ec2:DisassociateSubnetCidrBlock",
+        "ec2:ModifySubnetAttribute",
+        "ec2:ModifyVpcAttribute",
+        "ec2:ReplaceRoute",
+        "ec2:ReplaceRouteTableAssociation",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+        "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+        "elasticloadbalancing:*"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "ecr:*",
+      "Resource": "arn:${var.aws_partition}:ecr:${var.aws_region}:${var.aws_account_id}:repository/panther-*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "execute-api:Invoke",
+      "Resource": "arn:${var.aws_partition}:execute-api:${var.aws_region}:${var.aws_account_id}:*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "iam:*",
+      "Resource": "arn:${var.aws_partition}:iam::${var.aws_account_id}:role/panther-*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "kms:*",
+      "Resource": [
+        "arn:${var.aws_partition}:kms:${var.aws_region}:${var.aws_account_id}:alias/panther-*",
+        "arn:${var.aws_partition}:kms:${var.aws_region}:${var.aws_account_id}:key/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": "lambda:*",
+      "Resource": [
+        "arn:${var.aws_partition}:lambda:${var.aws_region}:${var.aws_account_id}:event-source-mapping:*",
+        "arn:${var.aws_partition}:lambda:${var.aws_region}:${var.aws_account_id}:function:panther-*",
+        "arn:${var.aws_partition}:lambda:${var.aws_region}:${var.aws_account_id}:layer:panther-*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": "s3:*",
+      "Resource": "arn:${var.aws_partition}:s3:::panther-*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "sns:*",
+      "Resource": "arn:${var.aws_partition}:sns:${var.aws_region}:${var.aws_account_id}:panther-*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "sqs:*",
+      "Resource": "arn:${var.aws_partition}:sqs:${var.aws_region}:${var.aws_account_id}:panther-*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "deployment" {
+  role       = aws_iam_role.deployment.name
+  policy_arn = aws_iam_policy.deployment.arn
+}

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -26,11 +26,10 @@ Before we cover deployment, let's establish the terminology:
 
 ## Prerequisites
 
-You need an AWS account and an IAM user or role with permission to create resources in Lambda, DynamoDB, S3, ECS, ELB, EC2 \(security groups, subnets, VPC\), SNS, SQS, SES, KMS, IAM, CloudFormation, CloudWatch, API Gateway, Cognito, and AppSync.
+You need an AWS account and an IAM user or role with permission to create and manage the necessary AWS resources. We provide an IAM role you can use for Panther deployment:
 
-{% hint style="info" %}
-Precise deployment policy coming soon!
-{% endhint %}
+- CloudFormation ([source](https://github.com/panther-labs/panther/tree/master/deployments/auxiliary/cloudformation/panther-deployment-role.yml)): [https://panther-public-cloudformation-templates.s3-us-west-2.amazonaws.com/panther-deployment-role/latest/template.yml](https://panther-public-cloudformation-templates.s3-us-west-2.amazonaws.com/panther-deployment-role/latest/template.yml)
+- Terraform ([source](<(https://github.com/panther-labs/panther/tree/master/deployments/auxiliary/terraform/panther-deployment-role.tf)>))
 
 _We recommend deploying Panther into its own AWS account via_ [_AWS Organizations_](https://aws.amazon.com/blogs/security/how-to-use-aws-organizations-to-automate-end-to-end-account-creation/)_. This ensures that detection infrastructure is contained within a single place._
 
@@ -117,6 +116,7 @@ Rather than deploying from within a docker container, you can instead configure 
 
 You're all set! Run `mage deploy`
 
+- If you use `aws-vault`, you must be authenticated with MFA. Otherwise, IAM role creation will fail with `InvalidClientTokenId`
 - The initial deployment will take 20-30 minutes. If your credentials timeout, you can safely redeploy to pick up where you left off.
 - Near the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
 - You'll get an email from [**no-reply@verificationemail.com**](mailto:no-reply@verificationemail.com) with your temporary password. If you don't see it, be sure to check your spam folder.

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -29,7 +29,7 @@ Before we cover deployment, let's establish the terminology:
 You need an AWS account and an IAM user or role with permission to create and manage the necessary AWS resources. We provide an IAM role you can use for Panther deployment:
 
 - CloudFormation ([source](https://github.com/panther-labs/panther/tree/master/deployments/auxiliary/cloudformation/panther-deployment-role.yml)): [https://panther-public-cloudformation-templates.s3-us-west-2.amazonaws.com/panther-deployment-role/latest/template.yml](https://panther-public-cloudformation-templates.s3-us-west-2.amazonaws.com/panther-deployment-role/latest/template.yml)
-- Terraform ([source](<(https://github.com/panther-labs/panther/tree/master/deployments/auxiliary/terraform/panther-deployment-role.tf)>))
+- Terraform ([source](https://github.com/panther-labs/panther/tree/master/deployments/auxiliary/terraform/panther-deployment-role.tf))
 
 _We recommend deploying Panther into its own AWS account via_ [_AWS Organizations_](https://aws.amazon.com/blogs/security/how-to-use-aws-organizations-to-automate-end-to-end-account-creation/)_. This ensures that detection infrastructure is contained within a single place._
 

--- a/web/src/pages/overview/index.tsx
+++ b/web/src/pages/overview/index.tsx
@@ -116,7 +116,7 @@ const Overview: React.FC = () => {
     return (
       <Alert
         variant="error"
-        title="We can\'t display this content right now"
+        title="We can't display this content right now"
         description={extractErrorMessage(error)}
       />
     );


### PR DESCRIPTION
## Background

Adding a Panther deployment role and other minor doc changes

Closes #145 
Closes #178 

## Changes

- Add a Panther deployment role (CloudFormation and Terraform versions)
- Reset our public templates S3 bucket with what is in the master branch of this repo
- Add `makefile` so Panther team can easily upload public templates to our bucket
- Fix small typo in frontend error message

## Testing

- Deployed Panther end-to-end with this IAM role
- Was able to successfully create with CloudFormation and with Terraform
