### PR TITLE
Connect Cognito custom message trigger to Lambda function

### DIFF
--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -179,6 +179,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
+        AppDomainURL: !GetAtt WebApplicationLoadBalancer.Outputs.LoadBalancerUrl
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
         Debug: !Ref Debug
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
@@ -189,6 +190,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
+        CustomMessageTriggerFunctionArn: !GetAtt AdminAPI.Outputs.CustomMessageTriggerFunctionArn
         PantherHost: !GetAtt WebApplicationLoadBalancer.Outputs.LoadBalancerUrl
       TemplateURL: core/cognito.yml
 

--- a/deployments/core/admin_api.yml
+++ b/deployments/core/admin_api.yml
@@ -65,12 +65,7 @@ Parameters:
 
   AppDomainURL:
     Type: String
-    Description: Panther App Domain used as a link for the customer in the invitation email
-    Default: app.runpanther.io
-  SesSourceEmailArn:
-    Type: String
-    Description: The ARN of a verified email address in Amazon SES
-    Default: ''
+    Description: Panther App Domain used as a link for the customer in the password reset email
 
 Conditions:
   AttachLayers: !Not [!Equals [!Join ['', !Ref LayerVersionArns], '']]
@@ -110,9 +105,6 @@ Resources:
           DEBUG: !Ref Debug
           USERS_TABLE_NAME: !Ref UsersTable
           ORGANIZATIONS_API: !Ref OrganizationAPIFunction
-          CUSTOM_MESSAGES_TRIGGER_HANDLER: !GetAtt CustomMessageTriggerFunction.Arn
-          APP_DOMAIN_URL: !Ref AppDomainURL
-          SES_SOURCE_EMAIL_ARN: !Ref SesSourceEmailArn
       FunctionName: panther-users-api
       Handler: main
       Layers: !If [AttachLayers, !Ref LayerVersionArns, !Ref 'AWS::NoValue']
@@ -176,7 +168,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../../out/bin/internal/core/custom_message/main
-      Description: Custom Message trigger for Cognito user events
+      Description: Custom message trigger for Cognito user events
       Environment:
         Variables:
           DEBUG: !Ref Debug
@@ -252,3 +244,8 @@ Resources:
                 - dynamodb:*Item
                 - dynamodb:Scan
               Resource: !GetAtt OrganizationTable.Arn
+
+Outputs:
+  CustomMessageTriggerFunctionArn:
+    Description: Lambda function for custom Cognito message triggers
+    Value: !GetAtt CustomMessageTriggerFunction.Arn

--- a/deployments/core/cognito.yml
+++ b/deployments/core/cognito.yml
@@ -18,6 +18,9 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Cognito User Pool
 
 Parameters:
+  CustomMessageTriggerFunctionArn:
+    Type: String
+    Description: Lambda function for custom cognito triggers
   PantherHost:
     Type: String
     Description: Load balancer URL hosting the deployed Panther website
@@ -46,6 +49,8 @@ Resources:
             <br /><small>Copyright © 2020 Panther Labs Inc. All rights reserved.</small>
       AutoVerifiedAttributes: # Attributes you want the user to verify (poor naming choice by AWS)
         - email
+      LambdaConfig:
+        CustomMessage: !Ref CustomMessageTriggerFunctionArn
       Policies:
         PasswordPolicy:
           MinimumLength: 12

--- a/internal/core/custom_message/api/forgot_password.go
+++ b/internal/core/custom_message/api/forgot_password.go
@@ -25,7 +25,7 @@ import (
 	"github.com/matcornic/hermes"
 	"go.uber.org/zap"
 
-	"github.com/panther-labs/panther/internal/core/users_api/email"
+	"github.com/panther-labs/panther/internal/core/custom_message/email"
 )
 
 func handleForgotPassword(event *events.CognitoEventUserPoolsCustomMessage) (*events.CognitoEventUserPoolsCustomMessage, error) {
@@ -56,7 +56,7 @@ If you did not request a password reset, you can ignore this email.`,
 				},
 			},
 			Outros: []string{
-				"Need help, or have questions? Just reply to this email, we'd love to help.",
+				"Need help, or have questions? Just email us at support@runpanther.io, we'd love to help.",
 			},
 		},
 	}

--- a/internal/core/custom_message/email/clients.go
+++ b/internal/core/custom_message/email/clients.go
@@ -34,7 +34,7 @@ var (
 		Product: hermes.Product{
 			// Appears in header & footer of e-mails
 			Name:      "Panther",
-			Link:      "runpanther.io",
+			Link:      "https://runpanther.io",
 			Copyright: "Copyright © " + strconv.Itoa(time.Now().Year()) + " Panther Labs Inc. All rights reserved.",
 			Logo:      pantherEmailLogo,
 		},

--- a/internal/core/custom_message/email/clients.go
+++ b/internal/core/custom_message/email/clients.go
@@ -19,7 +19,6 @@ package email
  */
 
 import (
-	"os"
 	"strconv"
 	"time"
 
@@ -29,14 +28,13 @@ import (
 var (
 	// The logo is fetched from panther-public cloudfront CDN
 	pantherEmailLogo = "https://d14d54mfia7r7w.cloudfront.net/panther-email-logo-white.png"
-	appDomainURL     = os.Getenv("APP_DOMAIN_URL")
 	// PantherEmailTemplate is used as a boilerplate for Panther themed email
 	PantherEmailTemplate = hermes.Hermes{
 		Theme: new(hermes.Flat),
 		Product: hermes.Product{
 			// Appears in header & footer of e-mails
 			Name:      "Panther",
-			Link:      appDomainURL,
+			Link:      "runpanther.io",
 			Copyright: "Copyright © " + strconv.Itoa(time.Now().Year()) + " Panther Labs Inc. All rights reserved.",
 			Logo:      pantherEmailLogo,
 		},

--- a/internal/core/custom_message/main/lambda.go
+++ b/internal/core/custom_message/main/lambda.go
@@ -28,6 +28,7 @@ import (
 	"github.com/panther-labs/panther/pkg/lambdalogger"
 )
 
+// TODO - merge this with users-api
 func lambdaHandler(ctx context.Context, event *events.CognitoEventUserPoolsCustomMessage) (
 	*events.CognitoEventUserPoolsCustomMessage, error) {
 


### PR DESCRIPTION
## Background
We have a custom format for password reset emails, but Cognito wasn't using it. Turns out we had the custom message Lambda function, it was just never connected to Cognito (we used to build the Congito user pool with an API call instead of CloudFormation)

Closes #190 

## Changes

- Connect `panther-custom-message-trigger` Lambda function to Cognito
- Remove some dead code in `users-api` related to how we used to set up Cognito pools

## Testing

- Deployed to dev account, triggered password reset flow:

![Screen Shot 2020-02-14 at 3 25 33 PM](https://user-images.githubusercontent.com/3608925/74576379-5b35ae00-4f3f-11ea-9974-3c2a4d089f8c.png)

Clicking the link in the email worked and I was able to reset the password and login with the new password

## Future
We are redesigning the `users-api` before v1; the custom message trigger can probably go there as well. It's a bit strange having an entire Lambda function for just this 1 use case (forgot password)
