### PR TITLE
Safeguard pathname when referrer in undefined on guarded-route

### DIFF
--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -72,7 +72,10 @@ const authLink = (createAuthLink({
   region: process.env.AWS_REGION,
   url: process.env.WEB_APPLICATION_GRAPHQL_API_ENDPOINT,
   auth: {
-    jwtToken: () => Auth.currentSession().then(session => session.getIdToken().getJwtToken()),
+    jwtToken: () =>
+      Auth.currentSession()
+        .then(session => session.getIdToken().getJwtToken())
+        .catch(() => null),
     type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
   },
 }) as unknown) as ApolloLink;

--- a/web/src/components/guarded-route.tsx
+++ b/web/src/components/guarded-route.tsx
@@ -64,7 +64,7 @@ const GuardedRoute: React.FC<GuardedRouteProps> = ({ limitAccessTo, ...rest }) =
     // referrer will exist)
   } else {
     redirectData = {
-      pathname: location?.state?.referrer.pathname || '/',
+      pathname: location?.state?.referrer?.pathname || '/',
       state: undefined,
     };
   }


### PR DESCRIPTION
## Background

- Fixing issue with login getting an exception

## Changes

- Checking referrer exists before access pathname

## Testing

- Locally:
a. Login with newly invited user
b. Logout and re-login
c. Login in a clean browser

Closes #229 
