### PR TITLE
Fixing name of Panther SQS queue

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -98,7 +98,7 @@ Resources:
   Subscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Sub arn:${AWS::Partition}:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications
+      Endpoint: !Sub arn:${AWS::Partition}:sqs:${PantherRegion}:${MasterAccountId}:panther-input-data-notifications-queue
       Protocol: sqs
       RawMessageDelivery: false
       TopicArn: !Ref Topic


### PR DESCRIPTION
## Background

After renaming the SQS queue where Panther receives notifications for new S3 data, we need to update our CFN templates that create subscriptions. 

## Changes

- Updated name of the SQS queue

