### PR TITLE
Remove swagger from deploy precheck

### DIFF
--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -103,19 +103,9 @@ Your AWS credentials _must_ be exported as environment variables for the docker 
 `aws-vault exec <profile> -- ./dev.sh`
 {% endhint %}
 
-{% hint style="info" %}
-Rather than deploying from your local machine, you can opt to use an EC2 instance with Docker and
-git installed. Instead of exporting your AWS credentials as environment variables, you will need to attach an IAM role to your EC2 instance profile, with enough permissions for the creation of all Panther resources.
-
-The minimum requirements for an EC2 machine are 1 vCPU and 2GB of memory. The lowest-cost instance that satisfies those requirements is an EC2 `t2.small`.
-{% endhint %}
-
-{% hint style="info" %}
-Rather than deploying from within a docker container, you can instead configure your [development environment](development.md#manual-installation) locally. This will take more time initially but will lead to faster deployments.
-{% endhint %}
-
 You're all set! Run `mage deploy`
 
+- If you've made any changes to the source files or want to run tests, you may need to first install development dependencies with `mage setup:all`
 - If you use `aws-vault`, you must be authenticated with MFA. Otherwise, IAM role creation will fail with `InvalidClientTokenId`
 - The initial deployment will take 20-30 minutes. If your credentials timeout, you can safely redeploy to pick up where you left off.
 - Near the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
@@ -131,16 +121,21 @@ By default, Panther generates a self-signed certificate, which will cause most b
 Your connection _is_ encrypted, and it's generally safe to continue if the domain matches the output of the deploy command. However, the warning exists because self-signed certificates do not protect you from man-in-the-middle attacks; for this reason production deployments should provide their own ACM certificate in the `deployments/panther_config.yml` file.
 {% endhint %}
 
+### Other Deployment Options
+Rather than deploying from within a docker container, you can instead configure your [development environment](development.md#manual-installation) locally. This will take more time initially but will lead to faster deployments.
+
+Or, you can deploy from an EC2 instance with Docker and git installed (in the same region you're deploying Panther to). This is typically the fastest option since it minimizes the latency when communicating with AWS services. Instead of exporting your AWS credentials as environment variables, you will need to attach the [deployment IAM role](#prerequisites) to your EC2 instance profile. Your EC2 instance needs at least 1 vCPU and 2GB of memory; the cheapest suitable instance type is a `t2.small`.
+
 ## Onboarding
 
-Follow the steps below to onboard data, add AWS accounts, configure alert destinations, and more. The first step is configuring your [alert outputs](destinations/alert-setup/). Then, proceed below to configure scans and real-time log analysis.
+Now you can follow the steps below to configure [alert outputs](destinations/alert-setup/), [cloud security scans](policies/scanning/), and [real-time log analysis](log-analysis/log-processing/)!
 
 #### Log Analysis
 
 - [Log Analysis Setup](log-analysis/log-processing/)
 - [Create Rules for supported Log Types](log-analysis/rules/)
 
-#### Cloud Compliance
+#### Cloud Security
 
 - [Background](policies/compliance-background.md)
 - [Compliance Scanning Setup](policies/scanning/)

--- a/tools/mage/build_namespace.go
+++ b/tools/mage/build_namespace.go
@@ -59,6 +59,10 @@ func (b Build) API() {
 		start := time.Now().UTC()
 		args := []string{"generate", "client", "-q", "-t", dir, "-f", spec}
 		cmd := filepath.Join(setupDirectory, "swagger")
+		if _, err = os.Stat(cmd); err != nil {
+			logger.Fatalf("%s not found (%v): run 'mage setup:all'", cmd, err)
+		}
+
 		if err := sh.Run(cmd, args...); err != nil {
 			logger.Fatalf("%s %s failed: %v", cmd, strings.Join(args, " "), err)
 		}

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -138,12 +138,6 @@ func deployPrecheck(awsRegion string) {
 	if !supportedRegions[awsRegion] {
 		logger.Fatalf("panther is not supported in %s region", awsRegion)
 	}
-
-	// Ensure swagger is installed
-	swagger := filepath.Join(setupDirectory, "swagger")
-	if _, err := os.Stat(swagger); err != nil {
-		logger.Fatalf("%s not found (%v): run 'mage setup:all'", swagger, err)
-	}
 }
 
 // Generate the set of deploy parameters for the main application stack.


### PR DESCRIPTION
## Background
#99 added a `deploy_precheck` routine which fails early if something is wrong with the user environment. I included `swagger` in those checks, but I forgot swagger is actually not required to deploy Panther.

`swagger` generates the Go files in `api/gateway`, but those files are already checked into the repo. So a fresh clone + deploy should not require swagger at all.

Closes #204 
Closes #198 

## Changes

- Remove `swagger` from the deploy precheck
    - Explicitly check for swagger existence right before invoking it so that we can still show the same helpful error message
- A few minor updates to the quick start / deployment documentation

## Testing

- Deployed from a fresh clone of Panther without running `mage setup:all`
