### PR TITLE
Fix radio buttons on policy tests

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -23,7 +23,6 @@ import Routes from 'Source/routes';
 import { History } from 'history';
 import { ApolloProvider } from '@apollo/client';
 import { AuthProvider } from 'Components/utils/auth-context';
-import PromptController from 'Components/utils/prompt-controller';
 import { ModalProvider } from 'Components/utils/modal-context';
 import { SidesheetProvider } from 'Components/utils/sidesheet-context';
 import ModalManager from 'Components/utils/modal-manager';
@@ -48,7 +47,6 @@ const App: React.FC<AppProps> = ({ history }) => {
                     <Routes />
                     <ModalManager />
                     <SidesheetManager />
-                    <PromptController />
                   </SnackbarProvider>
                 </ModalProvider>
               </SidesheetProvider>

--- a/web/src/components/fields/checkbox.tsx
+++ b/web/src/components/fields/checkbox.tsx
@@ -20,14 +20,11 @@ import React from 'react';
 import { Checkbox, CheckboxProps } from 'pouncejs';
 import { FieldConfig, useField } from 'formik';
 
-const MemoizedCheckbox = React.memo(Checkbox);
-
 const FormikCheckbox: React.FC<CheckboxProps & Required<Pick<FieldConfig, 'name'>>> = props => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [field, meta, { setValue }] = useField<boolean>(props.name);
 
-  const onChange = React.useMemo(() => setValue, []);
-  return <MemoizedCheckbox {...props} checked={field.value} onChange={onChange} />;
+  return <Checkbox {...props} checked={field.value} onChange={setValue} />;
 };
 
 export default FormikCheckbox;

--- a/web/src/components/fields/radio.tsx
+++ b/web/src/components/fields/radio.tsx
@@ -20,16 +20,17 @@ import React from 'react';
 import { Radio, RadioProps } from 'pouncejs';
 import { FieldConfig, useField } from 'formik';
 
-const MemoizedRadio = React.memo(Radio);
-
 const FormikRadio: React.FC<RadioProps & Required<Pick<FieldConfig, 'name' | 'value'>>> = props => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [field, meta, { setValue }] = useField(props.name);
 
-  // Here `props.value` is the value that the radio button should have according to the typical HTML
-  // and not the value that will be forced into Formik
-  const onChange = React.useMemo(() => () => setValue(props.value), [props.value]);
-  return <MemoizedRadio {...props} checked={field.value === props.value} onChange={onChange} />;
+  return (
+    <Radio
+      {...props}
+      checked={field.value === props.value}
+      onChange={() => setValue(props.value)}
+    />
+  );
 };
 
 export default FormikRadio;

--- a/web/src/components/fields/switch.tsx
+++ b/web/src/components/fields/switch.tsx
@@ -20,17 +20,11 @@ import React from 'react';
 import { Switch, SwitchProps } from 'pouncejs';
 import { FieldConfig, useField } from 'formik';
 
-const MemoizedSwitch = React.memo(Switch);
-
 const FormikSwitch: React.FC<SwitchProps & Required<Pick<FieldConfig, 'name'>>> = props => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [field, meta, { setValue }] = useField<boolean>(props.name);
 
-  // we are memoizing the reference of `setValue` so that our Switch component doesn't
-  // un-necessarily re-render on different field changes
-  // https://github.com/jaredpalmer/formik/issues/2268
-  const onChange = React.useMemo(() => setValue, []);
-  return <MemoizedSwitch {...props} checked={field.value} onChange={onChange} />;
+  return <Switch {...props} checked={field.value} onChange={setValue} />;
 };
 
 export default FormikSwitch;

--- a/web/src/components/forms/common/rule-form-test-fields.tsx
+++ b/web/src/components/forms/common/rule-form-test-fields.tsx
@@ -256,7 +256,6 @@ const RuleFormTestFields: React.FC = () => {
                             as={FormikRadio}
                             id="expected-result-true"
                             name={`tests[${activeTabIndex}].expectedResult`}
-                            checked={tests[activeTabIndex].expectedResult}
                             value={true}
                           />
                         </Flex>
@@ -268,7 +267,6 @@ const RuleFormTestFields: React.FC = () => {
                             as={FormikRadio}
                             id="expected-result-false"
                             name={`tests[${activeTabIndex}].expectedResult`}
-                            checked={tests[activeTabIndex].expectedResult}
                             value={false}
                           />
                         </Flex>

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -45,6 +45,7 @@ import ForgotPasswordConfirmPage from 'Pages/forgot-password-confirm';
 import ErrorBoundary from 'Components/error-boundary';
 import Page404 from 'Pages/404';
 import APIErrorFallback from 'Components/utils/api-error-fallback';
+import PromptController from 'Components/utils/prompt-controller';
 
 // Main page container for the web application, Navigation bar and Content body goes here
 const PrimaryPageLayout: React.FunctionComponent = () => {
@@ -109,6 +110,7 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
             </APIErrorFallback>
           </ErrorBoundary>
         </Layout>
+        <PromptController />
       </GuardedRoute>
     </Switch>
   );


### PR DESCRIPTION
## Background

Currently there is an issue with the way our cache-friendly radio buttons work with our form-management library and pounce.  This causes bugs where a value update is applied on the wrong fields.

I reported the [caching issue to the related repo and I got some upvotes](https://github.com/jaredpalmer/formik/issues/2268), so until this is fixed, I'm removing all memoization & caching from our:

* checkboxes
* radio
* switches

Closes #210 

## Changes

- Remove caching & optimizations from button-like form elements
- Remove un-needed props

## Locally

- How did you test your change?
