### PR TITLE
Fix swagger generation

### DIFF
--- a/api/gateway/compliance/client/operations/delete_status_parameters.go
+++ b/api/gateway/compliance/client/operations/delete_status_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // NewDeleteStatusParams creates a new DeleteStatusParams object

--- a/api/gateway/compliance/client/operations/delete_status_responses.go
+++ b/api/gateway/compliance/client/operations/delete_status_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // DeleteStatusReader is a Reader for the DeleteStatus structure.

--- a/api/gateway/compliance/client/operations/describe_org_responses.go
+++ b/api/gateway/compliance/client/operations/describe_org_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // DescribeOrgReader is a Reader for the DescribeOrg structure.

--- a/api/gateway/compliance/client/operations/describe_policy_responses.go
+++ b/api/gateway/compliance/client/operations/describe_policy_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // DescribePolicyReader is a Reader for the DescribePolicy structure.

--- a/api/gateway/compliance/client/operations/describe_resource_responses.go
+++ b/api/gateway/compliance/client/operations/describe_resource_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // DescribeResourceReader is a Reader for the DescribeResource structure.

--- a/api/gateway/compliance/client/operations/get_org_overview_responses.go
+++ b/api/gateway/compliance/client/operations/get_org_overview_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // GetOrgOverviewReader is a Reader for the GetOrgOverview structure.

--- a/api/gateway/compliance/client/operations/get_status_responses.go
+++ b/api/gateway/compliance/client/operations/get_status_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // GetStatusReader is a Reader for the GetStatus structure.

--- a/api/gateway/compliance/client/operations/operations_client.go
+++ b/api/gateway/compliance/client/operations/operations_client.go
@@ -27,11 +27,11 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new operations API client.
-func New(transport runtime.ClientTransport, formats strfmt.Registry) *Client {
+func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
 }
 
@@ -43,8 +43,29 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientService is the interface for Client methods
+type ClientService interface {
+	DeleteStatus(params *DeleteStatusParams) (*DeleteStatusOK, error)
+
+	DescribeOrg(params *DescribeOrgParams) (*DescribeOrgOK, error)
+
+	DescribePolicy(params *DescribePolicyParams) (*DescribePolicyOK, error)
+
+	DescribeResource(params *DescribeResourceParams) (*DescribeResourceOK, error)
+
+	GetOrgOverview(params *GetOrgOverviewParams) (*GetOrgOverviewOK, error)
+
+	GetStatus(params *GetStatusParams) (*GetStatusOK, error)
+
+	SetStatus(params *SetStatusParams) (*SetStatusCreated, error)
+
+	UpdateMetadata(params *UpdateMetadataParams) (*UpdateMetadataOK, error)
+
+	SetTransport(transport runtime.ClientTransport)
+}
+
 /*
-DeleteStatus deletes the status associated with one or more policies or resources
+  DeleteStatus deletes the status associated with one or more policies or resources
 */
 func (a *Client) DeleteStatus(params *DeleteStatusParams) (*DeleteStatusOK, error) {
 	// TODO: Validate the params before sending
@@ -78,7 +99,7 @@ func (a *Client) DeleteStatus(params *DeleteStatusParams) (*DeleteStatusOK, erro
 }
 
 /*
-DescribeOrg lists pass fail status for every policy and resource in the org
+  DescribeOrg lists pass fail status for every policy and resource in the org
 */
 func (a *Client) DescribeOrg(params *DescribeOrgParams) (*DescribeOrgOK, error) {
 	// TODO: Validate the params before sending
@@ -112,7 +133,7 @@ func (a *Client) DescribeOrg(params *DescribeOrgParams) (*DescribeOrgOK, error) 
 }
 
 /*
-DescribePolicy pages through resources affected by a specific policy
+  DescribePolicy pages through resources affected by a specific policy
 */
 func (a *Client) DescribePolicy(params *DescribePolicyParams) (*DescribePolicyOK, error) {
 	// TODO: Validate the params before sending
@@ -146,7 +167,7 @@ func (a *Client) DescribePolicy(params *DescribePolicyParams) (*DescribePolicyOK
 }
 
 /*
-DescribeResource pages through policies which affect this resource
+  DescribeResource pages through policies which affect this resource
 */
 func (a *Client) DescribeResource(params *DescribeResourceParams) (*DescribeResourceOK, error) {
 	// TODO: Validate the params before sending
@@ -180,7 +201,7 @@ func (a *Client) DescribeResource(params *DescribeResourceParams) (*DescribeReso
 }
 
 /*
-GetOrgOverview gets account totals and top failing policies resources
+  GetOrgOverview gets account totals and top failing policies resources
 */
 func (a *Client) GetOrgOverview(params *GetOrgOverviewParams) (*GetOrgOverviewOK, error) {
 	// TODO: Validate the params before sending
@@ -214,7 +235,7 @@ func (a *Client) GetOrgOverview(params *GetOrgOverviewParams) (*GetOrgOverviewOK
 }
 
 /*
-GetStatus gets compliance status for a single policy resource pair
+  GetStatus gets compliance status for a single policy resource pair
 */
 func (a *Client) GetStatus(params *GetStatusParams) (*GetStatusOK, error) {
 	// TODO: Validate the params before sending
@@ -248,7 +269,7 @@ func (a *Client) GetStatus(params *GetStatusParams) (*GetStatusOK, error) {
 }
 
 /*
-SetStatus sets the compliance status for a batch of resource policy pairs
+  SetStatus sets the compliance status for a batch of resource policy pairs
 */
 func (a *Client) SetStatus(params *SetStatusParams) (*SetStatusCreated, error) {
 	// TODO: Validate the params before sending
@@ -282,7 +303,7 @@ func (a *Client) SetStatus(params *SetStatusParams) (*SetStatusCreated, error) {
 }
 
 /*
-UpdateMetadata updates
+  UpdateMetadata updates
 */
 func (a *Client) UpdateMetadata(params *UpdateMetadataParams) (*UpdateMetadataOK, error) {
 	// TODO: Validate the params before sending

--- a/api/gateway/compliance/client/operations/set_status_parameters.go
+++ b/api/gateway/compliance/client/operations/set_status_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // NewSetStatusParams creates a new SetStatusParams object

--- a/api/gateway/compliance/client/operations/set_status_responses.go
+++ b/api/gateway/compliance/client/operations/set_status_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // SetStatusReader is a Reader for the SetStatus structure.

--- a/api/gateway/compliance/client/operations/update_metadata_parameters.go
+++ b/api/gateway/compliance/client/operations/update_metadata_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // NewUpdateMetadataParams creates a new UpdateMetadataParams object

--- a/api/gateway/compliance/client/operations/update_metadata_responses.go
+++ b/api/gateway/compliance/client/operations/update_metadata_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/compliance/models"
+	"github.com/panther-labs/panther/api/gateway/compliance/models"
 )
 
 // UpdateMetadataReader is a Reader for the UpdateMetadata structure.

--- a/api/gateway/compliance/client/panther_compliance_client.go
+++ b/api/gateway/compliance/client/panther_compliance_client.go
@@ -26,7 +26,7 @@ package client
 import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 
 	"github.com/panther-labs/panther/api/gateway/compliance/client/operations"
 )
@@ -73,9 +73,7 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) *PantherCom
 
 	cli := new(PantherCompliance)
 	cli.Transport = transport
-
 	cli.Operations = operations.New(transport, formats)
-
 	return cli
 }
 
@@ -120,7 +118,7 @@ func (cfg *TransportConfig) WithSchemes(schemes []string) *TransportConfig {
 
 // PantherCompliance is a client for panther compliance
 type PantherCompliance struct {
-	Operations *operations.Client
+	Operations operations.ClientService
 
 	Transport runtime.ClientTransport
 }
@@ -128,7 +126,5 @@ type PantherCompliance struct {
 // SetTransport changes the transport on the client and all its subresources
 func (c *PantherCompliance) SetTransport(transport runtime.ClientTransport) {
 	c.Transport = transport
-
 	c.Operations.SetTransport(transport)
-
 }

--- a/api/gateway/remediation/client/operations/list_remediations_responses.go
+++ b/api/gateway/remediation/client/operations/list_remediations_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/remediation/models"
+	"github.com/panther-labs/panther/api/gateway/remediation/models"
 )
 
 // ListRemediationsReader is a Reader for the ListRemediations structure.

--- a/api/gateway/remediation/client/operations/operations_client.go
+++ b/api/gateway/remediation/client/operations/operations_client.go
@@ -27,11 +27,11 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new operations API client.
-func New(transport runtime.ClientTransport, formats strfmt.Registry) *Client {
+func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
 }
 
@@ -43,8 +43,19 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientService is the interface for Client methods
+type ClientService interface {
+	ListRemediations(params *ListRemediationsParams) (*ListRemediationsOK, error)
+
+	RemediateResource(params *RemediateResourceParams) (*RemediateResourceOK, error)
+
+	RemediateResourceAsync(params *RemediateResourceAsyncParams) (*RemediateResourceAsyncOK, error)
+
+	SetTransport(transport runtime.ClientTransport)
+}
+
 /*
-ListRemediations retrieves available remediations
+  ListRemediations retrieves available remediations
 */
 func (a *Client) ListRemediations(params *ListRemediationsParams) (*ListRemediationsOK, error) {
 	// TODO: Validate the params before sending
@@ -78,7 +89,7 @@ func (a *Client) ListRemediations(params *ListRemediationsParams) (*ListRemediat
 }
 
 /*
-RemediateResource synchronouslies remediate resource for an account
+  RemediateResource synchronouslies remediate resource for an account
 */
 func (a *Client) RemediateResource(params *RemediateResourceParams) (*RemediateResourceOK, error) {
 	// TODO: Validate the params before sending
@@ -112,7 +123,7 @@ func (a *Client) RemediateResource(params *RemediateResourceParams) (*RemediateR
 }
 
 /*
-RemediateResourceAsync asynchronouslies remediate resource for an account
+  RemediateResourceAsync asynchronouslies remediate resource for an account
 */
 func (a *Client) RemediateResourceAsync(params *RemediateResourceAsyncParams) (*RemediateResourceAsyncOK, error) {
 	// TODO: Validate the params before sending

--- a/api/gateway/remediation/client/operations/remediate_resource_async_parameters.go
+++ b/api/gateway/remediation/client/operations/remediate_resource_async_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/remediation/models"
+	"github.com/panther-labs/panther/api/gateway/remediation/models"
 )
 
 // NewRemediateResourceAsyncParams creates a new RemediateResourceAsyncParams object

--- a/api/gateway/remediation/client/operations/remediate_resource_async_responses.go
+++ b/api/gateway/remediation/client/operations/remediate_resource_async_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/remediation/models"
+	"github.com/panther-labs/panther/api/gateway/remediation/models"
 )
 
 // RemediateResourceAsyncReader is a Reader for the RemediateResourceAsync structure.

--- a/api/gateway/remediation/client/operations/remediate_resource_parameters.go
+++ b/api/gateway/remediation/client/operations/remediate_resource_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/remediation/models"
+	"github.com/panther-labs/panther/api/gateway/remediation/models"
 )
 
 // NewRemediateResourceParams creates a new RemediateResourceParams object

--- a/api/gateway/remediation/client/operations/remediate_resource_responses.go
+++ b/api/gateway/remediation/client/operations/remediate_resource_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/remediation/models"
+	"github.com/panther-labs/panther/api/gateway/remediation/models"
 )
 
 // RemediateResourceReader is a Reader for the RemediateResource structure.

--- a/api/gateway/remediation/client/panther_remediation_client.go
+++ b/api/gateway/remediation/client/panther_remediation_client.go
@@ -26,7 +26,7 @@ package client
 import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 
 	"github.com/panther-labs/panther/api/gateway/remediation/client/operations"
 )
@@ -73,9 +73,7 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) *PantherRem
 
 	cli := new(PantherRemediation)
 	cli.Transport = transport
-
 	cli.Operations = operations.New(transport, formats)
-
 	return cli
 }
 
@@ -120,7 +118,7 @@ func (cfg *TransportConfig) WithSchemes(schemes []string) *TransportConfig {
 
 // PantherRemediation is a client for panther remediation
 type PantherRemediation struct {
-	Operations *operations.Client
+	Operations operations.ClientService
 
 	Transport runtime.ClientTransport
 }
@@ -128,7 +126,5 @@ type PantherRemediation struct {
 // SetTransport changes the transport on the client and all its subresources
 func (c *PantherRemediation) SetTransport(transport runtime.ClientTransport) {
 	c.Transport = transport
-
 	c.Operations.SetTransport(transport)
-
 }

--- a/api/gateway/remediation/models/error.go
+++ b/api/gateway/remediation/models/error.go
@@ -39,10 +39,6 @@ type Error struct {
 	Message *string `json:"message"`
 }
 
-func (m *Error) Error() string {
-	return *m.Message
-}
-
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
 	var res []error

--- a/api/gateway/resources/client/operations/add_resources_parameters.go
+++ b/api/gateway/resources/client/operations/add_resources_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // NewAddResourcesParams creates a new AddResourcesParams object

--- a/api/gateway/resources/client/operations/add_resources_responses.go
+++ b/api/gateway/resources/client/operations/add_resources_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // AddResourcesReader is a Reader for the AddResources structure.

--- a/api/gateway/resources/client/operations/delete_resources_parameters.go
+++ b/api/gateway/resources/client/operations/delete_resources_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // NewDeleteResourcesParams creates a new DeleteResourcesParams object

--- a/api/gateway/resources/client/operations/delete_resources_responses.go
+++ b/api/gateway/resources/client/operations/delete_resources_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // DeleteResourcesReader is a Reader for the DeleteResources structure.

--- a/api/gateway/resources/client/operations/get_org_overview_responses.go
+++ b/api/gateway/resources/client/operations/get_org_overview_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // GetOrgOverviewReader is a Reader for the GetOrgOverview structure.

--- a/api/gateway/resources/client/operations/get_resource_responses.go
+++ b/api/gateway/resources/client/operations/get_resource_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // GetResourceReader is a Reader for the GetResource structure.

--- a/api/gateway/resources/client/operations/list_resources_responses.go
+++ b/api/gateway/resources/client/operations/list_resources_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // ListResourcesReader is a Reader for the ListResources structure.

--- a/api/gateway/resources/client/operations/modify_resource_parameters.go
+++ b/api/gateway/resources/client/operations/modify_resource_parameters.go
@@ -33,7 +33,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // NewModifyResourceParams creates a new ModifyResourceParams object

--- a/api/gateway/resources/client/operations/modify_resource_responses.go
+++ b/api/gateway/resources/client/operations/modify_resource_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/panther-labs/panther/api/gateway/resources/models"
+	"github.com/panther-labs/panther/api/gateway/resources/models"
 )
 
 // ModifyResourceReader is a Reader for the ModifyResource structure.

--- a/api/gateway/resources/client/operations/operations_client.go
+++ b/api/gateway/resources/client/operations/operations_client.go
@@ -27,11 +27,11 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new operations API client.
-func New(transport runtime.ClientTransport, formats strfmt.Registry) *Client {
+func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
 }
 
@@ -43,8 +43,25 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientService is the interface for Client methods
+type ClientService interface {
+	AddResources(params *AddResourcesParams) (*AddResourcesCreated, error)
+
+	DeleteResources(params *DeleteResourcesParams) (*DeleteResourcesOK, error)
+
+	GetOrgOverview(params *GetOrgOverviewParams) (*GetOrgOverviewOK, error)
+
+	GetResource(params *GetResourceParams) (*GetResourceOK, error)
+
+	ListResources(params *ListResourcesParams) (*ListResourcesOK, error)
+
+	ModifyResource(params *ModifyResourceParams) (*ModifyResourceOK, error)
+
+	SetTransport(transport runtime.ClientTransport)
+}
+
 /*
-AddResources adds or replace resources across one or more accounts
+  AddResources adds or replace resources across one or more accounts
 */
 func (a *Client) AddResources(params *AddResourcesParams) (*AddResourcesCreated, error) {
 	// TODO: Validate the params before sending
@@ -78,7 +95,7 @@ func (a *Client) AddResources(params *AddResourcesParams) (*AddResourcesCreated,
 }
 
 /*
-DeleteResources deletes resources across multiple accounts
+  DeleteResources deletes resources across multiple accounts
 */
 func (a *Client) DeleteResources(params *DeleteResourcesParams) (*DeleteResourcesOK, error) {
 	// TODO: Validate the params before sending
@@ -112,7 +129,7 @@ func (a *Client) DeleteResources(params *DeleteResourcesParams) (*DeleteResource
 }
 
 /*
-GetOrgOverview gets an overview of the resources in an organization
+  GetOrgOverview gets an overview of the resources in an organization
 */
 func (a *Client) GetOrgOverview(params *GetOrgOverviewParams) (*GetOrgOverviewOK, error) {
 	// TODO: Validate the params before sending
@@ -146,7 +163,7 @@ func (a *Client) GetOrgOverview(params *GetOrgOverviewParams) (*GetOrgOverviewOK
 }
 
 /*
-GetResource gets resource details
+  GetResource gets resource details
 */
 func (a *Client) GetResource(params *GetResourceParams) (*GetResourceOK, error) {
 	// TODO: Validate the params before sending
@@ -180,7 +197,7 @@ func (a *Client) GetResource(params *GetResourceParams) (*GetResourceOK, error) 
 }
 
 /*
-ListResources lists resources for a customer account
+  ListResources lists resources for a customer account
 */
 func (a *Client) ListResources(params *ListResourcesParams) (*ListResourcesOK, error) {
 	// TODO: Validate the params before sending
@@ -214,7 +231,7 @@ func (a *Client) ListResources(params *ListResourcesParams) (*ListResourcesOK, e
 }
 
 /*
-ModifyResource modifies some properties of an existing resource
+  ModifyResource modifies some properties of an existing resource
 */
 func (a *Client) ModifyResource(params *ModifyResourceParams) (*ModifyResourceOK, error) {
 	// TODO: Validate the params before sending

--- a/api/gateway/resources/client/panther_resources_client.go
+++ b/api/gateway/resources/client/panther_resources_client.go
@@ -26,7 +26,7 @@ package client
 import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 
 	"github.com/panther-labs/panther/api/gateway/resources/client/operations"
 )
@@ -73,9 +73,7 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) *PantherRes
 
 	cli := new(PantherResources)
 	cli.Transport = transport
-
 	cli.Operations = operations.New(transport, formats)
-
 	return cli
 }
 
@@ -120,7 +118,7 @@ func (cfg *TransportConfig) WithSchemes(schemes []string) *TransportConfig {
 
 // PantherResources is a client for panther resources
 type PantherResources struct {
-	Operations *operations.Client
+	Operations operations.ClientService
 
 	Transport runtime.ClientTransport
 }
@@ -128,7 +126,5 @@ type PantherResources struct {
 // SetTransport changes the transport on the client and all its subresources
 func (c *PantherResources) SetTransport(transport runtime.ClientTransport) {
 	c.Transport = transport
-
 	c.Operations.SetTransport(transport)
-
 }

--- a/internal/compliance/remediation_api/handlers/post.go
+++ b/internal/compliance/remediation_api/handlers/post.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/gateway/remediation/models"
+	remediationmodels "github.com/panther-labs/panther/api/gateway/remediation/models"
 	"github.com/panther-labs/panther/internal/compliance/remediation_api/remediation"
 	"github.com/panther-labs/panther/pkg/gatewayapi"
 	"github.com/panther-labs/panther/pkg/genericapi"
@@ -43,8 +44,9 @@ func RemediateResource(request *events.APIGatewayProxyRequest) *events.APIGatewa
 	zap.L().Debug("invoking remediation synchronously")
 
 	if err := invoker.Remediate(remediateResource); err != nil {
-		if err == remediation.RemediationNotFound {
-			return gatewayapi.MarshalResponse(remediation.RemediationNotFound, http.StatusBadRequest)
+		if err == remediation.ErrNotFound {
+			return gatewayapi.MarshalResponse(
+				&remediationmodels.Error{Message: aws.String(err.Error())}, http.StatusBadRequest)
 		}
 		if _, ok := err.(*genericapi.DoesNotExistError); ok {
 			return gatewayapi.MarshalResponse(RemediationLambdaNotFound, http.StatusNotFound)

--- a/internal/compliance/remediation_api/remediation/invoke.go
+++ b/internal/compliance/remediation_api/remediation/invoke.go
@@ -60,7 +60,7 @@ var (
 			WithHost(resourcesServiceHostname)
 	resourcesClient = resourcesclient.NewHTTPClientWithConfig(nil, resourcesConfig)
 
-	RemediationNotFound = &remediationmodels.Error{Message: aws.String("Remediation not associated with policy")}
+	ErrNotFound = errors.New("Remediation not associated with policy")
 )
 
 // Remediate will invoke remediation action in an AWS account
@@ -75,7 +75,7 @@ func (remediator *Invoker) Remediate(remediation *remediationmodels.RemediateRes
 	}
 
 	if policy.AutoRemediationID == "" {
-		return RemediationNotFound
+		return ErrNotFound
 	}
 
 	resource, err := getResource(string(remediation.ResourceID))

--- a/internal/compliance/remediation_api/remediation/invoke_test.go
+++ b/internal/compliance/remediation_api/remediation/invoke_test.go
@@ -206,7 +206,7 @@ func TestRemediationNotFoundErrorIfNoRemediationConfigured(t *testing.T) {
 
 	result := remediator.Remediate(input)
 	assert.Error(t, result)
-	assert.Equal(t, RemediationNotFound, result)
+	assert.Equal(t, ErrNotFound, result)
 
 	mockClient.AssertExpectations(t)
 	mockRoundTripper.AssertExpectations(t)

--- a/tools/mage/build_namespace.go
+++ b/tools/mage/build_namespace.go
@@ -21,7 +21,6 @@ package mage
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -48,17 +47,22 @@ func (b Build) API() {
 	}
 
 	logger.Infof("build:api: generating Go SDK for %d APIs (%s)", len(specs), swaggerGlob)
+	cwd, err := os.Getwd()
+	if err != nil {
+		logger.Fatalf("failed to get current working directory: %v", err)
+	}
+
 	for _, spec := range specs {
-		rebuild, err := apiNeedsRebuilt(spec)
-		if err == nil && !rebuild {
-			logger.Debugf("build:api: %s is up to date", spec)
-			continue
+		// Swagger generates the wrong imports when running from the base directory, even with the
+		// "-t" flag. So we have to change to each api/gateway directory before running swagger
+		dir := filepath.Dir(spec)
+		if err = os.Chdir(dir); err != nil {
+			logger.Fatalf("failed to chdir %s: %v", dir, err)
 		}
 
-		dir := filepath.Dir(spec)
 		start := time.Now().UTC()
-		args := []string{"generate", "client", "-q", "-t", dir, "-f", spec}
-		cmd := filepath.Join(setupDirectory, "swagger")
+		args := []string{"generate", "client", "-q", "-f", filepath.Base(spec)}
+		cmd := filepath.Join(cwd, setupDirectory, "swagger")
 		if _, err = os.Stat(cmd); err != nil {
 			logger.Fatalf("%s not found (%v): run 'mage setup:all'", cmd, err)
 		}
@@ -78,37 +82,31 @@ func (b Build) API() {
 			}
 		}
 		client, models := filepath.Join(dir, "client"), filepath.Join(dir, "models")
-		walk(client, handler)
-		walk(models, handler)
+		walk(filepath.Base(client), handler)
+		walk(filepath.Base(models), handler)
 
 		// Add license and our formatting standard to the generated SDK.
+		if err = os.Chdir(cwd); err != nil {
+			logger.Fatalf("failed to chdir back to %s: %v", cwd, err)
+		}
 		fmtLicenseGroup(agplSource, client, models)
 		gofmt(dir, client, models)
 	}
 }
 
-// Returns true if the generated client + models are older than the given client spec
-func apiNeedsRebuilt(spec string) (bool, error) {
-	clientNeedsUpdate, err := target.Dir(path.Join(path.Dir(spec), "client"), spec)
-	if err != nil {
-		return true, err
-	}
-
-	modelsNeedUpdate, err := target.Dir(path.Join(path.Dir(spec), "models"), spec)
-	if err != nil {
-		return true, err
-	}
-
-	return clientNeedsUpdate || modelsNeedUpdate, nil
-}
-
 // Lambda Compile Go Lambda function source
 func (b Build) Lambda() {
+	if err := b.lambda(); err != nil {
+		logger.Fatal(err)
+	}
+}
+
+func (b Build) lambda() error {
 	modified, err := target.Dir("out/bin/internal", "api", "internal", "pkg")
 	if err == nil && !modified {
 		// The source folders are older than all the compiled binaries - nothing has changed
 		logger.Info("build:lambda: up to date")
-		return
+		return nil
 	}
 
 	mg.Deps(b.API)
@@ -123,9 +121,11 @@ func (b Build) Lambda() {
 	logger.Infof("build:lambda: compiling %d Go Lambda functions (internal/.../main)", len(packages))
 	for _, pkg := range packages {
 		if err := buildPackage(pkg); err != nil {
-			logger.Fatal(err)
+			return err
 		}
 	}
+
+	return nil
 }
 
 // Opstools Compile Go ops tools from source

--- a/tools/mage/fmt.go
+++ b/tools/mage/fmt.go
@@ -66,7 +66,7 @@ func gofmt(root string, paths ...string) {
 	logger.Info("fmt: gofmt " + strings.Join(paths, " "))
 
 	// 1) gofmt to standardize the syntax formatting with code simplification (-s) flag
-	if err := sh.Run("gofmt", append([]string{"-l", "-s", "-w"}, goTargets...)...); err != nil {
+	if err := sh.Run("gofmt", append([]string{"-l", "-s", "-w"}, paths...)...); err != nil {
 		logger.Fatalf("gofmt failed: %v", err)
 	}
 
@@ -78,7 +78,7 @@ func gofmt(root string, paths ...string) {
 	})
 
 	// 3) Goimports to group imports into 3 sections
-	args := append([]string{"-w", "-local=github.com/panther-labs/panther"}, goTargets...)
+	args := append([]string{"-w", "-local=github.com/panther-labs/panther"}, paths...)
 	if err := sh.Run("goimports", args...); err != nil {
 		logger.Fatalf("goimports failed: %v", err)
 	}

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -93,8 +93,6 @@ func (t Test) Go() {
 }
 
 func testGo() bool {
-	pass := true
-
 	// unit tests
 	logger.Info("test:go: unit tests")
 	args := []string{"test", "-vet", "", "-cover", "./..."}
@@ -119,7 +117,14 @@ func testGo() bool {
 
 	if err != nil {
 		logger.Errorf("go unit tests failed: %v", err)
-		pass = false
+		return false
+	}
+
+	// compile all Go Lambda functions
+	var b Build
+	if err := b.lambda(); err != nil {
+		logger.Errorf("go compilation failed: %v", err)
+		return false
 	}
 
 	// metalinting
@@ -130,10 +135,10 @@ func testGo() bool {
 	}
 	if err := sh.RunV(filepath.Join(setupDirectory, "golangci-lint"), args...); err != nil {
 		logger.Errorf("go linting failed: %v", err)
-		pass = false
+		return false
 	}
 
-	return pass
+	return true
 }
 
 // Python Test Python source


### PR DESCRIPTION
## Background

`mage build:api` does not work for new API changes because of a strange new bug in `swagger`:

1. `rm -r api/gateway/compliance/client api/gateway/compliance/models`
1. `.setup/swagger generate client -q -t api/gateway/compliance -f api/gateway/compliance/models`
1. `mage build:lambda` now fails because `complianceClient.Operations.GetStatus` does not exist. 
1. The autogenerated `api/gateway/compliance/client/panther_compliance_client.go` now has the wrong import!! It imports `github.com/panther-labs/panther/api/gateway/ANALYSIS/client/operations` (without the caps) instead of `gateway/COMPLIANCE/client/operations`

The version of swagger we use hasn't changed, but most likely one of the libraries it depends on has. When troubleshooting this, I also realized the `swagger` generated SDK has changed slightly.

Closes: #360

## Changes

- Regenerate all swagger clients and models
- Fix `build:api` to work around swagger import bug - run from the same directory
- Format only `api` files when running `build:api` (a bug was causing the entire project to be reformatted)
- Add `build:lambda` to `test:go` (#360)

## Testing

- `mage build:api fmt test:ci`
