### PR TITLE
Update docs for OSSEC.EventInfo logs

### DIFF
--- a/docs/gitbook/log-analysis/supported-logs/README.md
+++ b/docs/gitbook/log-analysis/supported-logs/README.md
@@ -34,11 +34,19 @@ AWS contains a variety of critical data sources used to audit API usage, databas
 
 ## [Nginx](https://github.com/panther-labs/panther/tree/master/internal/log_analysis/log_processor/parsers/nginxlogs)
 
-[Nginx](https://www.nginx.com/y) is a powerful open source web server. Nginx logs are configurable, Panther supports the NCSA combined log file format for Access logs.
+[Nginx](https://www.nginx.com/) is a powerful open source web server. Nginx logs are configurable, Panther supports the NCSA combined log file format for Access logs.
 
 | Log Type       | Reference                                              |
 | -------------- | ------------------------------------------------------ |
 | `Nginx.Access` | http://nginx.org/en/docs/http/ngx_http_log_module.html |
+
+## [OSSEC](https://github.com/panther-labs/panther/tree/master/internal/log_analysis/log_processor/parsers/osseclogs)
+
+[OSSEC](https://www.ossec.net/) is a widely used open source host intrusion detection system. Panther supports the JSON alerts.json log file format for OSSEC EventInfo alerts.
+
+| Log Type          | Reference                                              |
+| ----------------- | ------------------------------------------------------ |
+| `OSSEC.EventInfo` | https://www.ossec.net/docs/docs/formats/alerts.html    |
 
 ## Built-in Rule Packs
 


### PR DESCRIPTION
## Background

A new parser was introduced in #215, updating the supported-logs docs.

## Changes

* Add section for OSSEC logs to supported-logs
* Fixed typo in nginx url

## Testing

- Verified the URLs point to the correct resources
- Ran `mage test:ci` for spell checks
