### PR TITLE
Returning the dedup string that was used in an alert creation

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -75,6 +75,7 @@ type AlertDetails {
   eventsMatched: Int!
   events: [AWSJSON!]!
   eventsLastEvaluatedKey: String
+  dedupString: String
 }
 
 type ListAlertsResponse {
@@ -89,6 +90,7 @@ type AlertSummary {
   updateTime: AWSDateTime!
   ruleId: String
   severity: String
+  dedupString: String
 }
 
 input ListRulesInput {

--- a/api/lambda/alerts/models/api.go
+++ b/api/lambda/alerts/models/api.go
@@ -85,6 +85,7 @@ type ListAlertsOutput struct {
 type AlertSummary struct {
 	AlertID       *string    `json:"alertId"`
 	RuleID        *string    `json:"ruleId"`
+	DedupString   *string    `json:"dedupString"`
 	CreationTime  *time.Time `json:"creationTime"`
 	UpdateTime    *time.Time `json:"updateTime"`
 	EventsMatched *int       `json:"eventsMatched"`
@@ -95,6 +96,7 @@ type AlertSummary struct {
 type Alert struct {
 	AlertID                *string    `json:"alertId"`
 	RuleID                 *string    `json:"ruleId"`
+	DedupString            *string    `json:"dedupString"`
 	CreationTime           *time.Time `json:"creationTime"`
 	UpdateTime             *time.Time `json:"updateTime"`
 	EventsMatched          *int       `json:"eventsMatched"`

--- a/internal/log_analysis/alerts_api/api/api.go
+++ b/internal/log_analysis/alerts_api/api/api.go
@@ -89,12 +89,12 @@ func (t *EventPaginationToken) encode() (string, error) {
 }
 
 func decodePaginationToken(token string) (*EventPaginationToken, error) {
-	unmarshalled, err := base64.URLEncoding.DecodeString(token)
+	unmarshaled, err := base64.URLEncoding.DecodeString(token)
 	if err != nil {
 		return nil, err
 	}
 	result := &EventPaginationToken{}
-	if err = jsoniter.Unmarshal(unmarshalled, result); err != nil {
+	if err = jsoniter.Unmarshal(unmarshaled, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/internal/log_analysis/alerts_api/api/get_alert.go
+++ b/internal/log_analysis/alerts_api/api/get_alert.go
@@ -92,6 +92,7 @@ func (API) GetAlert(input *models.GetAlertInput) (result *models.GetAlertOutput,
 	result = &models.Alert{
 		AlertID:                &alertItem.AlertID,
 		RuleID:                 &alertItem.RuleID,
+		DedupString:            &alertItem.DedupString,
 		CreationTime:           &alertItem.CreationTime,
 		UpdateTime:             &alertItem.UpdateTime,
 		EventsMatched:          &alertItem.EventCount,

--- a/internal/log_analysis/alerts_api/api/get_alert_test.go
+++ b/internal/log_analysis/alerts_api/api/get_alert_test.go
@@ -114,7 +114,7 @@ func TestGetAlert(t *testing.T) {
 	alertItem := &table.AlertItem{
 		AlertID:      "alertId",
 		RuleID:       "ruleId",
-		DedupString: "dedupString",
+		DedupString:  "dedupString",
 		CreationTime: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC),
 		UpdateTime:   time.Date(2020, 1, 1, 1, 59, 0, 0, time.UTC),
 		Severity:     "INFO",
@@ -160,7 +160,7 @@ func TestGetAlert(t *testing.T) {
 	require.Equal(t, &models.GetAlertOutput{
 		AlertID:       aws.String("alertId"),
 		RuleID:        aws.String("ruleId"),
-		DedupString: aws.String("dedupString"),
+		DedupString:   aws.String("dedupString"),
 		CreationTime:  aws.Time(time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)),
 		UpdateTime:    aws.Time(time.Date(2020, 1, 1, 1, 59, 0, 0, time.UTC)),
 		EventsMatched: aws.Int(5),

--- a/internal/log_analysis/alerts_api/api/get_alert_test.go
+++ b/internal/log_analysis/alerts_api/api/get_alert_test.go
@@ -203,6 +203,7 @@ func TestGetAlertFilterOutS3KeysOutsideTheTimePeriod(t *testing.T) {
 		UpdateTime:   time.Date(2020, 1, 1, 1, 6, 0, 0, time.UTC),
 		Severity:     "INFO",
 		EventCount:   5,
+		DedupString:  "dedupString",
 		LogTypes:     []string{"logtype"},
 	}
 
@@ -228,6 +229,7 @@ func TestGetAlertFilterOutS3KeysOutsideTheTimePeriod(t *testing.T) {
 		CreationTime:  aws.Time(time.Date(2020, 1, 1, 1, 5, 0, 0, time.UTC)),
 		UpdateTime:    aws.Time(time.Date(2020, 1, 1, 1, 6, 0, 0, time.UTC)),
 		EventsMatched: aws.Int(5),
+		DedupString:   aws.String("dedupString"),
 		Events:        aws.StringSlice([]string{"testEvent"}),
 		EventsLastEvaluatedKey:
 		// nolint

--- a/internal/log_analysis/alerts_api/api/get_alert_test.go
+++ b/internal/log_analysis/alerts_api/api/get_alert_test.go
@@ -79,6 +79,16 @@ func (m *tableMock) GetAlert(input *string) (*table.AlertItem, error) {
 	return args.Get(0).(*table.AlertItem), args.Error(1)
 }
 
+func (m *tableMock) ListByRule(rule string, startKey *string, pageSize *int) ([]*table.AlertItem, *string, error) {
+	args := m.Called(rule, startKey, pageSize)
+	return args.Get(0).([]*table.AlertItem), args.Get(1).(*string), args.Error(2)
+}
+
+func (m *tableMock) ListAll(startKey *string, pageSize *int) ([]*table.AlertItem, *string, error) {
+	args := m.Called(startKey, pageSize)
+	return args.Get(0).([]*table.AlertItem), args.Get(1).(*string), args.Error(2)
+}
+
 func init() {
 	env = envConfig{
 		ProcessedDataBucket: "bucket",
@@ -104,6 +114,7 @@ func TestGetAlert(t *testing.T) {
 	alertItem := &table.AlertItem{
 		AlertID:      "alertId",
 		RuleID:       "ruleId",
+		DedupString: "dedupString",
 		CreationTime: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC),
 		UpdateTime:   time.Date(2020, 1, 1, 1, 59, 0, 0, time.UTC),
 		Severity:     "INFO",
@@ -149,6 +160,7 @@ func TestGetAlert(t *testing.T) {
 	require.Equal(t, &models.GetAlertOutput{
 		AlertID:       aws.String("alertId"),
 		RuleID:        aws.String("ruleId"),
+		DedupString: aws.String("dedupString"),
 		CreationTime:  aws.Time(time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)),
 		UpdateTime:    aws.Time(time.Date(2020, 1, 1, 1, 59, 0, 0, time.UTC)),
 		EventsMatched: aws.Int(5),

--- a/internal/log_analysis/alerts_api/api/list_alerts.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts.go
@@ -58,6 +58,7 @@ func alertItemsToAlertSummary(items []*table.AlertItem) []*models.AlertSummary {
 		result[i] = &models.AlertSummary{
 			AlertID:       &item.AlertID,
 			RuleID:        &item.RuleID,
+			DedupString:   &item.DedupString,
 			CreationTime:  &item.CreationTime,
 			Severity:      &item.Severity,
 			UpdateTime:    &item.UpdateTime,

--- a/internal/log_analysis/alerts_api/api/list_alerts_test.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts_test.go
@@ -1,5 +1,23 @@
 package api
 
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import (
 	"testing"
 	"time"
@@ -15,33 +33,33 @@ import (
 var (
 	timeInTest = time.Now()
 
-	alertItems = []*table.AlertItem {
+	alertItems = []*table.AlertItem{
 		{
-			RuleID: "ruleId",
-			AlertID: "alertId",
-			UpdateTime: timeInTest,
+			RuleID:       "ruleId",
+			AlertID:      "alertId",
+			UpdateTime:   timeInTest,
 			CreationTime: timeInTest,
-			Severity: "INFO",
-			DedupString: "dedupString",
-			LogTypes: []string{"AWS.CloudTrail"},
-			EventCount: 100,
+			Severity:     "INFO",
+			DedupString:  "dedupString",
+			LogTypes:     []string{"AWS.CloudTrail"},
+			EventCount:   100,
 		},
 	}
 
-	expectedAlertSummary = []*models.AlertSummary {
+	expectedAlertSummary = []*models.AlertSummary{
 		{
-			RuleID: aws.String("ruleId"),
-			AlertID: aws.String("alertId"),
-			UpdateTime: aws.Time(timeInTest),
-			CreationTime: aws.Time(timeInTest),
-			Severity: aws.String("INFO"),
-			DedupString: aws.String("dedupString"),
+			RuleID:        aws.String("ruleId"),
+			AlertID:       aws.String("alertId"),
+			UpdateTime:    aws.Time(timeInTest),
+			CreationTime:  aws.Time(timeInTest),
+			Severity:      aws.String("INFO"),
+			DedupString:   aws.String("dedupString"),
 			EventsMatched: aws.Int(100),
 		},
 	}
 )
 
-func TestListAlertsForRule(t *testing.T)  {
+func TestListAlertsForRule(t *testing.T) {
 	tableMock := &tableMock{}
 	alertsDB = tableMock
 
@@ -62,7 +80,7 @@ func TestListAlertsForRule(t *testing.T)  {
 	}, result)
 }
 
-func TestListAllAlerts(t *testing.T)  {
+func TestListAllAlerts(t *testing.T) {
 	tableMock := &tableMock{}
 	alertsDB = tableMock
 

--- a/internal/log_analysis/alerts_api/api/list_alerts_test.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/api/lambda/alerts/models"
+	"github.com/panther-labs/panther/internal/log_analysis/alerts_api/table"
+)
+
+var (
+	timeInTest = time.Now()
+
+	alertItems = []*table.AlertItem {
+		{
+			RuleID: "ruleId",
+			AlertID: "alertId",
+			UpdateTime: timeInTest,
+			CreationTime: timeInTest,
+			Severity: "INFO",
+			DedupString: "dedupString",
+			LogTypes: []string{"AWS.CloudTrail"},
+			EventCount: 100,
+		},
+	}
+
+	expectedAlertSummary = []*models.AlertSummary {
+		{
+			RuleID: aws.String("ruleId"),
+			AlertID: aws.String("alertId"),
+			UpdateTime: aws.Time(timeInTest),
+			CreationTime: aws.Time(timeInTest),
+			Severity: aws.String("INFO"),
+			DedupString: aws.String("dedupString"),
+			EventsMatched: aws.Int(100),
+		},
+	}
+)
+
+func TestListAlertsForRule(t *testing.T)  {
+	tableMock := &tableMock{}
+	alertsDB = tableMock
+
+	input := &models.ListAlertsInput{
+		RuleID:            aws.String("ruleId"),
+		PageSize:          aws.Int(10),
+		ExclusiveStartKey: aws.String("startKey"),
+	}
+
+	tableMock.On("ListByRule", "ruleId", aws.String("startKey"), aws.Int(10)).
+		Return(alertItems, aws.String("lastKey"), nil)
+	result, err := API{}.ListAlerts(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, &models.ListAlertsOutput{
+		Alerts:           expectedAlertSummary,
+		LastEvaluatedKey: aws.String("lastKey"),
+	}, result)
+}
+
+func TestListAllAlerts(t *testing.T)  {
+	tableMock := &tableMock{}
+	alertsDB = tableMock
+
+	input := &models.ListAlertsInput{
+		PageSize:          aws.Int(10),
+		ExclusiveStartKey: aws.String("startKey"),
+	}
+
+	tableMock.On("ListAll", aws.String("startKey"), aws.Int(10)).
+		Return(alertItems, aws.String("lastKey"), nil)
+	result, err := API{}.ListAlerts(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, &models.ListAlertsOutput{
+		Alerts:           expectedAlertSummary,
+		LastEvaluatedKey: aws.String("lastKey"),
+	}, result)
+}

--- a/internal/log_analysis/alerts_api/table/table.go
+++ b/internal/log_analysis/alerts_api/table/table.go
@@ -58,6 +58,7 @@ type DynamoItem = map[string]*dynamodb.AttributeValue
 type AlertItem struct {
 	AlertID      string    `json:"id"`
 	RuleID       string    `json:"ruleId"`
+	DedupString  string    `json:"dedup"`
 	CreationTime time.Time `json:"creationTime"`
 	UpdateTime   time.Time `json:"updateTime"`
 	Severity     string    `json:"severity"`

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -41,6 +41,7 @@ export type AlertDetails = {
   creationTime: Scalars['AWSDateTime'];
   updateTime: Scalars['AWSDateTime'];
   eventsMatched: Scalars['Int'];
+  dedupString: Scalars['String'];
   events: Array<Scalars['AWSJSON']>;
   eventsLastEvaluatedKey?: Maybe<Scalars['String']>;
 };

--- a/web/src/pages/AlertDetails/AlertDetails.tsx
+++ b/web/src/pages/AlertDetails/AlertDetails.tsx
@@ -37,6 +37,7 @@ export const ALERT_DETAILS = gql`
       creationTime
       eventsMatched
       updateTime
+      dedupString
       eventsLastEvaluatedKey
       events
     }

--- a/web/src/pages/ListAlerts/ListAlerts.tsx
+++ b/web/src/pages/ListAlerts/ListAlerts.tsx
@@ -38,6 +38,7 @@ export const LIST_ALERTS = gql`
         updateTime
         ruleId
         severity
+        dedupString
       }
       lastEvaluatedKey
     }


### PR DESCRIPTION
## Background

Return the dedup string that was used in alert creation. This value will eventually be displayed by frontend. 

Closes #345 

## Changes

- Modified Alerts API to return the dedup string that was used in generation of an alert.
- Added unit test for ListAlerts API operation

## Testing

- Unit tests
- Deployed and verified in my dev environment
