### PR TITLE
Bug scanning buckets in us-east-1

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/s3_bucket.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/s3_bucket.go
@@ -192,8 +192,9 @@ func getBucketLocation(s3Svc s3iface.S3API, bucketName *string) *string {
 		return nil
 	}
 
+	// The get-bucket-location API call returns null for buckets in us-east-1. This behavior is not documented by AWS.
 	if out.LocationConstraint == nil {
-		return nil
+		return aws.String("us-east-1")
 	}
 
 	return out.LocationConstraint

--- a/internal/compliance/snapshot_poller/pollers/aws/s3_bucket_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/s3_bucket_test.go
@@ -21,7 +21,9 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	awsmodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
@@ -159,6 +161,22 @@ func TestS3GetBucketLocation(t *testing.T) {
 
 	out := getBucketLocation(mockSvc, awstest.ExampleBucketName)
 	assert.Equal(t, "us-west-2", *out)
+	assert.NotEmpty(t, out)
+}
+
+// Specifically test for buckets located in the us-east-1 region
+func TestS3GetBucketLocationVirginia(t *testing.T) {
+	mockSvc := &awstest.MockS3{}
+	mockSvc.On("GetBucketLocation", mock.Anything).
+		Return(
+			&s3.GetBucketLocationOutput{
+				LocationConstraint: nil,
+			},
+			nil,
+		)
+
+	out := getBucketLocation(mockSvc, awstest.ExampleBucketName)
+	assert.Equal(t, "us-east-1", *out)
 	assert.NotEmpty(t, out)
 }
 


### PR DESCRIPTION
## Background

The snapshot poller was failing to scan buckets in `us-east-1`. That is because the `get-bucket-location` API call does not work for buckets in `us-east-1`.

## Changes

- If the `get-bucket-location` API call returns `null`, then assume the bucket is in `us-east-1`

## Testing

- Deployed to development account and manually verified
- Added new unit test to handle this case
