### PR TITLE
Fixing deployment issue

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -25,6 +25,8 @@ Parameters:
   MasterAccountId:
     Type: String
     Description: AWS account ID of the account running the Panther backend
+    Default: '' # DO NOT REMOTE. We need an empty value here (even though the parameter is required). The empty string will be
+    # replaced with appropriate value by Golang application.
 
   # Deployment toggles
   DeployCloudWatchEventSetup:

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -25,7 +25,6 @@ Parameters:
   MasterAccountId:
     Type: String
     Description: AWS account ID of the account running the Panther backend
-    Default: '' # MasterAccountId
 
   # Deployment toggles
   DeployCloudWatchEventSetup:

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -25,8 +25,9 @@ Parameters:
   MasterAccountId:
     Type: String
     Description: AWS account ID of the account running the Panther backend
-    Default: '' # DO NOT REMOVE. We need an empty value here (even though the parameter is required). The empty string will be
-    # replaced with appropriate value by Golang application.
+    Default: '' # MasterAccountId
+    # DO NOT EDIT OR REMOVE the above line. Panther application relies on the exact format of the above line
+    # in order to replace the MasterAccountId default value with an appropriate one.
 
   # Deployment toggles
   DeployCloudWatchEventSetup:

--- a/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-compliance-iam.yml
@@ -25,7 +25,7 @@ Parameters:
   MasterAccountId:
     Type: String
     Description: AWS account ID of the account running the Panther backend
-    Default: '' # DO NOT REMOTE. We need an empty value here (even though the parameter is required). The empty string will be
+    Default: '' # DO NOT REMOVE. We need an empty value here (even though the parameter is required). The empty string will be
     # replaced with appropriate value by Golang application.
 
   # Deployment toggles

--- a/deployments/onboard.yml
+++ b/deployments/onboard.yml
@@ -24,7 +24,6 @@ Resources:
     Properties:
       Parameters:
         MasterAccountId: !Ref AWS::AccountId
-        DeployRemediation: 'true'
-        DeployCloudWatchEventSetup: 'true'
-        DeployAuditRole: 'true'
+        DeployRemediation: true
+        DeployCloudWatchEventSetup: true
       TemplateURL: auxiliary/cloudformation/panther-compliance-iam.yml

--- a/deployments/onboard.yml
+++ b/deployments/onboard.yml
@@ -24,6 +24,6 @@ Resources:
     Properties:
       Parameters:
         MasterAccountId: !Ref AWS::AccountId
-        DeployRemediation: true
-        DeployCloudWatchEventSetup: true
+        DeployRemediation: 'true'
+        DeployCloudWatchEventSetup: 'true'
       TemplateURL: auxiliary/cloudformation/panther-compliance-iam.yml


### PR DESCRIPTION
## Background

Currently it is not possible to deploy from master due to an issue in the CFN templates. The `onboard.yml` is providing property `DeployAuditRole` to the `panther-compliance-iam.yml` template, but such property doesn't exist. 

## Changes

- Removed `DeployAuditRole` property from `onboard.yml`
- Removed default `MasterAccountId`. Such a default doesn't really make sense, the template cannot be deployed without it. 

## Testing

- Successfully deployed to my dev account. 
