### PR TITLE
Add memo to key components

### DIFF
--- a/web/src/components/utils/auth-context.tsx
+++ b/web/src/components/utils/auth-context.tsx
@@ -159,7 +159,7 @@ const previousUserSessionExists = Boolean(
   )
 );
 
-const AuthProvider: React.FC = ({ children }) => {
+const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Stores whether the system should consider the current user as logged-in or not. This can be
   // true without `authUser` being present, since `authUser` comes asynchronously from Cognito, thus
   // it's *always* initially `null`.
@@ -458,4 +458,6 @@ const AuthProvider: React.FC = ({ children }) => {
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
 };
 
-export { AuthContext, AuthProvider };
+const MemoizedAuthProvider = React.memo(AuthProvider);
+
+export { AuthContext, MemoizedAuthProvider as AuthProvider };

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -114,4 +114,4 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
   );
 };
 
-export default PrimaryPageLayout;
+export default React.memo(PrimaryPageLayout);


### PR DESCRIPTION
## Background

Small perf optimization in order to skip un-necessary re-renders. Will save a few `ms` of CPU time in certain user actions

## Changes

- Add component memoization in `AuthProvider` and `Routes`

## Testing

- Locally
