### PR TITLE
Catching currentSession error and returning null jwtToken

### DIFF
--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -72,7 +72,10 @@ const authLink = (createAuthLink({
   region: process.env.AWS_REGION,
   url: process.env.WEB_APPLICATION_GRAPHQL_API_ENDPOINT,
   auth: {
-    jwtToken: () => Auth.currentSession().then(session => session.getIdToken().getJwtToken()),
+    jwtToken: () =>
+      Auth.currentSession()
+        .then(session => session.getIdToken().getJwtToken())
+        .catch(() => null),
     type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
   },
 }) as unknown) as ApolloLink;


### PR DESCRIPTION
## Background

Loading UI with no session throws an unhandled rejection for Auth.currentSession()

## Changes

- Catching error and returning null jwtToken

## Testing

- Run locally with clear cache no error should be thrown 