### PR TITLE
Fixing a misnamed function

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-iam.yml
@@ -79,8 +79,8 @@ Resources:
                 - WithKmsPermissions
                 - Effect: Allow
                   Action:
-                   - kms:Decrypt
-                   - kms:DescribeKey
+                    - kms:Decrypt
+                    - kms:DescribeKey
                   Resource: !Ref EncryptionKeys
                 - !Ref AWS::NoValue
       Tags:

--- a/deployments/core/source_api.yml
+++ b/deployments/core/source_api.yml
@@ -147,4 +147,3 @@ Resources:
     Properties:
       LogGroupName: /aws/lambda/panther-source-api
       RetentionInDays: !Ref CloudWatchLogRetentionDays
-

--- a/docs/gitbook/operations/runbooks.md
+++ b/docs/gitbook/operations/runbooks.md
@@ -206,7 +206,7 @@ The `panther-rules-engine` lambda manages this table and it is used to
  * Processing of rules could be slowed or stopped if there are errors/throttles.
 
 ## panther-log-alert-forwarder
-This lambda reads from a DDB stream for the `panther-alert-dedup` table and writes alerts to the `panther-log-alerts-info` ddb table.
+This lambda reads from a DDB stream for the `panther-alert-dedup` table and writes alerts to the `panther-log-alert-info` ddb table.
  It also forwards alerts to `panther-alerts-queue` SQS queue where the appropriate Lambda picks them up for delivery.
 
  Failure Impact
@@ -215,7 +215,7 @@ This lambda reads from a DDB stream for the `panther-alert-dedup` table and writ
  * This Lambda processes alerts in batches. In case a batch partially fails, the whole batch will be retried which might lead
  to duplicate notifications for some alerts.
 
-## panther-log-alerts-info
+## panther-log-alert-info
 This table holds the alerts history and is managed by the `panther-log-alert-forwarder` lambda.
 
  Failure Impact

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
@@ -108,7 +108,7 @@ func (p *RFC3164Parser) LogType() string {
 }
 
 func (event *RFC3164) updatePantherFields(p *RFC3164Parser) {
-	event.SetCoreFieldsPtr(p.LogType(), event.Timestamp)
+	event.SetCoreFields(p.LogType(), event.Timestamp)
 
 	if event.Hostname != nil {
 		// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
@@ -197,5 +197,9 @@ func checkRFC3164(t *testing.T, log string, expectedEvent *RFC3164) {
 	require.Greater(t, len(*event.PantherRowID), 0) // ensure something is there.
 	expectedEvent.PantherRowID = event.PantherRowID
 
+	// PantherParseTime is set to time.Now().UTC(). Require not nil
+	require.NotNil(t, event.PantherParseTime)
+	expectedEvent.PantherParseTime = event.PantherParseTime
+
 	require.Equal(t, expectedEvent, event)
 }


### PR DESCRIPTION
## Background

A function was renamed in some places but not others it appears.

## Changes

- Renamed the function
- `mage fmt` caught some things

## Testing

- Unit tests
