### PR TITLE
Update endpoints return modified settings

### DIFF
--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -116,9 +116,8 @@ type UpdateIntegrationLastScanEndInput struct {
 
 // UpdateIntegrationSettingsInput is used to update integration settings.
 type UpdateIntegrationSettingsInput struct {
-	AWSAccountID     *string   `genericapi:"redact" json:"awsAccountId,omitempty" validate:"omitempty,len=12,numeric"`
 	IntegrationID    *string   `json:"integrationId" validate:"required,uuid4"`
-	IntegrationLabel *string   `json:"integrationLabel" validate:"min=1"`
+	IntegrationLabel *string   `json:"integrationLabel,omitempty" validate:"omitempty,min=1"`
 	ScanEnabled      *bool     `json:"scanEnabled"`
 	ScanIntervalMins *int      `json:"scanIntervalMins" validate:"omitempty,oneof=60 180 360 720 1440"`
 	S3Buckets        []*string `json:"s3Buckets"`

--- a/api/lambda/users/models/api.go
+++ b/api/lambda/users/models/api.go
@@ -77,3 +77,6 @@ type UpdateUserInput struct {
 	FamilyName *string `json:"familyName" validate:"omitempty,min=1"`
 	Email      *string `json:"email" validate:"omitempty,min=1"`
 }
+
+// UpdateUserOutput returns the new Panther user details.
+type UpdateUserOutput = User

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
-	golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb // indirect
+	golang.org/x/tools v0.0.0-20200302155637-b1e4e04173e0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/russross/blackfriday.v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb h1:RXjcsi6scaPhM5uXm7JRqP2JibKvbgMqx9zDLDB9voM=
 golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200302155637-b1e4e04173e0 h1:fgnkocwzO9swV2pnFKnfje0dMOdhcdolLbvr1gNEtlQ=
+golang.org/x/tools v0.0.0-20200302155637-b1e4e04173e0/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -102,7 +102,7 @@ func ScanAllResources(integrations []*models.SourceIntegrationMetadata) error {
 
 	// For each integration, add a ScanMsg to the queue per service
 	for _, integration := range integrations {
-		if !*integration.ScanEnabled {
+		if !aws.BoolValue(integration.ScanEnabled) {
 			continue
 		}
 

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -26,7 +26,7 @@ import (
 // UpdateIntegrationSettings makes an update to an integration from the UI.
 //
 // This endpoint updates attributes such as the behavior of the integration, or display information.
-func (API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettingsInput) error {
+func (API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettingsInput) (*models.SourceIntegration, error) {
 	return db.UpdateItem(&ddb.UpdateIntegrationItem{
 		IntegrationID:    input.IntegrationID,
 		IntegrationLabel: input.IntegrationLabel,
@@ -38,7 +38,7 @@ func (API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettingsInpu
 }
 
 // UpdateIntegrationLastScanStart updates an integration when a new scan is started.
-func (API) UpdateIntegrationLastScanStart(input *models.UpdateIntegrationLastScanStartInput) error {
+func (API) UpdateIntegrationLastScanStart(input *models.UpdateIntegrationLastScanStartInput) (*models.SourceIntegration, error) {
 	return db.UpdateItem(&ddb.UpdateIntegrationItem{
 		IntegrationID:     input.IntegrationID,
 		LastScanStartTime: input.LastScanStartTime,
@@ -47,7 +47,7 @@ func (API) UpdateIntegrationLastScanStart(input *models.UpdateIntegrationLastSca
 }
 
 // UpdateIntegrationLastScanEnd updates an integration when a scan ends.
-func (API) UpdateIntegrationLastScanEnd(input *models.UpdateIntegrationLastScanEndInput) error {
+func (API) UpdateIntegrationLastScanEnd(input *models.UpdateIntegrationLastScanEndInput) (*models.SourceIntegration, error) {
 	return db.UpdateItem(&ddb.UpdateIntegrationItem{
 		IntegrationID:        input.IntegrationID,
 		LastScanEndTime:      input.LastScanEndTime,

--- a/internal/core/source_api/api/update_integration_test.go
+++ b/internal/core/source_api/api/update_integration_test.go
@@ -46,7 +46,6 @@ func TestUpdateIntegrationSettings(t *testing.T) {
 	result, err := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
 		ScanEnabled:      aws.Bool(false),
 		IntegrationID:    aws.String(testIntegrationID),
-		AWSAccountID:     aws.String(testAccountID),
 		IntegrationLabel: aws.String("NewAWSTestingAccount"),
 		ScanIntervalMins: aws.Int(1440),
 	})

--- a/internal/core/source_api/api/update_integration_test.go
+++ b/internal/core/source_api/api/update_integration_test.go
@@ -38,10 +38,12 @@ func TestUpdateIntegrationSettings(t *testing.T) {
 	mockClient := &modelstest.MockDDBClient{}
 	db = &ddb.DDB{Client: mockClient, TableName: "test"}
 
-	resp := &dynamodb.UpdateItemOutput{}
+	resp := &dynamodb.UpdateItemOutput{Attributes: map[string]*dynamodb.AttributeValue{
+		"ScanEnabled": {BOOL: aws.Bool(false)},
+	}}
 	mockClient.On("UpdateItem", mock.Anything).Return(resp, nil)
 
-	result := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
+	result, err := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
 		ScanEnabled:      aws.Bool(false),
 		IntegrationID:    aws.String(testIntegrationID),
 		AWSAccountID:     aws.String(testAccountID),
@@ -49,7 +51,11 @@ func TestUpdateIntegrationSettings(t *testing.T) {
 		ScanIntervalMins: aws.Int(1440),
 	})
 
-	assert.NoError(t, result)
+	expected := &models.SourceIntegration{
+		SourceIntegrationMetadata: &models.SourceIntegrationMetadata{ScanEnabled: aws.Bool(false)},
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
 	mockClient.AssertExpectations(t)
 }
 
@@ -60,12 +66,13 @@ func TestUpdateIntegrationSettingsAwsS3Type(t *testing.T) {
 	resp := &dynamodb.UpdateItemOutput{}
 	mockClient.On("UpdateItem", mock.Anything).Return(resp, nil)
 
-	result := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
+	result, err := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
 		S3Buckets: aws.StringSlice([]string{"test-bucket-1", "test-bucket-2/*"}),
 		KmsKeys:   aws.StringSlice([]string{"arn:aws:kms:us-west-2:415773754570:key/27803c7e-9fa5-4fcb-9525-ee11c953d329"}),
 	})
 
-	assert.NoError(t, result)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 	mockClient.AssertExpectations(t)
 }
 
@@ -90,13 +97,14 @@ func TestUpdateIntegrationLastScanStart(t *testing.T) {
 	lastScanEndTime, err := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
 	require.NoError(t, err)
 
-	result := apiTest.UpdateIntegrationLastScanStart(&models.UpdateIntegrationLastScanStartInput{
+	result, err := apiTest.UpdateIntegrationLastScanStart(&models.UpdateIntegrationLastScanStartInput{
 		IntegrationID:     aws.String(testIntegrationID),
 		LastScanStartTime: &lastScanEndTime,
 		ScanStatus:        aws.String(models.StatusOK),
 	})
 
-	assert.NoError(t, result)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 	mockClient.AssertExpectations(t)
 }
 
@@ -127,6 +135,7 @@ func TestUpdateIntegrationLastScanEnd(t *testing.T) {
 		Key: map[string]*dynamodb.AttributeValue{
 			"integrationId": {S: aws.String(testIntegrationID)},
 		},
+		ReturnValues:     aws.String("ALL_NEW"),
 		TableName:        aws.String("test"),
 		UpdateExpression: expr.Update(),
 	}
@@ -135,13 +144,14 @@ func TestUpdateIntegrationLastScanEnd(t *testing.T) {
 	lastScanEndTime, err := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
 	require.NoError(t, err)
 
-	result := apiTest.UpdateIntegrationLastScanEnd(&models.UpdateIntegrationLastScanEndInput{
+	result, err := apiTest.UpdateIntegrationLastScanEnd(&models.UpdateIntegrationLastScanEndInput{
 		IntegrationID:        aws.String(testIntegrationID),
 		LastScanEndTime:      &lastScanEndTime,
 		LastScanErrorMessage: aws.String("something went wrong"),
 		ScanStatus:           aws.String(models.StatusError),
 	})
 
-	assert.NoError(t, result)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 	mockClient.AssertExpectations(t)
 }

--- a/internal/core/users_api/api/get_user.go
+++ b/internal/core/users_api/api/get_user.go
@@ -24,9 +24,5 @@ import (
 
 // GetUser calls userGateway to get user information.
 func (API) GetUser(input *models.GetUserInput) (*models.GetUserOutput, error) {
-	user, err := userGateway.GetUser(input.ID)
-	if err != nil {
-		return nil, err
-	}
-	return user, nil
+	return userGateway.GetUser(input.ID)
 }

--- a/internal/core/users_api/api/invite_user.go
+++ b/internal/core/users_api/api/invite_user.go
@@ -20,17 +20,12 @@ package api
 
 import (
 	"github.com/panther-labs/panther/api/lambda/users/models"
-	"github.com/panther-labs/panther/internal/core/users_api/gateway"
 )
 
 // InviteUser adds a new user to the Cognito user pool.
 func (API) InviteUser(input *models.InviteUserInput) (*models.InviteUserOutput, error) {
 	// Create user in Cognito
-	id, err := userGateway.CreateUser(&gateway.CreateUserInput{
-		GivenName:  input.GivenName,
-		FamilyName: input.FamilyName,
-		Email:      input.Email,
-	})
+	id, err := userGateway.CreateUser(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/users_api/api/invite_user_test.go
+++ b/internal/core/users_api/api/invite_user_test.go
@@ -43,11 +43,7 @@ func TestInviteUserCreateErr(t *testing.T) {
 	userGateway = mockGateway
 
 	// setup gateway expectations
-	mockGateway.On("CreateUser", &gateway.CreateUserInput{
-		GivenName:  input.GivenName,
-		FamilyName: input.FamilyName,
-		Email:      input.Email,
-	}).Return(aws.String(""), &genericapi.AWSError{})
+	mockGateway.On("CreateUser", input).Return(aws.String(""), &genericapi.AWSError{})
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)
@@ -66,11 +62,7 @@ func TestInviteUserDeleteErr(t *testing.T) {
 	userGateway = mockGateway
 
 	// setup expectations
-	mockGateway.On("CreateUser", &gateway.CreateUserInput{
-		GivenName:  input.GivenName,
-		FamilyName: input.FamilyName,
-		Email:      input.Email,
-	}).Return(aws.String(""), &genericapi.AWSError{})
+	mockGateway.On("CreateUser", input).Return(aws.String(""), &genericapi.AWSError{})
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)
@@ -89,11 +81,7 @@ func TestInviteUserHandle(t *testing.T) {
 	userGateway = mockGateway
 
 	// setup gateway expectations
-	mockGateway.On("CreateUser", &gateway.CreateUserInput{
-		GivenName:  input.GivenName,
-		FamilyName: input.FamilyName,
-		Email:      input.Email,
-	}).Return(userID, nil)
+	mockGateway.On("CreateUser", input).Return(userID, nil)
 
 	// call the code we are testing
 	result, err := (API{}).InviteUser(input)

--- a/internal/core/users_api/api/update_user.go
+++ b/internal/core/users_api/api/update_user.go
@@ -20,15 +20,14 @@ package api
 
 import (
 	"github.com/panther-labs/panther/api/lambda/users/models"
-	"github.com/panther-labs/panther/internal/core/users_api/gateway"
 )
 
 // UpdateUser modifies user attributes and roles.
-func (API) UpdateUser(input *models.UpdateUserInput) error {
-	return userGateway.UpdateUser(&gateway.UpdateUserInput{
-		GivenName:  input.GivenName,
-		FamilyName: input.FamilyName,
-		Email:      input.Email,
-		ID:         input.ID,
-	})
+func (API) UpdateUser(input *models.UpdateUserInput) (*models.UpdateUserOutput, error) {
+	if err := userGateway.UpdateUser(input); err != nil {
+		return nil, err
+	}
+
+	// Return updated user attributes
+	return userGateway.GetUser(input.ID)
 }

--- a/internal/core/users_api/api/update_user_test.go
+++ b/internal/core/users_api/api/update_user_test.go
@@ -34,7 +34,13 @@ type mockGatewayUpdateUserClient struct {
 	updateErr bool
 }
 
-func (m *mockGatewayUpdateUserClient) UpdateUser(*gateway.UpdateUserInput) error {
+func (m *mockGatewayUpdateUserClient) GetUser(id *string) (*models.User, error) {
+	return &models.User{
+		ID: id,
+	}, nil
+}
+
+func (m *mockGatewayUpdateUserClient) UpdateUser(*models.UpdateUserInput) error {
 	if m.updateErr {
 		return &genericapi.AWSError{}
 	}
@@ -47,7 +53,9 @@ func TestUpdateUserGatewayErr(t *testing.T) {
 		GivenName: aws.String("Richie"),
 		ID:        aws.String("user123"),
 	}
-	assert.Error(t, (API{}).UpdateUser(input))
+	result, err := (API{}).UpdateUser(input)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }
 
 func TestUpdateUserHandle(t *testing.T) {
@@ -56,5 +64,7 @@ func TestUpdateUserHandle(t *testing.T) {
 		GivenName: aws.String("Richie"),
 		ID:        aws.String("user123"),
 	}
-	assert.NoError(t, (API{}).UpdateUser(input))
+	result, err := (API{}).UpdateUser(input)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 }

--- a/internal/core/users_api/gateway/create_user.go
+++ b/internal/core/users_api/gateway/create_user.go
@@ -24,19 +24,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
+	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-// CreateUserInput is input for CreateUser request
-type CreateUserInput struct {
-	GivenName  *string `json:"givenName"`
-	FamilyName *string `json:"familyName"`
-	Email      *string `json:"email"`
-}
-
 // Create a AdminCreateUserInput from the CreateUserInput.
 func (g *UsersGateway) cognitoInputFromAPIInput(
-	input *CreateUserInput) *provider.AdminCreateUserInput {
+	input *models.InviteUserInput) *provider.AdminCreateUserInput {
 
 	var userAttrs []*provider.AttributeType
 	var lowercaseEmail = aws.String(strings.ToLower(*input.Email))
@@ -76,7 +70,7 @@ func (g *UsersGateway) cognitoInputFromAPIInput(
 }
 
 // CreateUser calls cognito api and creates a new user with specified attributes and sends out an email invitation
-func (g *UsersGateway) CreateUser(input *CreateUserInput) (*string, error) {
+func (g *UsersGateway) CreateUser(input *models.InviteUserInput) (*string, error) {
 	cognitoInput := g.cognitoInputFromAPIInput(input)
 	userOutput, err := g.userPoolClient.AdminCreateUser(cognitoInput)
 	if err != nil {

--- a/internal/core/users_api/gateway/create_user_test.go
+++ b/internal/core/users_api/gateway/create_user_test.go
@@ -25,10 +25,11 @@ import (
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-var testCreateUserInput = &CreateUserInput{
+var testCreateUserInput = &models.InviteUserInput{
 	GivenName:  aws.String("Joe"),
 	FamilyName: aws.String("Blow"),
 	Email:      aws.String("joe.blow@toe.com"),

--- a/internal/core/users_api/gateway/mock_gateway.go
+++ b/internal/core/users_api/gateway/mock_gateway.go
@@ -35,7 +35,7 @@ type MockUserGateway struct {
 // and just record the activity, and returns what the Mock object tells it to.
 
 // CreateUser mocks CreateUser for testing
-func (m *MockUserGateway) CreateUser(input *CreateUserInput) (*string, error) {
+func (m *MockUserGateway) CreateUser(input *models.InviteUserInput) (*string, error) {
 	args := m.Called(input)
 	return args.Get(0).(*string), args.Error(1)
 }
@@ -65,7 +65,7 @@ func (m *MockUserGateway) ResetUserPassword(id *string) error {
 }
 
 // UpdateUser mocks UpdateUser for testing
-func (m *MockUserGateway) UpdateUser(input *UpdateUserInput) error {
+func (m *MockUserGateway) UpdateUser(input *models.UpdateUserInput) error {
 	args := m.Called(input)
 	return args.Error(0)
 }

--- a/internal/core/users_api/gateway/update_user.go
+++ b/internal/core/users_api/gateway/update_user.go
@@ -22,20 +22,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
+	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-// UpdateUserInput is input for UpdateUser request
-type UpdateUserInput struct {
-	ID         *string `json:"id"`
-	GivenName  *string `json:"givenName"`
-	FamilyName *string `json:"familyName"`
-	Email      *string `json:"email"`
-}
-
 // Create a AdminUpdateUserAttributesInput from the UpdateUserInput.
 func (g *UsersGateway) updateInputMapping(
-	input *UpdateUserInput) *provider.AdminUpdateUserAttributesInput {
+	input *models.UpdateUserInput) *provider.AdminUpdateUserAttributesInput {
 
 	var userAttrs []*provider.AttributeType
 
@@ -71,8 +64,8 @@ func (g *UsersGateway) updateInputMapping(
 	}
 }
 
-// UpdateUser calls cognito api and update a user with specified attributes
-func (g *UsersGateway) UpdateUser(input *UpdateUserInput) error {
+// UpdateUser calls cognito to update a user with the specified attributes.
+func (g *UsersGateway) UpdateUser(input *models.UpdateUserInput) error {
 	cognitoInput := g.updateInputMapping(input)
 	if _, err := g.userPoolClient.AdminUpdateUserAttributes(cognitoInput); err != nil {
 		return &genericapi.AWSError{Method: "cognito.AdminUpdateUserAttributes", Err: err}

--- a/internal/core/users_api/gateway/update_user_test.go
+++ b/internal/core/users_api/gateway/update_user_test.go
@@ -26,6 +26,8 @@ import (
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	providerI "github.com/aws/aws-sdk-go/service/cognitoidentityprovider/cognitoidentityprovideriface"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/panther-labs/panther/api/lambda/users/models"
 )
 
 type mockUpdateUserClient struct {
@@ -44,7 +46,7 @@ func (m *mockUpdateUserClient) AdminUpdateUserAttributes(
 
 func TestUpdateUserGivenName(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockUpdateUserClient{}}
-	assert.NoError(t, gw.UpdateUser(&UpdateUserInput{
+	assert.NoError(t, gw.UpdateUser(&models.UpdateUserInput{
 		GivenName: aws.String("Richie"),
 		ID:        aws.String("user123"),
 	}))
@@ -52,7 +54,7 @@ func TestUpdateUserGivenName(t *testing.T) {
 
 func TestUpdateUserFamilyName(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockUpdateUserClient{}}
-	assert.NoError(t, gw.UpdateUser(&UpdateUserInput{
+	assert.NoError(t, gw.UpdateUser(&models.UpdateUserInput{
 		FamilyName: aws.String("Homie"),
 		ID:         aws.String("user123"),
 	}))
@@ -60,7 +62,7 @@ func TestUpdateUserFamilyName(t *testing.T) {
 
 func TestUpdateUserEmail(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockUpdateUserClient{}}
-	assert.NoError(t, gw.UpdateUser(&UpdateUserInput{
+	assert.NoError(t, gw.UpdateUser(&models.UpdateUserInput{
 		Email: aws.String("rich@homie.com"),
 		ID:    aws.String("user123"),
 	}))
@@ -68,7 +70,7 @@ func TestUpdateUserEmail(t *testing.T) {
 
 func TestUpdateMultipleAttributes(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockUpdateUserClient{}}
-	assert.NoError(t, gw.UpdateUser(&UpdateUserInput{
+	assert.NoError(t, gw.UpdateUser(&models.UpdateUserInput{
 		GivenName:  aws.String("Richie"),
 		FamilyName: aws.String("Homie"),
 		Email:      aws.String("rich@homie.com"),
@@ -78,7 +80,7 @@ func TestUpdateMultipleAttributes(t *testing.T) {
 
 func TestUpdateUserFailed(t *testing.T) {
 	gw := &UsersGateway{userPoolClient: &mockUpdateUserClient{serviceErr: true}}
-	assert.Error(t, gw.UpdateUser(&UpdateUserInput{
+	assert.Error(t, gw.UpdateUser(&models.UpdateUserInput{
 		ID:        aws.String("user123"),
 		GivenName: aws.String("Richie"),
 	}))

--- a/internal/core/users_api/gateway/users_gateway.go
+++ b/internal/core/users_api/gateway/users_gateway.go
@@ -32,12 +32,12 @@ var userPoolID = os.Getenv("USER_POOL_ID")
 
 // API defines the interface for the user gateway which can be used for mocking.
 type API interface {
-	CreateUser(input *CreateUserInput) (*string, error)
+	CreateUser(input *models.InviteUserInput) (*string, error)
 	DeleteUser(id *string) error
 	GetUser(id *string) (*models.User, error)
 	ListUsers() ([]*models.User, error)
 	ResetUserPassword(id *string) error
-	UpdateUser(input *UpdateUserInput) error
+	UpdateUser(input *models.UpdateUserInput) error
 }
 
 // UsersGateway encapsulates a service to Cognito Client.

--- a/tools/mage/fmt_license.go
+++ b/tools/mage/fmt_license.go
@@ -27,7 +27,6 @@ import (
 const (
 	agplSource       = "docs/LICENSE_HEADER_AGPL.txt"
 	apacheSource     = "docs/LICENSE_HEADER_APACHE.txt"
-	commercialSource = "docs/LICENSE_HEADER_PANTHER.txt"
 )
 
 var (
@@ -36,9 +35,6 @@ var (
 
 	// Standalone Go packages are Apache
 	apachePaths = []string{"pkg"}
-
-	// Enterprise closed-source code is Panther commercial license
-	commercialPaths = []string{"enterprise"}
 )
 
 // Add a comment character in front of each line in a block of license text.
@@ -61,9 +57,6 @@ func fmtLicense() {
 	logger.Info("fmt: license headers")
 	fmtLicenseGroup(agplSource, agplPaths...)
 	fmtLicenseGroup(apacheSource, apachePaths...)
-	if info, err := os.Stat("enterprise"); err == nil && info.IsDir() {
-		fmtLicenseGroup(commercialSource, commercialPaths...)
-	}
 }
 
 // Add one type of license header to a group of files.

--- a/tools/mage/fmt_license.go
+++ b/tools/mage/fmt_license.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	agplSource       = "docs/LICENSE_HEADER_AGPL.txt"
-	apacheSource     = "docs/LICENSE_HEADER_APACHE.txt"
+	agplSource   = "docs/LICENSE_HEADER_AGPL.txt"
+	apacheSource = "docs/LICENSE_HEADER_APACHE.txt"
 )
 
 var (


### PR DESCRIPTION
## Background
Fixes `UpdateUser` and `UpdateIntegration` endpoints to return the modified settings.

Closes #324 
Closes #325 
Closes #326

## Changes

- `users-api`
    - `UpdateUser` returns the new user settings. The Cognito update API does not have this information, so we just get it in the backend before returning.
    - Removes some redundant structs
- `source-api`
    - All of the update endpoints return the full integration model in their response
    - bugfix: `ScanEnabled` in `PutIntegration` is optional, but if omitted the API panics with a nil pointer dereference
    - bugfix: `UpdateIntegrationSettingsInput` includes an `AWSAccountId` field, but that field is completely ignored in the backend. It doesn't make sense to update the account ID of an existing source, so this field has been removed.
    - bugfix: The integration label is required when updating an integration but not when creating one. Changed to optional in both cases
- `mage fmt`
    - Remove unused references to `enterprise` submodule (which we will no longer be using)

## Testing

- Added integration test verification of settings update
- Deployed to dev account, invoked Lambdas directly to verify output.

Update user:

```json
{
  "createdAt": 1583174295,
  "email": "@runpanther.io",
  "familyName": "Byers",
  "givenName": "Austin",
  "id": "fce79740-d805-4121-97a5-8c31f2dc72b1",
  "status": "CONFIRMED"
}
```

Update integration:

```json
{
  "awsAccountId": "101802775469",
  "createdAtTime": "2020-03-02T20:52:51.051204342Z",
  "createdBy": "fce79740-d805-4121-97a5-8c31f2dc72b1",
  "integrationId": "ef168c2c-38ae-4141-8c6e-ff7a1a362dc7",
  "integrationLabel": "DisabledTest",
  "integrationType": "aws-scan",
  "scanEnabled": false,
  "scanIntervalMins": null,
  "s3Buckets": [],
  "kmsKeys": []
}
```
