### PR TITLE
v0.3.0 release

### DIFF
--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -87,7 +87,7 @@ Run Panther in 3 easy steps: clone the repo, install docker, and deploy!
 First, clone the latest release of the [Panther repo](https://github.com/panther-labs/panther):
 
 ```bash
-git clone https://github.com/panther-labs/panther --depth 1 --branch v0.2.0
+git clone https://github.com/panther-labs/panther --depth 1 --branch v0.3.0
 cd panther
 ```
 

--- a/tools/mage/util.go
+++ b/tools/mage/util.go
@@ -19,6 +19,7 @@ package mage
  */
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -164,12 +165,12 @@ func invokeLambda(awsSession *session.Session, functionName string, input interf
 
 // Prompt the user for a string input.
 func promptUser(prompt string, validator func(string) error) string {
-	var result string
-
+	reader := bufio.NewReader(os.Stdin)
 	for {
 		fmt.Print(prompt)
-		if n, err := fmt.Scanln(&result); err != nil && n != 0 { // n==0 on empty lines, handled below in validator
-			fmt.Println(err)
+		result, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("read string failed: %v\n", err)
 			continue
 		}
 

--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -72,10 +72,7 @@ const authLink = (createAuthLink({
   region: process.env.AWS_REGION,
   url: process.env.WEB_APPLICATION_GRAPHQL_API_ENDPOINT,
   auth: {
-    jwtToken: () =>
-      Auth.currentSession()
-        .then(session => session.getIdToken().getJwtToken())
-        .catch(() => null),
+    jwtToken: () => Auth.currentSession().then(session => session.getIdToken().getJwtToken()),
     type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
   },
 }) as unknown) as ApolloLink;


### PR DESCRIPTION
## Background
A few critical fixes before releasing v0.3.0, found during QA testing

## Changes

- Update documentation to reference 0.3.0 as the latest version
    - We should consider making a `stable` tag or similar that follows the latest release
- Revert #250 - it breaks the login flow (I was not ever able to login to a fresh deployment)
- Allow spaces in user input during first-time setup (e.g. company name = "Panther Labs")

## Testing

- Deployed fresh to dev account, logged in, viewed/edited policies, reset password, invited more users, etc
