### PR TITLE
Have datacatalog updater us the common function to create partitions 

### DIFF
--- a/pkg/awsglue/glue.go
+++ b/pkg/awsglue/glue.go
@@ -208,8 +208,9 @@ func (gm *GlueTableMetadata) SyncPartitions(glueClient glueiface.GlueAPI, s3Clie
 					continue
 				}
 
-				// leave _everything_ the same except the schema
+				// leave _everything_ the same except the schema, and the serde info
 				getPartitionOutput.Partition.StorageDescriptor.Columns = columns
+				getPartitionOutput.Partition.StorageDescriptor.SerdeInfo =  tableOutput.Table.StorageDescriptor.SerdeInfo
 				values := gm.partitionValues(update)
 				partitionInput := &glue.PartitionInput{
 					Values:            values,
@@ -242,7 +243,6 @@ func (gm *GlueTableMetadata) SyncPartitions(glueClient glueiface.GlueAPI, s3Clie
 	return failed
 }
 
-// Deprecated - use GluePartition.CreatePartition instead
 func (gm *GlueTableMetadata) CreateJSONPartition(client glueiface.GlueAPI, t time.Time) error {
 	// inherit StorageDescriptor from table
 	tableInput := &glue.GetTableInput{

--- a/pkg/awsglue/glue.go
+++ b/pkg/awsglue/glue.go
@@ -210,7 +210,7 @@ func (gm *GlueTableMetadata) SyncPartitions(glueClient glueiface.GlueAPI, s3Clie
 
 				// leave _everything_ the same except the schema, and the serde info
 				getPartitionOutput.Partition.StorageDescriptor.Columns = columns
-				getPartitionOutput.Partition.StorageDescriptor.SerdeInfo =  tableOutput.Table.StorageDescriptor.SerdeInfo
+				getPartitionOutput.Partition.StorageDescriptor.SerdeInfo = tableOutput.Table.StorageDescriptor.SerdeInfo
 				values := gm.partitionValues(update)
 				partitionInput := &glue.PartitionInput{
 					Values:            values,

--- a/pkg/awsglue/partition.go
+++ b/pkg/awsglue/partition.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/glue/glueiface"
 	"github.com/pkg/errors"
 
@@ -41,8 +38,9 @@ type GluePartition struct {
 	databaseName     string
 	tableName        string
 	s3Bucket         string
-	dataFormat       string // Can currently be only "json"
-	compression      string // Can only be "gzip" currently
+	dataFormat       string    // Can currently be only "json"
+	compression      string    // Can only be "gzip" currently
+	hour             time.Time // the hour this partition corresponds to
 	partitionColumns []PartitionColumnInfo
 }
 
@@ -105,45 +103,7 @@ type PartitionColumnInfo struct {
 
 // Creates a new partition in Glue using the client provided.
 func (gp *GluePartition) CreatePartition(client glueiface.GlueAPI) error {
-	partitionValues := make([]*string, len(gp.partitionColumns))
-	for i, field := range gp.partitionColumns {
-		partitionValues[i] = aws.String(field.Value)
-	}
-	partitionPrefix := gp.GetPartitionLocation()
-	partitionInput := &glue.PartitionInput{
-		Values:            partitionValues,
-		StorageDescriptor: getJSONPartitionDescriptor(partitionPrefix), // We only support JSON currently
-	}
-	input := &glue.CreatePartitionInput{
-		DatabaseName:   aws.String(gp.databaseName),
-		TableName:      aws.String(gp.tableName),
-		PartitionInput: partitionInput,
-	}
-	_, err := client.CreatePartition(input)
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == glue.ErrCodeAlreadyExistsException {
-				return nil
-			}
-		}
-		return errors.Wrap(err, "failed to create new partition")
-	}
-	return nil
-}
-
-func getJSONPartitionDescriptor(s3Path string) *glue.StorageDescriptor {
-	return &glue.StorageDescriptor{
-		InputFormat:  aws.String("org.apache.hadoop.mapred.TextInputFormat"),
-		OutputFormat: aws.String("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"),
-		SerdeInfo: &glue.SerDeInfo{
-			SerializationLibrary: aws.String("org.openx.data.jsonserde.JsonSerDe"),
-			Parameters: map[string]*string{
-				"serialization.format": aws.String("1"),
-				"case.insensitive":     aws.String("TRUE"), // treat as lower case
-			},
-		},
-		Location: aws.String(s3Path),
-	}
+	return NewGlueTableMetadata(models.LogData, gp.tableName, "", GlueTableHourly, nil).CreateJSONPartition(client, gp.hour)
 }
 
 // Gets the partition from S3bucket and S3 object key info.
@@ -208,6 +168,26 @@ func GetPartitionFromS3(s3Bucket, s3ObjectKey string) (*GluePartition, error) {
 		return partition, nil
 	}
 	partition.partitionColumns = append(partition.partitionColumns, hourPartitionKeyValue)
+
+	// add partition.hour as time.Time
+	year, err := strconv.Atoi(yearPartitionKeyValue.Value)
+	if err != nil {
+		return partition, nil
+	}
+	month, err := strconv.Atoi(monthPartitionKeyValue.Value)
+	if err != nil {
+		return partition, nil
+	}
+	day, err := strconv.Atoi(dayPartitionKeyValue.Value)
+	if err != nil {
+		return partition, nil
+	}
+	hour, err := strconv.Atoi(hourPartitionKeyValue.Value)
+	if err != nil {
+		return partition, nil
+	}
+	partition.hour = time.Date(year, time.Month(month), day, hour, 0, 0, 0, time.UTC)
+
 	return partition, nil
 }
 

--- a/pkg/awsglue/partition_test.go
+++ b/pkg/awsglue/partition_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/stretchr/testify/assert"
@@ -94,38 +93,6 @@ func TestCreatePartitionFromS3Log(t *testing.T) {
 	assert.Equal(t, expectedPartitionValues, partition.GetPartitionColumnsInfo())
 }
 
-func TestCreatePartition(t *testing.T) {
-	s3ObjectKey := "rules/table/year=2020/month=02/day=26/hour=15/rule_id=Rule.Id/item.json.gz"
-	partition, err := GetPartitionFromS3("bucket", s3ObjectKey)
-	require.NoError(t, err)
-
-	expectedCreatePartitionInput := &glue.CreatePartitionInput{
-		DatabaseName: aws.String(RuleMatchDatabaseName),
-		TableName:    aws.String("table"),
-		PartitionInput: &glue.PartitionInput{
-			StorageDescriptor: &glue.StorageDescriptor{
-				InputFormat:  aws.String("org.apache.hadoop.mapred.TextInputFormat"),
-				OutputFormat: aws.String("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"),
-				SerdeInfo: &glue.SerDeInfo{
-					SerializationLibrary: aws.String("org.openx.data.jsonserde.JsonSerDe"),
-					Parameters: map[string]*string{
-						"serialization.format": aws.String("1"),
-						"case.insensitive":     aws.String("TRUE"), // treat as lower case
-					},
-				},
-				Location: aws.String("s3://bucket/rules/table/year=2020/month=02/day=26/hour=15/"),
-			},
-			Values: aws.StringSlice([]string{"2020", "02", "26", "15"}),
-		},
-	}
-
-	mockClient := &mockGlue{}
-	mockClient.On("CreatePartition", expectedCreatePartitionInput).Return(&glue.CreatePartitionOutput{}, nil)
-
-	assert.NoError(t, partition.CreatePartition(mockClient))
-	mockClient.AssertExpectations(t)
-}
-
 func TestCreatePartitionUnknownPrefix(t *testing.T) {
 	s3ObjectKey := "wrong_prefix/table/year=2020/month=02/day=26/hour=15/rule_id=Rule.Id/item.json.gz"
 	_, err := GetPartitionFromS3("bucket", s3ObjectKey)
@@ -150,14 +117,41 @@ func TestCreatePartitionUknownFormat(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCreatePartitionLog(t *testing.T) {
+	s3ObjectKey := "logs/table/year=2020/month=02/day=26/hour=15/rule_id=Rule.Id/item.json.gz"
+	partition, err := GetPartitionFromS3("bucket", s3ObjectKey)
+	require.NoError(t, err)
+
+	mockClient := &mockGlue{}
+	mockClient.On("GetTable", mock.Anything).Return(testGetTableOutput, nil).Once()
+	mockClient.On("CreatePartition", mock.Anything).Return(&glue.CreatePartitionOutput{}, nil).Once()
+
+	assert.NoError(t, partition.CreatePartition(mockClient))
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreatePartitionRule(t *testing.T) {
+	s3ObjectKey := "rules/table/year=2020/month=02/day=26/hour=15/rule_id=Rule.Id/item.json.gz"
+	partition, err := GetPartitionFromS3("bucket", s3ObjectKey)
+	require.NoError(t, err)
+
+	mockClient := &mockGlue{}
+	mockClient.On("GetTable", mock.Anything).Return(testGetTableOutput, nil).Once()
+	mockClient.On("CreatePartition", mock.Anything).Return(&glue.CreatePartitionOutput{}, nil).Once()
+
+	assert.NoError(t, partition.CreatePartition(mockClient))
+	mockClient.AssertExpectations(t)
+}
+
 func TestCreatePartitionPartitionAlreadExists(t *testing.T) {
 	s3ObjectKey := "rules/table/year=2020/month=02/day=26/hour=15/rule_id=Rule.Id/item.json.gz"
 	partition, err := GetPartitionFromS3("bucket", s3ObjectKey)
 	require.NoError(t, err)
 
 	mockClient := &mockGlue{}
+	mockClient.On("GetTable", mock.Anything).Return(testGetTableOutput, nil).Once()
 	mockClient.On("CreatePartition", mock.Anything).
-		Return(&glue.CreatePartitionOutput{}, awserr.New(glue.ErrCodeAlreadyExistsException, "error", nil))
+		Return(&glue.CreatePartitionOutput{}, awserr.New(glue.ErrCodeAlreadyExistsException, "error", nil)).Once()
 
 	assert.NoError(t, partition.CreatePartition(mockClient))
 	mockClient.AssertExpectations(t)
@@ -169,8 +163,9 @@ func TestCreatePartitionAwsError(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient := &mockGlue{}
+	mockClient.On("GetTable", mock.Anything).Return(testGetTableOutput, nil).Once()
 	mockClient.On("CreatePartition", mock.Anything).
-		Return(&glue.CreatePartitionOutput{}, awserr.New(glue.ErrCodeInternalServiceException, "error", nil))
+		Return(&glue.CreatePartitionOutput{}, awserr.New(glue.ErrCodeInternalServiceException, "error", nil)).Once()
 
 	assert.Error(t, partition.CreatePartition(mockClient))
 	mockClient.AssertExpectations(t)
@@ -182,7 +177,8 @@ func TestCreatePartitionGeneralError(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient := &mockGlue{}
-	mockClient.On("CreatePartition", mock.Anything).Return(&glue.CreatePartitionOutput{}, errors.New("error"))
+	mockClient.On("GetTable", mock.Anything).Return(testGetTableOutput, nil).Once()
+	mockClient.On("CreatePartition", mock.Anything).Return(&glue.CreatePartitionOutput{}, errors.New("error")).Once()
 
 	assert.Error(t, partition.CreatePartition(mockClient))
 	mockClient.AssertExpectations(t)


### PR DESCRIPTION
## Before
The datacatalog updater used a function that hard coded elements of the StorageDescriptor for a table.

## The Need
We made a change to the cloudformation defining tables but the change was not made in the hardcoded description in partition.go. This caused mis-matches from old partitions to new partitions created by the lambda.

## After
The datacatalog updater now uses the common code (used by SyncPartitions()) that does not used hard coded StorageDescriptor config but reads it from the partition's table.  This avoids updating duplicated code and future-proofs this lambda for a time when we no longer will have StorageDescriptors hard coded anywhere in the code base, since the config is read from the live table.

## Changes
* Refactor the partition's CreatePartition() to call the metadata table's CreateJSONPartition()
* Update SyncPartitions to update SerdeInfo from parent table (as well as columns) since that can change on a schema change (and did for the issue that triggered this). When we incorporate Parquet support this will need to be slightly adjusted.

## Testing
mage test:ci
ran in dev account

