### PR TITLE
Force npm resolutions for acorn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10318,16 +10318,13 @@
       "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
+        "acorn": "^7.1.1",
         "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
+          "version": "^7.1.1"
         }
       }
     },
@@ -20352,7 +20349,7 @@
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
+        "acorn": "^7.1.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
@@ -20374,10 +20371,7 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
+          "version": "^7.1.1"
         },
         "ajv": {
           "version": "6.11.0",
@@ -20457,7 +20451,7 @@
       "integrity": "sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.7",
+        "acorn": "^7.1.1",
         "acorn-walk": "^6.1.1",
         "bfj": "^6.1.1",
         "chalk": "^2.4.1",
@@ -20473,10 +20467,7 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
+          "version": "^7.1.1"
         },
         "chalk": {
           "version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6302,12 +6302,6 @@
         "negotiator": "0.6.2"
       }
     },
-    "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
-      "dev": true
-    },
     "acorn-jsx": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
@@ -10330,9 +10324,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         }
       }
@@ -20380,9 +20374,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         },
         "ajv": {
@@ -20478,6 +20472,12 @@
         "ws": "^6.0.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+          "dev": true
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,11 @@
     "react-router-dom": "^5.1.2",
     "yup": "^0.28.1"
   },
+  "resolutions": {
+    "acorn": "^7.1.1"
+  },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "build": "node web/scripts/build.js",
     "start": "node web/scripts/start.js",
     "serve": "node web/scripts/serve.js",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
   "resolutions": {
     "acorn": "^7.1.1"
   },
+  "config": {
+    "unsafe-perm": true
+  },
   "scripts": {
     "preinstall": "npx npm-force-resolutions",
     "build": "node web/scripts/build.js",


### PR DESCRIPTION
## Background

`Acorn`, a JS package that other packages have it as a dependency, recently reported a vulnerability. The packages that we are using have not yet updated to the patched version and [some won't](https://github.com/webpack/webpack/issues/10516) due to the fact that it requires bumping their packages to a  breaking change version.

Instead of waiting a few days or removing the auditing all-together, I opted for a local resolution. Specifically, I installed a hook for forcing the resolution of the `acorn` package (for all packages that have `acorn` as a dependency) to the patched version. Whenever `webpack` and `eslint` upgrade their dependencies to handle it themselves, we can safely remove this hook. Until then, it's the only way to fix the `npm audit` outputs.   

---

**These changes will be reverted, when the upstream packages update their dependencies**

## Changes

- Force resolution of `acorn` to vulnerability-patched version for all packages that use `acorn`
- Allow NPM to not assume a user (run with privileges), since it conflicts with CircleCI permissions 

## Testing

- The packages that depend on `acorn` are built-tools. I tested locally that the project gets built correctly.
