### PR TITLE
Update quick-start docs

### DIFF
--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -82,7 +82,7 @@ Tools like [aws-vault](https://github.com/99designs/aws-vault) can help with all
 
 ## Deployment
 
-Run Panther in 3 easy steps: clone the repo, install docker, and deploy!
+Run Panther in 4 easy steps: clone the repo, install docker, setup the project and then deploy it!
 
 First, clone the latest release of the [Panther repo](https://github.com/panther-labs/panther):
 
@@ -113,6 +113,8 @@ The minimum requirements for an EC2 machine are 1 vCPU and 2GB of memory. The lo
 {% hint style="info" %}
 Rather than deploying from within a docker container, you can instead configure your [development environment](development.md#manual-installation) locally. This will take more time initially but will lead to faster deployments.
 {% endhint %}
+
+Lastly, setup the project's dependencies by running `mage setup:all`.
 
 You're all set! Run `mage deploy`
 

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -114,7 +114,9 @@ The minimum requirements for an EC2 machine are 1 vCPU and 2GB of memory. The lo
 Rather than deploying from within a docker container, you can instead configure your [development environment](development.md#manual-installation) locally. This will take more time initially but will lead to faster deployments.
 {% endhint %}
 
-Lastly, setup the project's dependencies by running `mage setup:all`.
+Lastly, setup the project's deployment dependencies by running `mage setup:deploy`.
+
+> You only need to run `mage setup:deploy` the first time you are installing Panther. Future deployments can omit this step.
 
 You're all set! Run `mage deploy`
 

--- a/tools/mage/setup_namespace.go
+++ b/tools/mage/setup_namespace.go
@@ -41,11 +41,16 @@ var (
 // Setup contains targets for installing development / CI dependencies
 type Setup mg.Namespace
 
-// All Install all development dependencies
+// All Install all development & deployment dependencies
 func (s Setup) All() {
 	s.Go()
 	s.Python()
 	s.Web()
+}
+
+// Deploy Install the necessary dependencies for deployment
+func (s Setup) Deploy() {
+	s.Go()
 }
 
 // Go Install goimports, go-swagger, and golangci-lint


### PR DESCRIPTION
## Background

Quick Start docs are outdated. A `mage setup:all` is required in order to install swagger, etc.

Closes #198 

## Changes

- Update quick start docs

## Testing

- N/A
