### PR TITLE
Add Alex to default owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 #
 # Default Owners
 #
-* @3nvi @austinbyers @nhakmiller @kostaspap @jacknagz @rleighton
+* @3nvi @austinbyers @nhakmiller @kostaspap @jacknagz @rleighton @alexmylonas
 
 #
 # Documentation


### PR DESCRIPTION
## Background

Automatically add Alex as a reviewer to PRs

## Changes

- Add Alex to default group within CODEOWNERS

## Testing

N/A
