### PR TITLE
Poller Scanning Nonexistant ECS Clusters Fix

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -93,11 +93,6 @@ func describeCluster(ecsSvc ecsiface.ECSAPI, arn *string) (*ecs.Cluster, error) 
 		return nil, nil
 	}
 
-	if len(out.Clusters) != 1 {
-		zap.L().Error("ecs.DescribeClusters did not return exactly one result", zap.Int("number of results", len(out.Clusters)))
-		return nil, nil
-	}
-
 	return out.Clusters[0], nil
 }
 

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -84,6 +84,15 @@ func describeCluster(ecsSvc ecsiface.ECSAPI, arn *string) (*ecs.Cluster, error) 
 		return nil, err
 	}
 
+	if len(out.Clusters) == 0 {
+		zap.L().Warn(
+			"tried to scan non-existent resource",
+			zap.String("resourceType", awsmodels.EcsClusterSchema),
+			zap.String("resourceId", *arn),
+		)
+		return nil, nil
+	}
+
 	if len(out.Clusters) != 1 {
 		zap.L().Error("ecs.DescribeClusters did not return exactly one result", zap.Int("number of results", len(out.Clusters)))
 		return nil, nil
@@ -254,7 +263,7 @@ func buildEcsClusterSnapshot(ecsSvc ecsiface.ECSAPI, clusterArn *string) *awsmod
 	}
 
 	details, err := describeCluster(ecsSvc, clusterArn)
-	if err != nil {
+	if err != nil || details == nil {
 		return nil
 	}
 

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster_test.go
@@ -21,7 +21,9 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	awsmodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
@@ -48,6 +50,21 @@ func TestEcsClusterDescribe(t *testing.T) {
 	out, err := describeCluster(mockSvc, awstest.ExampleClusterArn)
 	require.NoError(t, err)
 	assert.NotEmpty(t, out)
+}
+
+func TestEcsClusterDescribeDoesNotExist(t *testing.T) {
+	mockSvc := &awstest.MockEcs{}
+	mockSvc.On("DescribeClusters", mock.Anything).
+		Return(
+			&ecs.DescribeClustersOutput{
+				Clusters: nil,
+			},
+			nil,
+		)
+
+	out, err := describeCluster(mockSvc, awstest.ExampleClusterArn)
+	require.NoError(t, err)
+	assert.Nil(t, out)
 }
 
 func TestEcsClusterDescribeError(t *testing.T) {


### PR DESCRIPTION
## Background

Sometimes a request gets to the snapshot poller to scan a non-existent resource. This is most common right after the resource is deleted, as typically before it is deleted there are several API calls removing things from it which trigger a scan before the actual delete API call comes through, then the resource gets deleted before we can scan it. When that happens, the snapshot poller needs to be resilient and not log an error and certainly not panic. This change adds more graceful handling of non-existent resource scanning to the ECS cluster poller. This functionality is already present for most other pollers.

We observed this behavior in our internal deployment of Panther.

## Changes

- When DescribeClusters returns no error but also no clusters, assume it's because we received a scan request for a non-existent resource and WARN without erroring

## Testing

- Added a new unit test
- Deployed manually to my dev account, observed failed scan before and after
