### PR TITLE
Adding Alert forwarder component

### DIFF
--- a/deployments/backend.yml
+++ b/deployments/backend.yml
@@ -345,6 +345,7 @@ Resources:
 
         SQSKeyId: !Ref QueueEncryptionKey
         AnalysisApiId: !GetAtt AnalysisAPI.Outputs.GatewayId
+        AlertDedupTableStreamArn: !GetAtt RulesEngine.Outputs.AlertDedupTableStreamArn
       TemplateURL: log_analysis/alerts.yml
 
   RulesEngine:

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -330,7 +330,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../../out/bin/internal/log_analysis/alert_forwarder/main
-      Description: Lambda for storing events from
+      Description: Lambda that creates and updates alerts in alerts-info table
       Environment:
         Variables:
           DEBUG: !Ref Debug

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -350,17 +350,6 @@ Resources:
       Timeout: 30
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
-        - Id: ReadTableStreams
-          Version: 2012-10-17
-          Statement:
-            - Effect: Allow
-              Action:
-                - dynamodb:DescribeStream
-                - dynamodb:GetRecords
-                - dynamodb:GetShardIterator
-                - dynamodb:ListStreams
-              Resource: !Sub ${LogAlertsTable.Arn}/stream/*
-
         - Id: ManageAlerts
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -358,5 +358,3 @@ Resources:
                 - dynamodb:PutItem
               Resource:
                 - !GetAtt LogAlertsTable.Arn
-
-

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -44,6 +44,9 @@ Parameters:
   SQSKeyId:
     Type: String
     Description: KMS key ID for SQS encryption
+  AlertDedupTableStreamArn:
+    Type: String
+    Description: The stream arn of the alerts dedup table
 
 Conditions:
   AttachLayers: !Not [!Equals [!Join ['', !Ref LayerVersionArns], '']]
@@ -336,7 +339,7 @@ Resources:
         DynamoDBEvent:
           Type: DynamoDB
           Properties:
-            Stream: !GetAtt LogAlertsTable.StreamArn
+            Stream: !Ref AlertDedupTableStreamArn
             StartingPosition: TRIM_HORIZON
             BatchSize: 10
       FunctionName: panther-log-alert-forwarder

--- a/deployments/log_analysis/alerts.yml
+++ b/deployments/log_analysis/alerts.yml
@@ -273,3 +273,98 @@ Resources:
                 - !GetAtt AlertsTable.Arn
                 - !GetAtt EventsTable.Arn
                 - !GetAtt RecentAlertsTable.Arn
+
+  ##### Dynamo table that stores alert information #####
+  LogAlertsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: panther-log-alerts-info
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+        - AttributeName: creationTime
+          AttributeType: S
+        - AttributeName: ruleId
+          AttributeType: S
+        - AttributeName: timePartition
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - # Add an index ruleId to efficiently list alerts for a specific rule
+          KeySchema:
+            - AttributeName: ruleId
+              KeyType: HASH
+            - AttributeName: creationTime
+              KeyType: RANGE
+          IndexName: ruleId-creationTime-index
+          Projection:
+            ProjectionType: ALL
+        - # Add an index using timePartition to efficiently list alerts by creationTime
+          KeySchema:
+            - AttributeName: timePartition
+              KeyType: HASH
+            - AttributeName: creationTime
+              KeyType: RANGE
+          IndexName: timePartition-creationTime-index
+          Projection:
+            ProjectionType: ALL
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
+      SSESpecification:
+        SSEEnabled: True
+
+  ##### Alert forwarder Lambda
+  AlertForwarderLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/panther-log-alert-forwarder
+      RetentionInDays: !Ref CloudWatchLogRetentionDays
+
+  AlertsForwarderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../../out/bin/internal/log_analysis/alert_forwarder/main
+      Description: Lambda for storing events from
+      Environment:
+        Variables:
+          DEBUG: !Ref Debug
+          ALERTS_TABLE: !Ref LogAlertsTable
+      Events:
+        DynamoDBEvent:
+          Type: DynamoDB
+          Properties:
+            Stream: !GetAtt LogAlertsTable.StreamArn
+            StartingPosition: TRIM_HORIZON
+            BatchSize: 10
+      FunctionName: panther-log-alert-forwarder
+      Handler: main
+      Layers: !If [AttachLayers, !Ref LayerVersionArns, !Ref 'AWS::NoValue']
+      MemorySize: 128
+      Runtime: go1.x
+      Timeout: 30
+      Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
+      Policies:
+        - Id: ReadTableStreams
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:DescribeStream
+                - dynamodb:GetRecords
+                - dynamodb:GetShardIterator
+                - dynamodb:ListStreams
+              Resource: !Sub ${LogAlertsTable.Arn}/stream/*
+
+        - Id: ManageAlerts
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:PutItem
+              Resource:
+                - !GetAtt LogAlertsTable.Arn
+
+

--- a/deployments/log_analysis/rules_engine.yml
+++ b/deployments/log_analysis/rules_engine.yml
@@ -124,6 +124,8 @@ Resources:
           KeyType: HASH
       SSESpecification:
         SSEEnabled: True
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
 
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -222,3 +224,8 @@ Resources:
             - Effect: Allow
               Action: execute-api:Invoke
               Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${AnalysisApiId}/v1/GET/enabled
+
+Outputs:
+  AlertDedupTableStreamArn:
+    Description: ARN of Alert Dedup table stream
+    Value: !GetAtt AlertsDedup.StreamArn

--- a/internal/core/alert_delivery/models/api.go
+++ b/internal/core/alert_delivery/models/api.go
@@ -56,7 +56,7 @@ type Alert struct {
 	// Tags is the set of policy tags.
 	Tags []*string `json:"tags,omitempty"`
 
-	// ID specifies the alertId that this Alert is associated with.
+	// AlertID specifies the alertId that this Alert is associated with.
 	AlertID *string `json:"alertId,omitempty"`
 
 	// Type specifies if an alert is for a policy or a rule

--- a/internal/core/alert_delivery/models/api.go
+++ b/internal/core/alert_delivery/models/api.go
@@ -56,7 +56,7 @@ type Alert struct {
 	// Tags is the set of policy tags.
 	Tags []*string `json:"tags,omitempty"`
 
-	// AlertID specifies the alertId that this Alert is associated with.
+	// ID specifies the alertId that this Alert is associated with.
 	AlertID *string `json:"alertId,omitempty"`
 
 	// Type specifies if an alert is for a policy or a rule

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -1,17 +1,5 @@
 package forwarder
 
-import (
-	"os"
-	"strconv"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"github.com/pkg/errors"
-)
-
 /**
  * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
  * Copyright (C) 2020 Panther Labs Inc
@@ -29,6 +17,19 @@ import (
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/pkg/errors"
+)
+
 var (
 	alertsTable                           = os.Getenv("ALERTS_TABLE")
 	awsSession                            = session.Must(session.NewSession())
@@ -44,18 +45,20 @@ func Process(event *AlertDedupEvent) error {
 		AlertDedupEvent: *event,
 	}
 
-	marshalledAlert, err := dynamodbattribute.MarshalMap(alert)
+	marshaledAlert, err := dynamodbattribute.MarshalMap(alert)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshall alert")
+		return errors.Wrap(err, "failed to marshal alert")
 	}
 	putItemRequest := &dynamodb.PutItemInput{
-		Item:      marshalledAlert,
+		Item:      marshaledAlert,
 		TableName: aws.String(alertsTable),
 	}
 	_, err = ddbClient.PutItem(putItemRequest)
 	if err != nil {
 		return errors.Wrap(err, "failed to update store alert")
 	}
+
+	//TODO Add logic that forwards messages to Alert Delivery SQS queue
 	return nil
 }
 

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -30,7 +30,7 @@ import (
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 var (
-	alertsTable                           = os.Getenv("RECENT_ALERTS_TABLE")
+	alertsTable                           = os.Getenv("ALERTS_TABLE")
 	awsSession                            = session.Must(session.NewSession())
 	ddbClient   dynamodbiface.DynamoDBAPI = dynamodb.New(awsSession)
 )

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -2,6 +2,7 @@ package forwarder
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -34,10 +35,13 @@ var (
 	ddbClient   dynamodbiface.DynamoDBAPI = dynamodb.New(awsSession)
 )
 
+const defaultTimePartition = "defaultPartition"
+
 func Process(event *AlertDedupEvent) error {
 	alert := &Alert{
 		ID:              generateAlertID(event),
-		AlertDedupEvent: &event,
+		TimePartition: defaultTimePartition,
+		AlertDedupEvent: *event,
 	}
 
 	marshalledAlert, err := dynamodbattribute.MarshalMap(alert)
@@ -56,5 +60,5 @@ func Process(event *AlertDedupEvent) error {
 }
 
 func generateAlertID(event *AlertDedupEvent) string {
-	return event.RuleID + "-" + event.DeduplicationString + "-" + string(event.AlertCount)
+	return event.RuleID + "-" + event.DeduplicationString + "-" + strconv.FormatInt(event.AlertCount, 10)
 }

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -1,0 +1,60 @@
+package forwarder
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/pkg/errors"
+)
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+var (
+	alertsTable                           = os.Getenv("RECENT_ALERTS_TABLE")
+	awsSession                            = session.Must(session.NewSession())
+	ddbClient   dynamodbiface.DynamoDBAPI = dynamodb.New(awsSession)
+)
+
+func Process(event *AlertDedupEvent) error {
+	alert := &Alert{
+		ID:              generateAlertID(event),
+		AlertDedupEvent: &event,
+	}
+
+	marshalledAlert, err := dynamodbattribute.MarshalMap(alert)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshall alert")
+	}
+	putItemRequest := &dynamodb.PutItemInput{
+		Item:      marshalledAlert,
+		TableName: aws.String(alertsTable),
+	}
+	_, err = ddbClient.PutItem(putItemRequest)
+	if err != nil {
+		return errors.Wrap(err, "failed to update store alert")
+	}
+	return nil
+}
+
+func generateAlertID(event *AlertDedupEvent) string {
+	return event.RuleID + "-" + event.DeduplicationString + "-" + string(event.AlertCount)
+}

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -40,7 +40,7 @@ const defaultTimePartition = "defaultPartition"
 func Process(event *AlertDedupEvent) error {
 	alert := &Alert{
 		ID:              generateAlertID(event),
-		TimePartition: defaultTimePartition,
+		TimePartition:   defaultTimePartition,
 		AlertDedupEvent: *event,
 	}
 
@@ -60,5 +60,5 @@ func Process(event *AlertDedupEvent) error {
 }
 
 func generateAlertID(event *AlertDedupEvent) string {
-	return event.RuleID + "-" + event.DeduplicationString + "-" + strconv.FormatInt(event.AlertCount, 10)
+	return event.RuleID + ":" + event.DeduplicationString + ":" + strconv.FormatInt(event.AlertCount, 10)
 }

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -1,5 +1,23 @@
 package forwarder
 
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import (
 	"errors"
 	"testing"
@@ -32,7 +50,7 @@ var testAlertDedupEvent = &AlertDedupEvent{
 	EventCount:          100,
 }
 
-func init(){
+func init() {
 	alertsTable = "alertsTable"
 }
 
@@ -42,7 +60,7 @@ func TestProcess(t *testing.T) {
 	ddbClient = ddbMock
 
 	expectedAlert := &Alert{
-		ID:              "ruleId-dedupString-10",
+		ID:              "ruleId:dedupString:10",
 		TimePartition:   "defaultPartition",
 		AlertDedupEvent: *testAlertDedupEvent,
 	}
@@ -51,14 +69,13 @@ func TestProcess(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedPutItemRequest := &dynamodb.PutItemInput{
-		Item: expectedMarshalledAlert,
+		Item:      expectedMarshalledAlert,
 		TableName: aws.String("alertsTable"),
 	}
 
 	ddbMock.On("PutItem", expectedPutItemRequest).Return(&dynamodb.PutItemOutput{}, nil)
 	assert.NoError(t, Process(testAlertDedupEvent))
 }
-
 
 // The handler signatures must match those in the LambdaInput struct.
 func TestProcessDDBError(t *testing.T) {

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -1,0 +1,70 @@
+package forwarder
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockDynamoDB struct {
+	dynamodbiface.DynamoDBAPI
+	mock.Mock
+}
+
+func (m *mockDynamoDB) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*dynamodb.PutItemOutput), args.Error(1)
+}
+
+var testAlertDedupEvent = &AlertDedupEvent{
+	RuleID:              "ruleId",
+	DeduplicationString: "dedupString",
+	AlertCount:          10,
+	CreationTime:        time.Now().UTC(),
+	UpdateTime:          time.Now().UTC(),
+	EventCount:          100,
+}
+
+func init(){
+	alertsTable = "alertsTable"
+}
+
+// The handler signatures must match those in the LambdaInput struct.
+func TestProcess(t *testing.T) {
+	ddbMock := &mockDynamoDB{}
+	ddbClient = ddbMock
+
+	expectedAlert := &Alert{
+		ID:              "ruleId-dedupString-10",
+		TimePartition:   "defaultPartition",
+		AlertDedupEvent: *testAlertDedupEvent,
+	}
+
+	expectedMarshalledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)
+	assert.NoError(t, err)
+
+	expectedPutItemRequest := &dynamodb.PutItemInput{
+		Item: expectedMarshalledAlert,
+		TableName: aws.String("alertsTable"),
+	}
+
+	ddbMock.On("PutItem", expectedPutItemRequest).Return(&dynamodb.PutItemOutput{}, nil)
+	assert.NoError(t, Process(testAlertDedupEvent))
+}
+
+
+// The handler signatures must match those in the LambdaInput struct.
+func TestProcessDDBError(t *testing.T) {
+	ddbMock := &mockDynamoDB{}
+	ddbClient = ddbMock
+
+	ddbMock.On("PutItem", mock.Anything).Return(&dynamodb.PutItemOutput{}, errors.New("error"))
+	assert.Error(t, Process(testAlertDedupEvent))
+}

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -65,11 +65,11 @@ func TestProcess(t *testing.T) {
 		AlertDedupEvent: *testAlertDedupEvent,
 	}
 
-	expectedMarshalledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)
+	expectedMarshaledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)
 	assert.NoError(t, err)
 
 	expectedPutItemRequest := &dynamodb.PutItemInput{
-		Item:      expectedMarshalledAlert,
+		Item:      expectedMarshaledAlert,
 		TableName: aws.String("alertsTable"),
 	}
 

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -33,11 +33,11 @@ type AlertDedupEvent struct {
 	CreationTime        time.Time `dynamodbav:"creationTime,string"`
 	UpdateTime          time.Time `dynamodbav:"updateTime,string"`
 	EventCount          int64     `dynamodbav:"eventCount,number"`
-	TimePartition       string    `dynamodbav:"timePartition,string"`
 }
 
 type Alert struct {
 	ID string `dynamodbav:"id,string"`
+	TimePartition       string    `dynamodbav:"timePartition,string"`
 	AlertDedupEvent
 }
 

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -1,0 +1,73 @@
+package forwarder
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/pkg/errors"
+)
+
+// AlertDedupEvent represents the event sent to the AlertProcessor by the compliance engine.
+type AlertDedupEvent struct {
+	RuleID              string    `dynamodbav:"ruleId,string"`
+	DeduplicationString string    `dynamodbav:"dedup,string"`
+	AlertCount          int64     `dynamodbav:"-"` // Not storing this field in DDB
+	CreationTime        time.Time `dynamodbav:"creationTime,string"`
+	UpdateTime          time.Time `dynamodbav:"updateTime,string"`
+	EventCount          int64     `dynamodbav:"eventCount,number"`
+	TimePartition       string    `dynamodbav:"timePartition,string"`
+}
+
+type Alert struct {
+	ID string `dynamodbav:"id,string"`
+	AlertDedupEvent
+}
+
+func FromDynamodDBAttribute(input map[string]events.DynamoDBAttributeValue) (*AlertDedupEvent, error) {
+	alertCount, err := input["alertCount"].Integer()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get 'alertCount'")
+	}
+
+	alertCreationEpoch, err := input["alertCreationTime"].Integer()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get 'alertCreationTime'")
+	}
+
+	alertUpdateEpoch, err := input["alertUpdateTime"].Integer()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get 'alertUpdateTime'")
+	}
+
+	eventCount, err := input["eventCount"].Integer()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get 'eventCount'")
+	}
+
+	return &AlertDedupEvent{
+		RuleID:              input["ruleId"].String(),
+		DeduplicationString: input["dedup"].String(),
+		AlertCount:          alertCount,
+		CreationTime:        time.Unix(alertCreationEpoch, 0),
+		UpdateTime:          time.Unix(alertUpdateEpoch, 0),
+		EventCount:          eventCount,
+	}, nil
+}

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AlertDedupEvent represents the event sent to the AlertProcessor by the compliance engine.
+// AlertDedupEvent represents the event stored in the alert dedup DDB table by the rules engine
 type AlertDedupEvent struct {
 	RuleID              string    `dynamodbav:"ruleId,string"`
 	DeduplicationString string    `dynamodbav:"dedup,string"`

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -77,8 +77,8 @@ func FromDynamodDBAttribute(input map[string]events.DynamoDBAttributeValue) (*Al
 		RuleID:              ruleID.String(),
 		DeduplicationString: deduplicationString.String(),
 		AlertCount:          alertCount,
-		CreationTime:        time.Unix(alertCreationEpoch, 0),
-		UpdateTime:          time.Unix(alertUpdateEpoch, 0),
+		CreationTime:        time.Unix(alertCreationEpoch, 0).UTC(),
+		UpdateTime:          time.Unix(alertUpdateEpoch, 0).UTC(),
 		EventCount:          eventCount,
 	}, nil
 }
@@ -96,7 +96,7 @@ func getIntegerAttribute(key string, input map[string]events.DynamoDBAttributeVa
 }
 
 func getAttribute(key string, inputMap map[string]events.DynamoDBAttributeValue) (events.DynamoDBAttributeValue, error) {
-	attributeValue, ok := inputMap["alertCount"]
+	attributeValue, ok := inputMap[key]
 	if !ok {
 		return events.DynamoDBAttributeValue{}, errors.Errorf("could not find '%s' attribute", key)
 	}

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -35,9 +35,10 @@ type AlertDedupEvent struct {
 	EventCount          int64     `dynamodbav:"eventCount,number"`
 }
 
+// Alert contains all the fields associated to the alert stored in DDB
 type Alert struct {
-	ID string `dynamodbav:"id,string"`
-	TimePartition       string    `dynamodbav:"timePartition,string"`
+	ID            string `dynamodbav:"id,string"`
+	TimePartition string `dynamodbav:"timePartition,string"`
 	AlertDedupEvent
 }
 

--- a/internal/log_analysis/alert_forwarder/forwarder/models_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestConvertAttribute(t *testing.T) {
 	expectedAlertDedup := &AlertDedupEvent{
 		RuleID:              "testRuleId",
@@ -41,7 +40,6 @@ func TestConvertAttribute(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedAlertDedup, alertDedupEvent)
 }
-
 
 func TestMissingRuleId(t *testing.T) {
 	testInput := getNewTestCase()
@@ -93,7 +91,7 @@ func TestMissingEventCount(t *testing.T) {
 
 func TestInvalidInteger(t *testing.T) {
 	testInput := getNewTestCase()
-	testInput["alertCreationTime"] =  events.NewNumberAttribute("notaninteger")
+	testInput["alertCreationTime"] = events.NewNumberAttribute("notaninteger")
 	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
 	require.Nil(t, alertDedupEvent)
 	require.Error(t, err)

--- a/internal/log_analysis/alert_forwarder/forwarder/models_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models_test.go
@@ -1,0 +1,111 @@
+package forwarder
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+
+func TestConvertAttribute(t *testing.T) {
+	expectedAlertDedup := &AlertDedupEvent{
+		RuleID:              "testRuleId",
+		DeduplicationString: "testDedup",
+		AlertCount:          10,
+		CreationTime:        time.Unix(1582285279, 0).UTC(),
+		UpdateTime:          time.Unix(1582285280, 0).UTC(),
+		EventCount:          100,
+	}
+
+	alertDedupEvent, err := FromDynamodDBAttribute(getNewTestCase())
+	require.NoError(t, err)
+	require.Equal(t, expectedAlertDedup, alertDedupEvent)
+}
+
+
+func TestMissingRuleId(t *testing.T) {
+	testInput := getNewTestCase()
+	delete(testInput, "ruleId")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func TestMissingDedup(t *testing.T) {
+	testInput := getNewTestCase()
+	delete(testInput, "dedup")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func TestMissingAlertCount(t *testing.T) {
+	testInput := getNewTestCase()
+	delete(testInput, "alertCount")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func TestMissingAlertCreationTime(t *testing.T) {
+	testInput := getNewTestCase()
+	delete(testInput, "alertCreationTime")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func TestMissingAlertUpdateTime(t *testing.T) {
+	testInput := getNewTestCase()
+	delete(testInput, "alertUpdateTime")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func TestMissingEventCount(t *testing.T) {
+	testInput := getNewTestCase()
+	delete(testInput, "eventCount")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func TestInvalidInteger(t *testing.T) {
+	testInput := getNewTestCase()
+	testInput["alertCreationTime"] =  events.NewNumberAttribute("notaninteger")
+	alertDedupEvent, err := FromDynamodDBAttribute(testInput)
+	require.Nil(t, alertDedupEvent)
+	require.Error(t, err)
+}
+
+func getNewTestCase() map[string]events.DynamoDBAttributeValue {
+	return map[string]events.DynamoDBAttributeValue{
+		"ruleId":            events.NewStringAttribute("testRuleId"),
+		"dedup":             events.NewStringAttribute("testDedup"),
+		"alertCount":        events.NewNumberAttribute("10"),
+		"alertCreationTime": events.NewNumberAttribute("1582285279"),
+		"alertUpdateTime":   events.NewNumberAttribute("1582285280"),
+		"eventCount":        events.NewNumberAttribute("100"),
+	}
+}

--- a/internal/log_analysis/alert_forwarder/main/lambda.go
+++ b/internal/log_analysis/alert_forwarder/main/lambda.go
@@ -24,13 +24,10 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/pkg/errors"
-	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/panther-labs/panther/internal/log_analysis/alert_forwarder/forwarder"
 	"github.com/panther-labs/panther/pkg/lambdalogger"
 )
-
-var validate = validator.New()
 
 func main() {
 	lambda.Start(reporterHandler)

--- a/internal/log_analysis/alert_forwarder/main/lambda.go
+++ b/internal/log_analysis/alert_forwarder/main/lambda.go
@@ -37,7 +37,7 @@ func reporterHandler(ctx context.Context, event events.DynamoDBEvent) error {
 	lambdalogger.ConfigureGlobal(ctx, nil)
 
 	for _, record := range event.Records {
-		event, err := forwarder.FromDynamodDBAttribute(record.Change.OldImage)
+		event, err := forwarder.FromDynamodDBAttribute(record.Change.NewImage)
 		if err != nil {
 			return errors.Wrap(err, "failed to unmarshall new image")
 		}

--- a/internal/log_analysis/alert_forwarder/main/lambda.go
+++ b/internal/log_analysis/alert_forwarder/main/lambda.go
@@ -47,13 +47,12 @@ func reporterHandler(lc *lambdacontext.LambdaContext, event events.DynamoDBEvent
 		operation.Stop().Log(err, zap.Int("messageCount", len(event.Records)))
 	}()
 
-
 	for _, record := range event.Records {
 		event, err := forwarder.FromDynamodDBAttribute(record.Change.NewImage)
 		if err != nil {
 			return errors.Wrap(err, "failed to unmarshal new image")
 		}
-
+		// Note that if there is an error in processing any of the messages in the batch, the whole batch will be retried.
 		if err = forwarder.Process(event); err != nil {
 			return errors.Wrap(err, "encountered issue while handling event")
 		}

--- a/internal/log_analysis/alert_forwarder/main/lambda.go
+++ b/internal/log_analysis/alert_forwarder/main/lambda.go
@@ -1,0 +1,53 @@
+package main
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/pkg/errors"
+	"gopkg.in/go-playground/validator.v9"
+
+	"github.com/panther-labs/panther/internal/log_analysis/alert_forwarder/forwarder"
+	"github.com/panther-labs/panther/pkg/lambdalogger"
+)
+
+var validate = validator.New()
+
+func main() {
+	lambda.Start(reporterHandler)
+}
+
+func reporterHandler(ctx context.Context, event events.DynamoDBEvent) error {
+	lambdalogger.ConfigureGlobal(ctx, nil)
+
+	for _, record := range event.Records {
+		event, err := forwarder.FromDynamodDBAttribute(record.Change.OldImage)
+		if err != nil {
+			return errors.Wrap(err, "failed to unmarshall new image")
+		}
+
+		if err := forwarder.Process(event); err != nil {
+			return errors.Wrap(err, "encountered issue while handling event")
+		}
+	}
+	return nil
+}

--- a/internal/log_analysis/alert_forwarder/main/lambda.go
+++ b/internal/log_analysis/alert_forwarder/main/lambda.go
@@ -50,7 +50,9 @@ func reporterHandler(lc *lambdacontext.LambdaContext, event events.DynamoDBEvent
 	for _, record := range event.Records {
 		event, err := forwarder.FromDynamodDBAttribute(record.Change.NewImage)
 		if err != nil {
-			return errors.Wrap(err, "failed to unmarshal new image")
+			operation.LogError(errors.Wrapf(err, "failed to unmarshal item"))
+			// continuing since there is nothing we can do here
+			continue
 		}
 		// Note that if there is an error in processing any of the messages in the batch, the whole batch will be retried.
 		if err = forwarder.Process(event); err != nil {

--- a/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo.go
+++ b/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo.go
@@ -19,9 +19,9 @@ package osseclogs
  */
 
 import (
+	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )

--- a/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo_test.go
+++ b/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo_test.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )
 
 func TestEventInfo(t *testing.T) {


### PR DESCRIPTION
## Background

This PR introduces the Alert forwarder Lambda. This Lambda listens for changes in the `panther-alert-dedup` table. `panther-alert-dedup` table is used for alert deduplication 

The Lambda takes the DDB update and stores the associated information on the `panther-log-alerts-info` table. This table will eventually replace `panther-log-alerts` table. 

Closes #183 

## Changes

- Added new Lambda and DDB table. 

## Testing

- Unit tests
- Deployed in my account
