### PR TITLE
Added setAuthenticated when users verify their MFA for the first time

### DIFF
--- a/web/src/components/utils/auth-context.tsx
+++ b/web/src/components/utils/auth-context.tsx
@@ -281,10 +281,10 @@ const AuthProvider: React.FC = ({ children }) => {
       try {
         await Auth.verifyTotpToken(authUser, mfaCode);
         await Auth.setPreferredMFA(authUser, 'TOTP');
-
-        const userWithMFA = await Auth.currentAuthenticatedUser();
-        setAuthUser(userWithMFA);
-
+        // NOTE: User is confirmed at this point so we can go ahead an logged in here
+        const confirmedUser = await Auth.currentAuthenticatedUser();
+        setAuthUser(confirmedUser);
+        setAuthenticated(true);
         onSuccess();
       } catch (err) {
         onError(err as AuthError);

--- a/web/src/components/utils/auth-context.tsx
+++ b/web/src/components/utils/auth-context.tsx
@@ -281,7 +281,7 @@ const AuthProvider: React.FC = ({ children }) => {
       try {
         await Auth.verifyTotpToken(authUser, mfaCode);
         await Auth.setPreferredMFA(authUser, 'TOTP');
-        // NOTE: User is confirmed at this point so we can go ahead an logged in here
+        // NOTE: User is confirmed at this point so we can go ahead and log in user here
         const confirmedUser = await Auth.currentAuthenticatedUser();
         setAuthUser(confirmedUser);
         setAuthenticated(true);


### PR DESCRIPTION
## Background

- First time users had to re-enter email/pass and MFA the first time the login in UI

This PR resolves this #142 

## Changes

- Added authenticated as true when a first time users MFA is verified

## Testing

- Locally
