### PR TITLE
Syslog parser for RFC3164 formatted logs

### DIFF
--- a/docs/gitbook/log-analysis/supported-logs/README.md
+++ b/docs/gitbook/log-analysis/supported-logs/README.md
@@ -48,6 +48,15 @@ AWS contains a variety of critical data sources used to audit API usage, databas
 | ----------------- | --------------------------------------------------- |
 | `OSSEC.EventInfo` | https://www.ossec.net/docs/docs/formats/alerts.html |
 
+## [Syslog](https://github.com/panther-labs/panther/tree/master/internal/log_analysis/log_processor/parsers/sysloglogs)
+
+[Syslog](https://en.wikipedia.org/wiki/Syslog) is a protocol for message logging. It has become the standard logging solution on Unix-like systems.
+
+| Log Type          | Reference                                              |
+| ----------------- | ------------------------------------------------------ |
+| `Syslog.RFC3164`  | https://tools.ietf.org/html/rfc3164                    |
+
+
 ## Built-in Rule Packs
 
 {% hint style="info" %}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/influxdata/go-syslog/v3 v3.0.0
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.9
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,9 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/go-syslog v1.0.1 h1:a/ARpnCDr/sX/hVH7dyQVi+COXlEzM4bNIoolOfw99Y=
+github.com/influxdata/go-syslog/v3 v3.0.0 h1:jichmjSZlYK0VMmlz+k4WeOQd7z745YLsvGMqwtYt4I=
+github.com/influxdata/go-syslog/v3 v3.0.0/go.mod h1:tulsOp+CecTAYC27u9miMgq21GqXRW6VdKbOG+QSP4Q=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -161,6 +164,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
 github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
@@ -1,0 +1,114 @@
+package sysloglogs
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"net"
+	"time"
+
+	"github.com/influxdata/go-syslog/v3/rfc3164"
+	"go.uber.org/zap"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
+)
+
+var RFC3164Desc = `Syslog parser for the RFC3164 format (ie. BSD-syslog messages)
+Reference: https://tools.ietf.org/html/rfc3164`
+
+// nolint:lll
+type RFC3164 struct {
+	Priority  *uint8             `json:"priority" validate:"required" description:"Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message."`
+	Facility  *uint8             `json:"facility" validate:"required" description:"Facility value helps determine which process created the message. Eg: 0 = kernel messages, 3 = system daemons."`
+	Severity  *uint8             `json:"severity" validate:"required" description:"Severity indicates how severe the message is. Eg: 0=Emergency to 7=Debug."`
+	Timestamp *timestamp.RFC3339 `json:"timestamp,omitempty" description:"Timestamp of the syslog message in UTC."`
+	Hostname  *string            `json:"hostname,omitempty" description:"Hostname identifies the machine that originally sent the syslog message."`
+	Appname   *string            `json:"appname,omitempty" description:"Appname identifies the device or application that originated the syslog message."`
+	ProcID    *string            `json:"procid,omitempty" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
+	MsgID     *string            `json:"msgid,omitempty" description:"MsgID identifies the type of message. For example, a firewall might use the MsgID 'TCPIN' for incoming TCP traffic."`
+	Message   *string            `json:"message,omitempty" description:"Message contains free-form text that provides information about the event."`
+
+	// NOTE: added to end of struct to allow expansion later
+	parsers.PantherLog
+}
+
+// RFC3164Parser parses Syslog logs in the RFC3164 format
+type RFC3164Parser struct{}
+
+func (p *RFC3164Parser) New() parsers.LogParser {
+	return &RFC3164Parser{}
+}
+
+// Parse returns the parsed events or nil if parsing failed
+func (p *RFC3164Parser) Parse(log string) []interface{} {
+	parser := rfc3164.NewParser(
+		rfc3164.WithBestEffort(),
+		rfc3164.WithTimezone(time.UTC),
+		rfc3164.WithYear(rfc3164.CurrentYear{}),
+		rfc3164.WithRFC3339(),
+	)
+
+	msg, err := parser.Parse([]byte(log))
+	if err != nil {
+		zap.L().Debug("failed to parse log", zap.Error(err))
+		return nil
+	}
+	internalRFC3164 := msg.(*rfc3164.SyslogMessage)
+
+	externalRFC3164 := &RFC3164{
+		Priority:  internalRFC3164.Priority,
+		Facility:  internalRFC3164.Facility,
+		Severity:  internalRFC3164.Severity,
+		Timestamp: (*timestamp.RFC3339)(internalRFC3164.Timestamp),
+		Hostname:  internalRFC3164.Hostname,
+		Appname:   internalRFC3164.Appname,
+		ProcID:    internalRFC3164.ProcID,
+		MsgID:     internalRFC3164.MsgID,
+		Message:   internalRFC3164.Message,
+	}
+
+	externalRFC3164.updatePantherFields(p)
+
+	if err := parsers.Validator.Struct(externalRFC3164); err != nil {
+		zap.L().Debug("failed to validate log", zap.Error(err))
+		return nil
+	}
+
+	return []interface{}{externalRFC3164}
+}
+
+// LogType returns the log type supported by this parser
+func (p *RFC3164Parser) LogType() string {
+	return "Syslog.RFC3164"
+}
+
+func (event *RFC3164) updatePantherFields(p *RFC3164Parser) {
+	event.SetCoreFieldsPtr(p.LogType(), event.Timestamp)
+
+	if event.Hostname != nil {
+		// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
+		// add as a domain name. https://tools.ietf.org/html/rfc3164#section-6.2.4
+		hostname := *event.Hostname
+		if net.ParseIP(hostname) != nil {
+			event.AppendAnyIPAddresses(hostname)
+		} else {
+			event.AppendAnyDomainNames(hostname)
+		}
+	}
+}

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
@@ -24,11 +24,28 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )
 
+var parser parsers.LogParser
+
 func TestRFC3164(t *testing.T) {
+	zap.ReplaceGlobals(zaptest.NewLogger(t))
+	syslogRFC3164 := &RFC3164Parser{}
+	parser = syslogRFC3164.New()
+
+	t.Run("Simple", testRFC3164Simple)
+	t.Run("WithRFC3339Timestamp", testRFC3164WithRFC3339Timestamp)
+	t.Run("Example1", testRFC3164Example1)
+	t.Run("Example2", testRFC3164Example2)
+	t.Run("Example3", testRFC3164Example3)
+}
+
+func testRFC3164Simple(t *testing.T) {
 	//nolint:lll
 	log := `<13>Dec  2 16:31:03 host app: Test`
 
@@ -55,7 +72,7 @@ func TestRFC3164(t *testing.T) {
 	checkRFC3164(t, log, expectedEvent)
 }
 
-func TestRFC3164WithRFC3339Timestamp(t *testing.T) {
+func testRFC3164WithRFC3339Timestamp(t *testing.T) {
 	//nolint:lll
 	log := `<28>2019-12-02T16:49:23+02:00 host app[23410]: Test`
 
@@ -83,7 +100,7 @@ func TestRFC3164WithRFC3339Timestamp(t *testing.T) {
 }
 
 // Example1 from https://tools.ietf.org/html/rfc3164#section-5.4
-func TestRFC3164Example1(t *testing.T) {
+func testRFC3164Example1(t *testing.T) {
 	//nolint:lll
 	log := `<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`
 
@@ -111,7 +128,7 @@ func TestRFC3164Example1(t *testing.T) {
 }
 
 // Example2 from https://tools.ietf.org/html/rfc3164#section-5.4
-func TestRFC3164Example2(t *testing.T) {
+func testRFC3164Example2(t *testing.T) {
 	//nolint:lll
 	log := `<13>Feb  5 17:32:18 10.0.0.99 Use the BFG!`
 
@@ -139,7 +156,7 @@ func TestRFC3164Example2(t *testing.T) {
 }
 
 // Example3 from https://tools.ietf.org/html/rfc3164#section-5.4
-func TestRFC3164Example3(t *testing.T) {
+func testRFC3164Example3(t *testing.T) {
 	//nolint:lll
 	log := `<165>Aug 24 05:34:00 CST 1987 mymachine myproc[10]: %% It's time to make the do-nuts %%`
 
@@ -172,7 +189,6 @@ func TestRFC3164Type(t *testing.T) {
 }
 
 func checkRFC3164(t *testing.T, log string, expectedEvent *RFC3164) {
-	parser := &RFC3164Parser{}
 	events := parser.Parse(log)
 	require.Equal(t, 1, len(events))
 	event := events[0].(*RFC3164)

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
@@ -1,0 +1,110 @@
+package sysloglogs
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
+)
+
+func TestRFC3164(t *testing.T) {
+	//nolint:lll
+	log := `<13>Dec  2 16:31:03 host app: Test`
+
+	expectedTime := time.Date(time.Now().UTC().Year(), 12, 2, 16, 31, 03, 0, time.UTC)
+
+	expectedEvent := &RFC3164{
+		Priority:  aws.Uint8(13),
+		Facility:  aws.Uint8(1),
+		Severity:  aws.Uint8(5),
+		Timestamp: (*timestamp.RFC3339)(&expectedTime),
+		Hostname:  aws.String("host"),
+		Appname:   aws.String("app"),
+		ProcID:    nil,
+		MsgID:     nil,
+		Message:   aws.String("Test"),
+	}
+
+	expectedEvent.AppendAnyDomainNamePtrs(expectedEvent.Hostname)
+
+	// panther fields
+	expectedEvent.PantherLogType = aws.String("Syslog.RFC3164")
+	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+
+	checkRFC3164(t, log, expectedEvent)
+}
+
+func TestRFC3164WithRFC3339Timestamp(t *testing.T) {
+	//nolint:lll
+	log := `<28>2019-12-02T16:49:23+02:00 host app[23410]: Test`
+
+	expectedTime, _ := time.Parse(time.RFC3339, "2019-12-02T16:49:23+02:00")
+
+	fmt.Println(expectedTime)
+
+	expectedEvent := &RFC3164{
+		Priority:  aws.Uint8(28),
+		Facility:  aws.Uint8(3),
+		Severity:  aws.Uint8(4),
+		Timestamp: (*timestamp.RFC3339)(&expectedTime),
+		Hostname:  aws.String("host"),
+		Appname:   aws.String("app"),
+		ProcID:    aws.String("23410"),
+		MsgID:     nil,
+		Message:   aws.String("Test"),
+	}
+
+	expectedEvent.AppendAnyDomainNamePtrs(expectedEvent.Hostname)
+
+	// panther fields
+	expectedEvent.PantherLogType = aws.String("Syslog.RFC3164")
+	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+
+	checkRFC3164(t, log, expectedEvent)
+}
+
+func TestRFC3164Type(t *testing.T) {
+	parser := &RFC3164Parser{}
+	require.Equal(t, "Syslog.RFC3164", parser.LogType())
+}
+
+func checkRFC3164(t *testing.T, log string, expectedEvent *RFC3164) {
+	parser := &RFC3164Parser{}
+	events := parser.Parse(log)
+	require.Equal(t, 1, len(events))
+	event := events[0].(*RFC3164)
+
+	// rowid changes each time
+	require.Greater(t, len(*event.PantherRowID), 0) // ensure something is there.
+	expectedEvent.PantherRowID = event.PantherRowID
+
+	spew.Dump(event)
+	spew.Dump(expectedEvent)
+	fmt.Println(reflect.DeepEqual(expectedEvent, event))
+
+	require.Equal(t, expectedEvent, event)
+}

--- a/internal/log_analysis/log_processor/registry/registry.go
+++ b/internal/log_analysis/log_processor/registry/registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/nginxlogs"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/osquerylogs"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/osseclogs"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/sysloglogs"
 	"github.com/panther-labs/panther/pkg/awsglue"
 )
 
@@ -61,6 +62,8 @@ var (
 			&osquerylogs.Snapshot{}, osquerylogs.SnapshotDesc),
 		(&osseclogs.EventInfoParser{}).LogType(): DefaultLogParser(&osseclogs.EventInfoParser{},
 			&osseclogs.EventInfo{}, osseclogs.EventInfoDesc),
+		(&sysloglogs.RFC3164Parser{}).LogType(): DefaultLogParser(&sysloglogs.RFC3164Parser{},
+			&sysloglogs.RFC3164{}, sysloglogs.RFC3164Desc),
 	}
 )
 

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -80,6 +80,7 @@ export const LOG_TYPES = [
   'Osquery.Snapshot',
   'Osquery.Status',
   'OSSEC.EventInfo',
+  'Syslog.RFC3164',
 ] as const;
 
 export const SEVERITY_COLOR_MAP: { [key in SeverityEnum]: BadgeProps['color'] } = {


### PR DESCRIPTION
## Background

This PR introduces a new Parser for Syslog RFC3164 formatted logs as planned in #200.

## Changes

* Created new parser for RFC3164 format (BSD syslog messages)
* Updated parser documentation for syslog.
* Added `Syslog.RFC3164` as a whitelisted log type for the frontend UI.
* Added `sysloglogs.RFC3164Parser` to the log registry.
* Added examples from https://tools.ietf.org/html/rfc3164#section-5.4 as unit tests.

## Testing

- Unit tests

Waiting on #304 and #261 to merge before merging from master and running an end-to-end test.
