### PR TITLE
users-api: prevent deleting last user and move pagination to backend

### DIFF
--- a/api/lambda/users/models/api.go
+++ b/api/lambda/users/models/api.go
@@ -51,15 +51,11 @@ type InviteUserOutput struct {
 }
 
 // ListUsersInput lists all users in Panther.
-type ListUsersInput struct {
-	Limit           *int64  `json:"limit" validate:"omitempty,min=1"`
-	PaginationToken *string `json:"paginationToken" validate:"omitempty,min=1"`
-}
+type ListUsersInput struct{}
 
 // ListUsersOutput returns a page of users.
 type ListUsersOutput struct {
-	Users           []*User `json:"users"`
-	PaginationToken *string `json:"paginationToken"`
+	Users []*User `json:"users"`
 }
 
 // RemoveUserInput deletes a user.

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9 // indirect
-	golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 // indirect
+	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/russross/blackfriday.v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -270,14 +270,8 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200204230316-67a4523381ef h1:mdhEDFpO1Tfj7PXIflIuP1tbXt4rJgHIvbzdh62SARw=
-golang.org/x/tools v0.0.0-20200204230316-67a4523381ef/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17 h1:a/Fd23DJvg1CaeDH0dYHahE+hCI0v9rFgxSNIThoUcM=
-golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7 h1:SWKaJjEEnIUqoSX43gli3maUBM+1QSfJVGHfmeeQlFg=
-golang.org/x/tools v0.0.0-20200212211505-6dd6151793f7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 h1:90L2fHeLQmQFe04F648NKZE5sQP/M/6CjHcjtM7jP5U=
-golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd h1:hHkvGJK23seRCflePJnVa9IMv8fsuavSCWKd11kDQFs=
+golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/core/users_api/api/list_users.go
+++ b/internal/core/users_api/api/list_users.go
@@ -21,14 +21,11 @@ package api
 import "github.com/panther-labs/panther/api/lambda/users/models"
 
 // ListUsers lists details for each user in Panther.
-func (API) ListUsers(input *models.ListUsersInput) (*models.ListUsersOutput, error) {
-	listOutput, err := userGateway.ListUsers(input.Limit, input.PaginationToken)
+func (API) ListUsers(*models.ListUsersInput) (*models.ListUsersOutput, error) {
+	users, err := userGateway.ListUsers()
 	if err != nil {
 		return nil, err
 	}
 
-	return &models.ListUsersOutput{
-		Users:           listOutput.Users,
-		PaginationToken: listOutput.PaginationToken,
-	}, nil
+	return &models.ListUsersOutput{Users: users}, nil
 }

--- a/internal/core/users_api/api/list_users_test.go
+++ b/internal/core/users_api/api/list_users_test.go
@@ -34,42 +34,33 @@ type mockGatewayListUsersClient struct {
 	listUserGatewayErr bool
 }
 
-func (m *mockGatewayListUsersClient) ListUsers(limit *int64, paginationToken *string) (*gateway.ListUsersOutput, error) {
+func (m *mockGatewayListUsersClient) ListUsers() ([]*models.User, error) {
 	if m.listUserGatewayErr {
 		return nil, &genericapi.AWSError{}
 	}
 
-	return &gateway.ListUsersOutput{
-		Users: []*models.User{
-			{
-				GivenName:  aws.String("Joe"),
-				FamilyName: aws.String("Blow"),
-				ID:         aws.String("user123"),
-				Email:      aws.String("joe@blow.com"),
-				CreatedAt:  aws.Int64(1545442826),
-				Status:     aws.String("CONFIRMED"),
-			},
+	return []*models.User{
+		{
+			GivenName:  aws.String("Joe"),
+			FamilyName: aws.String("Blow"),
+			ID:         aws.String("user123"),
+			Email:      aws.String("joe@blow.com"),
+			CreatedAt:  aws.Int64(1545442826),
+			Status:     aws.String("CONFIRMED"),
 		},
-		PaginationToken: paginationToken,
 	}, nil
 }
 
 func TestListUsersGatewayErr(t *testing.T) {
 	userGateway = &mockGatewayListUsersClient{listUserGatewayErr: true}
-	result, err := (API{}).ListUsers(&models.ListUsersInput{
-		Limit:           aws.Int64(10),
-		PaginationToken: aws.String("paginationToken"),
-	})
+	result, err := (API{}).ListUsers(&models.ListUsersInput{})
 	assert.Nil(t, result)
 	assert.Error(t, err)
 }
 
 func TestListUsersHandle(t *testing.T) {
 	userGateway = &mockGatewayListUsersClient{}
-	result, err := (API{}).ListUsers(&models.ListUsersInput{
-		Limit:           aws.Int64(10),
-		PaginationToken: aws.String("paginationToken"),
-	})
+	result, err := (API{}).ListUsers(&models.ListUsersInput{})
 	assert.NotNil(t, result)
 	assert.NoError(t, err)
 }

--- a/internal/core/users_api/api/remove_user.go
+++ b/internal/core/users_api/api/remove_user.go
@@ -33,7 +33,7 @@ func (API) RemoveUser(input *models.RemoveUserInput) error {
 		return err
 	}
 
-	if len(users) == 0 {
+	if len(users) == 1 {
 		return &genericapi.InUseError{Message: "can't delete the last user"}
 	}
 

--- a/internal/core/users_api/api/remove_user.go
+++ b/internal/core/users_api/api/remove_user.go
@@ -19,7 +19,6 @@ package api
  */
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/users/models"
@@ -28,13 +27,13 @@ import (
 
 // RemoveUser deletes a user from cognito.
 func (API) RemoveUser(input *models.RemoveUserInput) error {
-	list, err := userGateway.ListUsers(aws.Int64(1), nil)
+	users, err := userGateway.ListUsers()
 	if err != nil {
 		zap.L().Error("error listing users", zap.Error(err))
 		return err
 	}
 
-	if len(list.Users) == 0 {
+	if len(users) == 0 {
 		return &genericapi.InUseError{Message: "can't delete the last user"}
 	}
 

--- a/internal/core/users_api/api/remove_user_test.go
+++ b/internal/core/users_api/api/remove_user_test.go
@@ -39,8 +39,7 @@ func TestRemoveUserCognitoErr(t *testing.T) {
 	// replace the global variables with our mock objects
 	userGateway = mockGateway
 
-	mockGateway.On("ListUsers", aws.Int64(1), (*string)(nil)).Return(
-		&gateway.ListUsersOutput{Users: make([]*models.User, 3)}, nil)
+	mockGateway.On("ListUsers").Return(make([]*models.User, 3), nil)
 	mockGateway.On("DeleteUser", removeUserInput.ID).Return(&genericapi.AWSError{})
 
 	err := (API{}).RemoveUser(removeUserInput)
@@ -54,8 +53,7 @@ func TestRemoveLastUser(t *testing.T) {
 	mockGateway := &gateway.MockUserGateway{}
 	userGateway = mockGateway
 
-	mockGateway.On("ListUsers", aws.Int64(1), (*string)(nil)).Return(
-		&gateway.ListUsersOutput{Users: nil}, nil)
+	mockGateway.On("ListUsers").Return(make([]*models.User, 0), nil)
 
 	err := (API{}).RemoveUser(removeUserInput)
 	assert.Error(t, err)
@@ -67,8 +65,7 @@ func TestRemoveUserHandle(t *testing.T) {
 	mockGateway := &gateway.MockUserGateway{}
 	userGateway = mockGateway
 
-	mockGateway.On("ListUsers", aws.Int64(1), (*string)(nil)).Return(
-		&gateway.ListUsersOutput{Users: make([]*models.User, 3)}, nil)
+	mockGateway.On("ListUsers").Return(make([]*models.User, 3), nil)
 	mockGateway.On("DeleteUser", removeUserInput.ID).Return(nil)
 
 	assert.NoError(t, (API{}).RemoveUser(removeUserInput))

--- a/internal/core/users_api/api/remove_user_test.go
+++ b/internal/core/users_api/api/remove_user_test.go
@@ -53,7 +53,7 @@ func TestRemoveLastUser(t *testing.T) {
 	mockGateway := &gateway.MockUserGateway{}
 	userGateway = mockGateway
 
-	mockGateway.On("ListUsers").Return(make([]*models.User, 0), nil)
+	mockGateway.On("ListUsers").Return(make([]*models.User, 1), nil)
 
 	err := (API{}).RemoveUser(removeUserInput)
 	assert.Error(t, err)

--- a/internal/core/users_api/gateway/list_users_test.go
+++ b/internal/core/users_api/gateway/list_users_test.go
@@ -34,14 +34,16 @@ type mockListUsersClient struct {
 	serviceErr bool
 }
 
-func (m *mockListUsersClient) ListUsers(
-	*provider.ListUsersInput) (*provider.ListUsersOutput, error) {
+func (m *mockListUsersClient) ListUsersPages(
+	input *provider.ListUsersInput,
+	pager func(*provider.ListUsersOutput, bool) bool,
+) error {
 
 	if m.serviceErr {
-		return nil, errors.New("cognito does not exist")
+		return errors.New("cognito does not exist")
 	}
 
-	return &provider.ListUsersOutput{
+	pager(&provider.ListUsersOutput{
 		Users: []*provider.UserType{
 			{
 				Attributes: []*provider.AttributeType{
@@ -65,26 +67,20 @@ func (m *mockListUsersClient) ListUsers(
 				UserStatus:           aws.String("CONFIRMED"),
 			},
 		},
-		PaginationToken: aws.String("token123"),
-	}, nil
+	}, true)
+	return nil
 }
 
 func TestListUsers(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockListUsersClient{}}
-	result, err := gw.ListUsers(
-		aws.Int64(10),
-		aws.String("paginationToken"),
-	)
+	result, err := gw.ListUsers()
 	assert.NotNil(t, result)
 	assert.NoError(t, err)
 }
 
 func TestListUsersFailed(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockListUsersClient{serviceErr: true}}
-	result, err := gw.ListUsers(
-		aws.Int64(10),
-		aws.String("paginationToken"),
-	)
+	result, err := gw.ListUsers()
 	assert.Nil(t, result)
 	assert.Error(t, err)
 }

--- a/internal/core/users_api/gateway/mock_gateway.go
+++ b/internal/core/users_api/gateway/mock_gateway.go
@@ -53,9 +53,9 @@ func (m *MockUserGateway) GetUser(id *string) (*models.User, error) {
 }
 
 // ListUsers mocks ListUsers for testing
-func (m *MockUserGateway) ListUsers(limit *int64, paginationToken *string) (*ListUsersOutput, error) {
-	args := m.Called(limit, paginationToken)
-	return args.Get(0).(*ListUsersOutput), args.Error(1)
+func (m *MockUserGateway) ListUsers() ([]*models.User, error) {
+	args := m.Called()
+	return args.Get(0).([]*models.User), args.Error(1)
 }
 
 // ResetUserPassword mocks ResetUserPassword for testing

--- a/internal/core/users_api/gateway/users_gateway.go
+++ b/internal/core/users_api/gateway/users_gateway.go
@@ -35,7 +35,7 @@ type API interface {
 	CreateUser(input *CreateUserInput) (*string, error)
 	DeleteUser(id *string) error
 	GetUser(id *string) (*models.User, error)
-	ListUsers(limit *int64, paginationToken *string) (*ListUsersOutput, error)
+	ListUsers() ([]*models.User, error)
 	ResetUserPassword(id *string) error
 	UpdateUser(input *UpdateUserInput) error
 }

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -242,7 +242,7 @@ func postDeploySetup(awsSession *session.Session, backendOutputs map[string]stri
 // If the users list is empty (e.g. on the initial deploy), create the first user.
 func inviteFirstUser(awsSession *session.Session) error {
 	input := &usermodels.LambdaInput{
-		ListUsers: &usermodels.ListUsersInput{Limit: aws.Int64(1)},
+		ListUsers: &usermodels.ListUsersInput{},
 	}
 	var output usermodels.ListUsersOutput
 	if err := invokeLambda(awsSession, "panther-users-api", input, &output); err != nil {


### PR DESCRIPTION
## Background
Some small changes to the `users-api`, following up from #213 

Closes #217 

## Changes

- The `users-api` service will refuse a user deletion request if that user is the last one remaining
- The `limit` and `paging` info in the `ListUsers` endpoint has been removed
    - There will almost certainly only ever be 1 page of users, the frontend does not and will not add paging here. In the rare event we do need to page over the results, the backend handles this before returning

## Testing

- Deployed to dev account, was able to list users but not able to delete myself (because I was the only user)

![Screen Shot 2020-02-21 at 5 17 05 PM](https://user-images.githubusercontent.com/3608925/75083504-001b3280-54ce-11ea-80c0-277f5aada9b4.png)

(we may want a more helpful error message)
