### PR TITLE
Generalize user-based input linkification

### DIFF
--- a/web/src/components/linkify.tsx
+++ b/web/src/components/linkify.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box } from 'pouncejs';
+import { LinkifyProps } from 'linkifyjs/react';
+import { css } from '@emotion/core';
+
+const OriginalReactLinkify = React.lazy(() =>
+  import(/* webpackChunkName: "linkify" */ 'linkifyjs/react.js')
+) as React.FC<LinkifyProps>;
+
+const linkifyOptions = {
+  attributes: {
+    rel: 'noopener noreferrer',
+  },
+  className: '',
+  defaultProtocol: 'https',
+};
+
+const Linkify: React.FC = ({ children }) => {
+  return (
+    <Box
+      css={css`
+        word-break: break-word;
+      `}
+    >
+      <React.Suspense fallback={<div>{children}</div>}>
+        <OriginalReactLinkify options={linkifyOptions}>{children}</OriginalReactLinkify>
+      </React.Suspense>
+    </Box>
+  );
+};
+
+export default Linkify;

--- a/web/src/pages/alert-details/subcomponent/alert-details-info.tsx
+++ b/web/src/pages/alert-details/subcomponent/alert-details-info.tsx
@@ -21,7 +21,7 @@ import { Link } from 'react-router-dom';
 import urls from 'Source/urls';
 import React from 'react';
 import { AlertDetails, RuleDetails } from 'Generated/schema';
-import Linkify from 'linkifyjs/react';
+import Linkify from 'Components/linkify';
 import { SEVERITY_COLOR_MAP } from 'Source/constants';
 import { formatDatetime } from 'Helpers/utils';
 import Panel from 'Components/panel';
@@ -117,9 +117,7 @@ const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, rule }) => {
             DESCRIPTION
           </Label>
           <Text size="medium" color={rule.description ? 'black' : 'grey200'}>
-            <React.Suspense fallback={<span>{rule.description}</span>}>
-              <Linkify>{rule.description || 'No description available'}</Linkify>
-            </React.Suspense>
+            <Linkify>{rule.description || 'No description available'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>
@@ -127,9 +125,7 @@ const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, rule }) => {
             RUNBOOK
           </Label>
           <Text size="medium" color={rule.runbook ? 'black' : 'grey200'}>
-            <React.Suspense fallback={<span>{rule.runbook}</span>}>
-              <Linkify>{rule.runbook || 'No runbook available'}</Linkify>
-            </React.Suspense>
+            <Linkify>{rule.runbook || 'No runbook available'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>

--- a/web/src/pages/policy-details/subcomponents/policy-details-info.tsx
+++ b/web/src/pages/policy-details/subcomponents/policy-details-info.tsx
@@ -21,18 +21,14 @@ import { Link } from 'react-router-dom';
 import { Badge, Box, Button, Grid, Icon, Label, Text } from 'pouncejs';
 import { capitalize, formatDatetime } from 'Helpers/utils';
 import Panel from 'Components/panel';
+import Linkify from 'Components/linkify';
 import { ComplianceStatusEnum, PolicyDetails } from 'Generated/schema';
 import { READONLY_ROLES_ARRAY, SEVERITY_COLOR_MAP } from 'Source/constants';
-import { LinkifyProps } from 'linkifyjs/react';
 import urls from 'Source/urls';
 import JsonViewer from 'Components/json-viewer';
 import useModal from 'Hooks/useModal';
 import { MODALS } from 'Components/utils/modal-context';
 import RoleRestrictedAccess from 'Components/role-restricted-access';
-
-const Linkify = React.lazy(() =>
-  import(/* webpackChunkName: "linkify" */ 'linkifyjs/react.js')
-) as React.FC<LinkifyProps>;
 
 interface ResourceDetailsInfoProps {
   policy?: PolicyDetails;
@@ -133,13 +129,7 @@ const PolicyDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ policy }) => {
             REFERENCE
           </Label>
           <Text size="medium" color={policy.reference ? 'blue300' : 'grey200'}>
-            {policy.reference ? (
-              <a href={policy.reference} target="_blank" rel="noopener noreferrer">
-                {policy.reference}
-              </a>
-            ) : (
-              'No reference found'
-            )}
+            <Linkify>{policy.reference || 'No reference found'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>
@@ -163,9 +153,7 @@ const PolicyDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ policy }) => {
             DESCRIPTION
           </Label>
           <Text size="medium" color={policy.description ? 'black' : 'grey200'}>
-            <React.Suspense fallback={<span>{policy.description}</span>}>
-              <Linkify>{policy.description || 'No description available'}</Linkify>
-            </React.Suspense>
+            <Linkify>{policy.description || 'No description available'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>
@@ -173,9 +161,7 @@ const PolicyDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ policy }) => {
             RUNBOOK
           </Label>
           <Text size="medium" color={policy.runbook ? 'black' : 'grey200'}>
-            <React.Suspense fallback={<span>{policy.runbook}</span>}>
-              <Linkify>{policy.runbook || 'No runbook available'}</Linkify>
-            </React.Suspense>
+            <Linkify>{policy.runbook || 'No runbook available'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>

--- a/web/src/pages/rule-details/subcomponents/rule-details-info.tsx
+++ b/web/src/pages/rule-details/subcomponents/rule-details-info.tsx
@@ -21,17 +21,13 @@ import { Link } from 'react-router-dom';
 import { Badge, Box, Button, Grid, Icon, Label, Text } from 'pouncejs';
 import { formatDatetime } from 'Helpers/utils';
 import Panel from 'Components/panel';
+import Linkify from 'Components/linkify';
 import { RuleDetails } from 'Generated/schema';
 import { SEVERITY_COLOR_MAP, READONLY_ROLES_ARRAY } from 'Source/constants';
-import { LinkifyProps } from 'linkifyjs/react';
 import urls from 'Source/urls';
 import useModal from 'Hooks/useModal';
 import { MODALS } from 'Components/utils/modal-context';
 import RoleRestrictedAccess from 'Components/role-restricted-access';
-
-const Linkify = React.lazy(() =>
-  import(/* webpackChunkName: "linkify" */ 'linkifyjs/react.js')
-) as React.FC<LinkifyProps>;
 
 interface ResourceDetailsInfoProps {
   rule?: RuleDetails;
@@ -99,13 +95,7 @@ const RuleDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ rule }) => {
             REFERENCE
           </Label>
           <Text size="medium" color={rule.reference ? 'blue300' : 'grey200'}>
-            {rule.reference ? (
-              <a href={rule.reference} target="_blank" rel="noopener noreferrer">
-                {rule.reference}
-              </a>
-            ) : (
-              'No reference found'
-            )}
+            <Linkify>{rule.reference || 'No reference found'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>
@@ -129,9 +119,7 @@ const RuleDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ rule }) => {
             DESCRIPTION
           </Label>
           <Text size="medium" color={rule.description ? 'black' : 'grey200'}>
-            <React.Suspense fallback={<span>{rule.description}</span>}>
-              <Linkify>{rule.description || 'No description available'}</Linkify>
-            </React.Suspense>
+            <Linkify>{rule.description || 'No description available'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>
@@ -139,9 +127,7 @@ const RuleDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ rule }) => {
             RUNBOOK
           </Label>
           <Text size="medium" color={rule.runbook ? 'black' : 'grey200'}>
-            <React.Suspense fallback={<span>{rule.runbook}</span>}>
-              <Linkify>{rule.runbook || 'No runbook available'}</Linkify>
-            </React.Suspense>
+            <Linkify>{rule.runbook || 'No runbook available'}</Linkify>
           </Text>
         </Box>
         <Box my={1}>


### PR DESCRIPTION

## Background

This PR makes sure that all the URLization from data that the user has entered gets treated the same way. This helps with:

1. Not having to re-write the same logic more than once
2. Having a unified visual experience
3. Giving us parse safety

This doesn't include links that we create, but links that get parsed from stuff like runbook, reference, etc.

## Changes

- Add a single `linkify` component
- Migrate all user-based linkification to it

## Testing

- Manually & Locally
