### PR TITLE
Updated initial analysis sets to always point to latest

### DIFF
--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -79,4 +79,4 @@ PipLayer:
 # If the analysis-api is non-empty, this setting is ignored and you can instead
 # use the BulkUpload functionality from the web app to upload new or modified rule sets.
 InitialAnalysisSets:
-  - https://github.com/panther-labs/panther-analysis/releases/download/v1.0.1/panther-analysis-all.zip
+  - https://github.com/panther-labs/panther-analysis/releases/latest/download/panther-analysis-all.zip


### PR DESCRIPTION
## Background

The initial policies/rules set was set to a specific tagged release of the `panther-analysis`, this switches it to latest so it doesn't have to be updated all the time.

## Changes

- Pointed initial analysis set at latest

## Testing

- Copied the URL into my browser and the proper pack was downloaded
