### PR TITLE
Adding permissions required for cross-account subscription confirmation 

### DIFF
--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -119,6 +119,12 @@ Resources:
             BatchSize: 10
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
+        - Id: ConfirmCrossAccountSubscription
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: sns:ConfirmSubscription
+              Resource: !GetAtt Queue.Arn
         - Id: ReceiveFromInputSqsQueue
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -123,10 +123,10 @@ Resources:
           Version: 2012-10-17
           Statement:
             - Effect: Allow
-              # This policy allows the log processor to confirm SNS->SQS subscriptions
-              # to the panther-input-data-notifications queue. Note that by default SQS queue policy blacklists all accounts
-              # from subscribing to it. When a user onboards a log source, they specify an AWS Account ID they want to onboard logs from
-              # and this whitelists that AWS Account.
+              # This policy allows the log processor to confirm SNS->SQS subscriptions to the panther-input-data-notifications queue.
+              # Note that by default SQS queue policy blocks all accounts from subscribing to it.
+              # When a user onboards a log source, they specify an AWS Account ID they want to onboard logs from.
+              # This account will be whitelisted and SNS topic from it can subscribe to the SQS queue.
               Action: sns:ConfirmSubscription
               Resource: '*'
         - Id: ReceiveFromInputSqsQueue

--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -119,12 +119,12 @@ Resources:
             BatchSize: 10
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - Id: ConfirmCrossAccountSubscription
+        - Id: ConfirmSubscriptions
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: sns:ConfirmSubscription
-              Resource: !GetAtt Queue.Arn
+              Resource: '*'
         - Id: ReceiveFromInputSqsQueue
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -123,6 +123,10 @@ Resources:
           Version: 2012-10-17
           Statement:
             - Effect: Allow
+              # This policy allows the log processor to confirm SNS->SQS subscriptions
+              # to the panther-input-data-notifications queue. Note that by default SQS queue policy blacklists all accounts
+              # from subscribing to it. When a user onboards a log source, they specify an AWS Account ID they want to onboard logs from
+              # and this whitelists that AWS Account.
               Action: sns:ConfirmSubscription
               Resource: '*'
         - Id: ReceiveFromInputSqsQueue


### PR DESCRIPTION
## Background

Fixing permissions issue. 
Closes #201 

## Changes

- Log processor needs to confirm SNS->SQS subscription. It was missing the appropriate permissions. 

## Testing

- Setup SNS->SQS cross-account in my dev environment. I was able to get the subscription setup. 
