### PR TITLE
Updated audit role permissions

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -97,6 +97,7 @@ Resources:
                 Action:
                   - dynamodb:ListTagsOfResource
                   - kms:ListResourceTags
+                  - sns:ListTagsForResource
                   - waf:ListTagsForResource
                   - waf-regional:ListTagsForResource
                 Resource: '*'

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -77,6 +77,18 @@ Resources:
                   - cloudformation:DetectStackDrift
                   - cloudformation:DetectStackResourceDrift
                 Resource: '*'
+        - PolicyName: CloudFormationStackDriftDetectionSupplements
+          # These permissions are not directly required for scanning, but are required by AWS in
+          # order to perform CloudFormation Stack drift detection on the corresponding resource types
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sns:ListTagsForResource
+                  - lambda:GetFunction
+                  - apigateway:GET
+                Resource: '*'
         - PolicyName: GetWAFACLs
           PolicyDocument:
             Version: 2012-10-17
@@ -97,7 +109,6 @@ Resources:
                 Action:
                   - dynamodb:ListTagsOfResource
                   - kms:ListResourceTags
-                  - sns:ListTagsForResource
                   - waf:ListTagsForResource
                   - waf-regional:ListTagsForResource
                 Resource: '*'

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9 // indirect
-	golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7 // indirect
+	golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/russross/blackfriday.v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 h1:a/Fd23DJvg1CaeDH0dYHahE
 golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7 h1:SWKaJjEEnIUqoSX43gli3maUBM+1QSfJVGHfmeeQlFg=
 golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 h1:90L2fHeLQmQFe04F648NKZE5sQP/M/6CjHcjtM7jP5U=
+golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Background

An external contributor reported an error in the snapshot poller when trying to call `ListTagsForResources` on an SNS Topic. Although we do not scan SNS Topics, we scan CloudFormation stacks and do drift detections, so we need to grant the snapshot poller the permissions needed to do drift detections on these resources.

Note that even without the correct permissions, we can still perform the stack drift detections. The resources we don't have permissions to scanned just won't be in the results. So if a stack creates two IAM roles (supported resources) and one SNS Topic (unsupported resource), we are still able to get the drift results from the two IAM roles, just not the SNS Topic. This change allows us to still get drift detection results for SNS Topics despite us not supporting them as a standalone resource.

While researching this issue I decided to check if there were any permissions we were missing to perform CloudFormation stack drift detections, and it appears at the very least we are missing `lambda:GetFunction` and `apigateway:GET`. I've included these permissions in the change as well, but they are much broader permissions than just listing tags so I'm open to suggestions about whether or not we should include them. 

Closes #203.
 
## Changes

- Updated PantherAuditRole to include the following permissions:
  - `lambda:GetFunction`
  - `apigateway:GET`
  - `sns:ListTagsForResource`

## Testing

- Deployed to my dev account, and observed successful resource drift detections for CloudFormation stacks with SNS Topics, Lambdas, and API Gateways
