### PR TITLE
Policy/Alert URLs + Cloud Sec Overview Wording

### DIFF
--- a/deployments/core/outputs.yml
+++ b/deployments/core/outputs.yml
@@ -186,12 +186,12 @@ Resources:
         Variables:
           ALERT_QUEUE_URL: !Ref AlertQueue
           ALERT_RETRY_DURATION_MINS: !Ref AlertRetryDurationMins
-          ALERT_URL_PREFIX: !Sub https://${AppFqdn}/alerts/
+          ALERT_URL_PREFIX: !Sub https://${AppFqdn}/log-analysis/alerts/
           MAX_RETRY_DELAY_SECS: !Ref MaxRetryDelaySecs
           MIN_RETRY_DELAY_SECS: !Ref MinRetryDelaySecs
           OUTPUTS_API: panther-outputs-api
           OUTPUTS_REFRESH_INTERVAL_MIN: '5'
-          POLICY_URL_PREFIX: !Sub https://${AppFqdn}/policies/
+          POLICY_URL_PREFIX: !Sub https://${AppFqdn}/cloud-security/policies/
       Events:
         AlertQueue:
           Type: SQS

--- a/web/src/components/auth-page-container.tsx
+++ b/web/src/components/auth-page-container.tsx
@@ -65,10 +65,10 @@ const AuthPageContainer: React.FC<AuthPageContainer> & AuthPageContainerComposit
               letterSpacing="0.5px"
               textAlign="center"
             >
-              Quickly and Automatically Detect Threats in Log Data and Cloud Infrastructure
+              Detect threats with log data and improve cloud security posture
             </Heading>
             <Text size="large" color="white" mt={5} textAlign="center">
-              Designed for organizations of any size
+              Designed for any scale
             </Text>
           </Flex>
         </Flex>

--- a/web/src/pages/compliance-overview/index.tsx
+++ b/web/src/pages/compliance-overview/index.tsx
@@ -142,16 +142,16 @@ const ComplianceOverview: React.FC = () => {
         is="section"
         mb={3}
       >
-        <DonutChartWrapper title="Policy Overview" icon="policy">
+        <DonutChartWrapper title="Policy Severity" icon="policy">
           <PoliciesBySeverityChart policies={data.organizationStats.appliedPolicies} />
         </DonutChartWrapper>
-        <DonutChartWrapper title="Policy Failure Breakdown" icon="policy">
+        <DonutChartWrapper title="Policy Failure" icon="policy">
           <PoliciesByStatusChart policies={data.organizationStats.appliedPolicies} />
         </DonutChartWrapper>
-        <DonutChartWrapper title="Resources Platforms" icon="resource">
+        <DonutChartWrapper title="Resource Type" icon="resource">
           <ResourcesByPlatformChart resources={data.organizationStats.scannedResources} />
         </DonutChartWrapper>
-        <DonutChartWrapper title="Resources Health" icon="resource">
+        <DonutChartWrapper title="Resource Health" icon="resource">
           <ResourcesByStatusChart resources={data.organizationStats.scannedResources} />
         </DonutChartWrapper>
       </Grid>

--- a/web/src/pages/compliance-overview/skeleton.tsx
+++ b/web/src/pages/compliance-overview/skeleton.tsx
@@ -39,16 +39,16 @@ const ComplianceOverviewPageSkeleton: React.FC = () => {
         is="section"
         mb={3}
       >
-        <DonutChartWrapper title="Policy Overview" icon="policy">
+        <DonutChartWrapper title="Policy Severity" icon="policy">
           <ChartPlaceholder />
         </DonutChartWrapper>
-        <DonutChartWrapper title="Policy Failure Breakdown" icon="policy">
+        <DonutChartWrapper title="Policy Failure" icon="policy">
           <ChartPlaceholder />
         </DonutChartWrapper>
-        <DonutChartWrapper title="Resources Platforms" icon="resource">
+        <DonutChartWrapper title="Resource Type" icon="resource">
           <ChartPlaceholder />
         </DonutChartWrapper>
-        <DonutChartWrapper title="Resources Health" icon="resource">
+        <DonutChartWrapper title="Resource Health" icon="resource">
           <ChartPlaceholder />
         </DonutChartWrapper>
       </Grid>


### PR DESCRIPTION
## Background

I found a bug in the alerting workflow after we split the pages. The policy/alert links were missing the new path prefixes.

Made some additional wording edits too.

Request - @3nvi can we make the "Resource Platforms" breakdown by type?

## Changes

- Fix alert/policy urls
- Reword the auth page text again (can we also increase the padding around the text?)
- Rename the chart headers on the Cloud Security overview.

## Testing

- Deployed into my test account
