### PR TITLE
Minor Fixes

### DIFF
--- a/internal/compliance/alert_processor/processor/processor_test.go
+++ b/internal/compliance/alert_processor/processor/processor_test.go
@@ -87,7 +87,7 @@ func TestHandleEventWithAlert(t *testing.T) {
 
 	// mock call to compliance-api
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(complianceResponse, http.StatusOK), nil).Once()
-	// mock call to policy-api
+	// mock call to analysis-api
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(policyResponse, http.StatusOK), nil).Once()
 	// mock call to remediate-api
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse("", http.StatusOK), nil).Once()
@@ -130,7 +130,7 @@ func TestHandleEventWithAlertButNoAutoRemediationID(t *testing.T) {
 
 	// mock call to compliance-api
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(complianceResponse, http.StatusOK), nil).Once()
-	// mock call to policy-api
+	// mock call to analysis-api
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(policyResponse, http.StatusOK), nil).Once()
 	// should NOT call remediation api!
 

--- a/internal/compliance/aws_event_processor/processor/process.go
+++ b/internal/compliance/aws_event_processor/processor/process.go
@@ -129,6 +129,8 @@ var (
 
 		// ec2
 		"DeleteNetworkInterface": {}, // we handle "DetachNetworkInterface"
+		"CreateInternetGateway":  {}, // Currently we don't have an EC2 InternetGateway resource,
+		"DeleteInternetGateway":  {}, // when we do we will need to handle these
 
 		// ecs
 		"DeleteAccountSetting":     {},

--- a/internal/compliance/compliance_api/main/integration_test.go
+++ b/internal/compliance/compliance_api/main/integration_test.go
@@ -319,7 +319,7 @@ func describeOrgResource(t *testing.T) {
 // A policy which doesn't exist returns empty results.
 //
 // We don't return 404 because a disabled policy will not exist in the compliance-api but would
-// in the policy-api
+// in the analysis-api
 func describePolicyEmpty(t *testing.T) {
 	t.Parallel()
 	result, err := apiClient.Operations.DescribePolicy(&operations.DescribePolicyParams{

--- a/internal/compliance/resource_processor/processor/analysis_api.go
+++ b/internal/compliance/resource_processor/processor/analysis_api.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/gateway/analysis/client/operations"
+	"github.com/panther-labs/panther/api/gateway/analysis/models"
 )
 
 const cacheDuration = 30 * time.Second
@@ -35,7 +36,7 @@ type policyCacheEntry struct {
 
 var policyCache policyCacheEntry
 
-// Get enabled policies from either the memory cache or the policy-api
+// Get enabled policies from either the memory cache or the analysis-api
 func getPolicies() (policyMap, error) {
 	if policyCache.Policies != nil && policyCache.LastUpdated.Add(cacheDuration).After(time.Now()) {
 		// Cache entry exists and hasn't expired yet
@@ -46,7 +47,7 @@ func getPolicies() (policyMap, error) {
 
 	// Load from policy-api
 	result, err := analysisClient.Operations.GetEnabledPolicies(
-		&operations.GetEnabledPoliciesParams{HTTPClient: httpClient})
+		&operations.GetEnabledPoliciesParams{HTTPClient: httpClient, Type: string(models.AnalysisTypePOLICY)})
 	if err != nil {
 		zap.L().Error("failed to load policies from policy-api", zap.Error(err))
 		return nil, err

--- a/internal/compliance/resource_processor/processor/analysis_api.go
+++ b/internal/compliance/resource_processor/processor/analysis_api.go
@@ -45,14 +45,14 @@ func getPolicies() (policyMap, error) {
 		return policyCache.Policies, nil
 	}
 
-	// Load from policy-api
+	// Load from analysis-api
 	result, err := analysisClient.Operations.GetEnabledPolicies(
 		&operations.GetEnabledPoliciesParams{HTTPClient: httpClient, Type: string(models.AnalysisTypePOLICY)})
 	if err != nil {
-		zap.L().Error("failed to load policies from policy-api", zap.Error(err))
+		zap.L().Error("failed to load policies from analysis-api", zap.Error(err))
 		return nil, err
 	}
-	zap.L().Info("successfully loaded enabled policies from policy-api",
+	zap.L().Info("successfully loaded enabled policies from analysis-api",
 		zap.Int("policyCount", len(result.Payload.Policies)))
 
 	// Convert list of policies into a map by ID

--- a/internal/compliance/resource_processor/processor/handler.go
+++ b/internal/compliance/resource_processor/processor/handler.go
@@ -146,7 +146,7 @@ func (r *batchResults) analyzeUpdatedPolicy(policy *analysismodels.Policy) error
 
 // Analyze each org in turn and report status entries and alert notifications across the entire batch
 //
-// Policies can either be provided by the caller or else they will be fetched from policy-api.
+// Policies can either be provided by the caller or else they will be fetched from analysis-api.
 func (r *batchResults) analyze(resources resourceMap, policies policyMap) error {
 	// Fetch policies and evaluate them against the resources
 	var err error


### PR DESCRIPTION
## Background

When #357 merged, the resource-processor was broken because it relied on the default behavior of `GetEnabledPolicies` which was removed in that PR. This adds the explicit analysis type to the call.

Additionally, I added two more events to the aws-event-processor ignore list that were pointed out by @rleighton as particularly noisy.

## Changes

- Added explicit analysis-type to `GetEnabledPolicies` call
- Updated `policy-api` references to `analysis-api`
- Added two new events to `aws-event-processor` ignore list 

## Testing

- Deployed to dev account and manually verified
