### PR TITLE
Move prompt controller to authenticated section

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -23,7 +23,6 @@ import Routes from 'Source/routes';
 import { History } from 'history';
 import { ApolloProvider } from '@apollo/client';
 import { AuthProvider } from 'Components/utils/auth-context';
-import PromptController from 'Components/utils/prompt-controller';
 import { ModalProvider } from 'Components/utils/modal-context';
 import { SidesheetProvider } from 'Components/utils/sidesheet-context';
 import ModalManager from 'Components/utils/modal-manager';
@@ -48,7 +47,6 @@ const App: React.FC<AppProps> = ({ history }) => {
                     <Routes />
                     <ModalManager />
                     <SidesheetManager />
-                    <PromptController />
                   </SnackbarProvider>
                 </ModalProvider>
               </SidesheetProvider>

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -45,6 +45,7 @@ import ForgotPasswordConfirmPage from 'Pages/forgot-password-confirm';
 import ErrorBoundary from 'Components/error-boundary';
 import Page404 from 'Pages/404';
 import APIErrorFallback from 'Components/utils/api-error-fallback';
+import PromptController from 'Components/utils/prompt-controller';
 
 // Main page container for the web application, Navigation bar and Content body goes here
 const PrimaryPageLayout: React.FunctionComponent = () => {
@@ -109,6 +110,7 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
             </APIErrorFallback>
           </ErrorBoundary>
         </Layout>
+        <PromptController />
       </GuardedRoute>
     </Switch>
   );


### PR DESCRIPTION
## Background

Currently, we perform API calls to check for user error reporting consents even when the user is not authenticated. This PR moves the component in the "authenticated user" part of the app, in order to only fire if the user is authenticated

## Changes

- Move `PromptController` component

## Testing

- Observed XHR requests remotely & locally
