### PR TITLE
Allowing users to customize alert title using Python

### DIFF
--- a/internal/core/alert_delivery/models/api.go
+++ b/internal/core/alert_delivery/models/api.go
@@ -61,4 +61,7 @@ type Alert struct {
 
 	// Type specifies if an alert is for a policy or a rule
 	Type *string `json:"type,omitempty" validate:"omitempty,oneof=RULE POLICY"`
+
+	// Title is the optional title for the alert
+	Title *string `json:"title,omitempty"`
 }

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -116,6 +116,9 @@ func generateDetailedAlertMessage(alert *alertmodels.Alert) string {
 }
 
 func generateAlertTitle(alert *alertmodels.Alert) string {
+	if alert.Title != nil {
+		return *alert.Title
+	}
 	if aws.StringValue(alert.Type) == alertmodels.RuleType {
 		return "New Alert: " + getDisplayName(alert)
 	}

--- a/internal/core/alert_delivery/outputs/outputs_test.go
+++ b/internal/core/alert_delivery/outputs/outputs_test.go
@@ -18,7 +18,15 @@ package outputs
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import "github.com/stretchr/testify/mock"
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	alertModel "github.com/panther-labs/panther/internal/core/alert_delivery/models"
+)
 
 func init() {
 	policyURLPrefix = "https://panther.io/policies/"
@@ -33,4 +41,44 @@ type mockHTTPWrapper struct {
 func (m *mockHTTPWrapper) post(postInput *PostInput) *AlertDeliveryError {
 	args := m.Called(postInput)
 	return args.Get(0).(*AlertDeliveryError)
+}
+
+func TestGenerateAlertTitleReturnGivenTitle(t *testing.T) {
+	alert := &alertModel.Alert{
+		Title: aws.String("my title"),
+	}
+
+	assert.Equal(t, "my title", generateAlertTitle(alert))
+}
+
+func TestGenerateAlertTitleRulePolicyName(t *testing.T) {
+	alert := &alertModel.Alert{
+		Type:       aws.String(alertModel.RuleType),
+		PolicyName: aws.String("rule name"),
+	}
+	assert.Equal(t, "New Alert: rule name", generateAlertTitle(alert))
+}
+
+func TestGenerateAlertTitleRulePolicyId(t *testing.T) {
+	alert := &alertModel.Alert{
+		Type:       aws.String(alertModel.RuleType),
+		PolicyName: aws.String("rule.id"),
+	}
+	assert.Equal(t, "New Alert: rule.id", generateAlertTitle(alert))
+}
+
+func TestGenerateAlertTitlePolicyName(t *testing.T) {
+	alert := &alertModel.Alert{
+		Type:       aws.String(alertModel.PolicyType),
+		PolicyName: aws.String("policy name"),
+	}
+	assert.Equal(t, "Policy Failure: policy name", generateAlertTitle(alert))
+}
+
+func TestGenerateAlertTitlePolicyId(t *testing.T) {
+	alert := &alertModel.Alert{
+		Type:       aws.String(alertModel.PolicyType),
+		PolicyName: aws.String("policy.id"),
+	}
+	assert.Equal(t, "Policy Failure: policy.id", generateAlertTitle(alert))
 }

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -22,6 +22,7 @@ import (
 	"crypto/md5" // nolint(gosec)
 	"encoding/hex"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -68,6 +69,7 @@ func SendAlert(event *AlertDedupEvent) error {
 		return errors.Wrap(err, "failed to marshal alert notification")
 	}
 
+	time.Tick()
 	input := &sqs.SendMessageInput{
 		QueueUrl:    aws.String(env.AlertingQueueURL),
 		MessageBody: aws.String(msgBody),
@@ -106,5 +108,6 @@ func getAlert(alert *AlertDedupEvent) (*alertModel.Alert, error) {
 		Tags:              aws.StringSlice(rule.Payload.Tags),
 		Type:              aws.String(alertModel.RuleType),
 		AlertID:           aws.String(generateAlertID(alert)),
+		Title: alert.Title,
 	}, nil
 }

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -22,7 +22,6 @@ import (
 	"crypto/md5" // nolint(gosec)
 	"encoding/hex"
 	"strconv"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -69,7 +68,6 @@ func SendAlert(event *AlertDedupEvent) error {
 		return errors.Wrap(err, "failed to marshal alert notification")
 	}
 
-	time.Tick()
 	input := &sqs.SendMessageInput{
 		QueueUrl:    aws.String(env.AlertingQueueURL),
 		MessageBody: aws.String(msgBody),
@@ -108,6 +106,6 @@ func getAlert(alert *AlertDedupEvent) (*alertModel.Alert, error) {
 		Tags:              aws.StringSlice(rule.Payload.Tags),
 		Type:              aws.String(alertModel.RuleType),
 		AlertID:           aws.String(generateAlertID(alert)),
-		Title: alert.Title,
+		Title:             alert.Title,
 	}, nil
 }

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 )
 
@@ -36,7 +37,7 @@ type AlertDedupEvent struct {
 	EventCount          int64     `dynamodbav:"eventCount,number"`
 	Severity            string    `dynamodbav:"severity,string"`
 	LogTypes            []string  `dynamodbav:"logTypes,stringset"`
-	Title string `dynamodbav:"title,string,omitempty"`
+	Title *string `dynamodbav:"title,string,omitempty"`
 }
 
 // Alert contains all the fields associated to the alert stored in DDB
@@ -115,7 +116,7 @@ func FromDynamodDBAttribute(input map[string]events.DynamoDBAttributeValue) (eve
 
 	title := getOptionalAttribute("title", input)
 	if title != nil {
-		result.Title = title.String()
+		result.Title = aws.String(title.String())
 	}
 
 	return result, nil

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -37,7 +37,7 @@ type AlertDedupEvent struct {
 	EventCount          int64     `dynamodbav:"eventCount,number"`
 	Severity            string    `dynamodbav:"severity,string"`
 	LogTypes            []string  `dynamodbav:"logTypes,stringset"`
-	Title *string `dynamodbav:"title,string,omitempty"`
+	Title               *string   `dynamodbav:"title,string,omitempty"`
 }
 
 // Alert contains all the fields associated to the alert stored in DDB

--- a/internal/log_analysis/log_processor/parsers/awslogs/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/pantherlog.go
@@ -18,15 +18,11 @@ package awslogs
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import (
-	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
-)
+import "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
 
 // nolint(lll)
 type AWSPantherLog struct {
 	parsers.PantherLog
-
-
 
 	PantherAnyAWSAccountIds  *parsers.PantherAnyString `json:"p_any_aws_account_ids,omitempty" description:"Panther added field with collection of aws account ids associated with the row"`
 	PantherAnyAWSInstanceIds *parsers.PantherAnyString `json:"p_any_aws_instance_ids,omitempty" description:"Panther added field with collection of aws instance ids associated with the row"`

--- a/internal/log_analysis/log_processor/parsers/awslogs/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/pantherlog.go
@@ -18,11 +18,15 @@ package awslogs
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
+import (
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
+)
 
 // nolint(lll)
 type AWSPantherLog struct {
 	parsers.PantherLog
+
+
 
 	PantherAnyAWSAccountIds  *parsers.PantherAnyString `json:"p_any_aws_account_ids,omitempty" description:"Panther added field with collection of aws account ids associated with the row"`
 	PantherAnyAWSInstanceIds *parsers.PantherAnyString `json:"p_any_aws_instance_ids,omitempty" description:"Panther added field with collection of aws instance ids associated with the row"`

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -27,7 +27,7 @@ class EventMatch:
     dedup: str
     severity: str
     event: Dict[str, Any]
-    title: Optional[str]
+    title: Optional[str] = None
 
 
 @dataclass

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 @dataclass
@@ -27,6 +27,7 @@ class EventMatch:
     dedup: str
     severity: str
     event: Dict[str, Any]
+    title: Optional[str]
 
 
 @dataclass

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -13,15 +13,15 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from datetime import datetime
 import hashlib
 import os
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 import boto3
 
-from . import AlertInfo, OutputGroupingKey
+from . import AlertInfo
 
 _DDB_TABLE_NAME = os.environ['ALERTS_DEDUP_TABLE']
 _DDB_CLIENT = boto3.client('dynamodb')
@@ -44,6 +44,20 @@ _ALERT_TITLE = 'title'
 _ALERT_MERGE_PERIOD_SECONDS = 3600
 
 
+# pylint: disable=too-many-instance-attributes
+@dataclass
+class MatchingGroupInfo:
+    """Represents information for a batch of matched events"""
+    rule_id: str
+    rule_version: str
+    log_type: str
+    dedup: str
+    severity: str
+    num_matches: int
+    title: Optional[str]
+    processing_time: datetime
+
+
 def _generate_dedup_key(rule_id: str, dedup: str) -> str:
     key = rule_id + ':' + dedup
     return hashlib.md5(key.encode('utf-8')).hexdigest()  # nosec
@@ -54,32 +68,29 @@ def _generate_alert_id(rule_id: str, dedup: str, count: str) -> str:
     return hashlib.md5(key.encode('utf-8')).hexdigest()  # nosec
 
 
-def update_get_alert_info(
-    match_time: datetime, num_matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]
-) -> AlertInfo:
+def update_get_alert_info(info: MatchingGroupInfo) -> AlertInfo:
     """Updates the alert information and returns the result.
 
     The method will update the alertCreationTime, eventCount of an alert. If a new alert will have to be created,
     it will also create a new alertId with the appropriate alertCreationTime. """
     try:
-        return _update_get_conditional(match_time, num_matches, key, severity, version, title)
+        return _update_get_conditional(info)
     except _DDB_CLIENT.exceptions.ConditionalCheckFailedException:
         # If conditional update failed on Condition, the event needs to be merged
-        return _update_get(match_time, num_matches, key)
+        return _update_get(info)
 
 
-def _update_get_conditional(
-    time: datetime, matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]
-) -> AlertInfo:
+def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     """Performs a conditional update to DDB to verify whether we need to create a new alert.
     The condition will succeed only if:
     1. It is the first time this rule with this dedup string fires
     2. This rule with the same dedup string has fired before, but it fired more than _ALERT_MERGE_PERIOD_SECONDS earlier
     """
+
     condition_expression = '(#1 < :1) OR (attribute_not_exists(#2))'
     update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
 
-    if title:
+    if group_info.title:
         update_expression += ', #12=:12'
     expresion_attribute_names = {
         '#1': _ALERT_CREATION_TIME_ATTR_NAME,
@@ -95,49 +106,49 @@ def _update_get_conditional(
         '#11': _RULE_VERSION_ATTR_NAME,
     }
 
-    if title:
+    if group_info.title:
         expresion_attribute_names['#12'] = _ALERT_TITLE
 
     expression_attribute_values = {
         ':1': {
-            'N': '{}'.format(int(time.timestamp()) - _ALERT_MERGE_PERIOD_SECONDS)
+            'N': '{}'.format(int(group_info.processing_time.timestamp()) - _ALERT_MERGE_PERIOD_SECONDS)
         },
         ':3': {
             'N': '1'
         },
         ':4': {
-            'S': key.rule_id
+            'S': group_info.rule_id
         },
         ':5': {
-            'S': key.dedup
+            'S': group_info.dedup
         },
         ':6': {
-            'N': time.strftime('%s')
+            'N': group_info.processing_time.strftime('%s')
         },
         ':7': {
-            'N': time.strftime('%s')
+            'N': group_info.processing_time.strftime('%s')
         },
         ':8': {
-            'N': '{}'.format(matches)
+            'N': '{}'.format(group_info.num_matches)
         },
         ':9': {
-            'S': severity
+            'S': group_info.severity
         },
         ':10': {
-            'SS': [key.log_type]
+            'SS': [group_info.log_type]
         },
         ':11': {
-            'S': version
+            'S': group_info.rule_version
         },
     }
 
-    if title:
-        expression_attribute_values[':12'] = {'S': title}
+    if group_info.title:
+        expression_attribute_values[':12'] = {'S': group_info.title}
 
     response = _DDB_CLIENT.update_item(
         TableName=_DDB_TABLE_NAME,
         Key={_PARTITION_KEY_NAME: {
-            'S': _generate_dedup_key(key.rule_id, key.dedup)
+            'S': _generate_dedup_key(group_info.rule_id, group_info.dedup)
         }},
         # Setting proper values for alertCreationTime, alertUpdateTime,
         UpdateExpression=update_expression,
@@ -147,19 +158,20 @@ def _update_get_conditional(
         ReturnValues='ALL_NEW'
     )
     alert_count = response['Attributes'][_ALERT_COUNT_ATTR_NAME]['N']
-    alert_id = _generate_alert_id(key.rule_id, key.dedup, alert_count)
-    return AlertInfo(alert_id=alert_id, alert_creation_time=time, alert_update_time=time)
+    alert_id = _generate_alert_id(group_info.rule_id, group_info.dedup, alert_count)
+    return AlertInfo(alert_id=alert_id, alert_creation_time=group_info.processing_time, alert_update_time=group_info.processing_time)
 
 
-def _update_get(match_time: datetime, num_matches: int, key: OutputGroupingKey) -> AlertInfo:
+def _update_get(group_info: MatchingGroupInfo) -> AlertInfo:
     """Updates the following attributes in DDB:
     1. Alert event account - it adds the new events to existing
     2. Alert Update Time - it sets it to given time
     """
+
     response = _DDB_CLIENT.update_item(
         TableName=_DDB_TABLE_NAME,
         Key={_PARTITION_KEY_NAME: {
-            'S': _generate_dedup_key(key.rule_id, key.dedup)
+            'S': _generate_dedup_key(group_info.rule_id, group_info.dedup)
         }},
         # Setting proper value to alertUpdateTime. Increase event count
         UpdateExpression='SET #1=:1\nADD #2 :2, #3 :3',
@@ -170,13 +182,13 @@ def _update_get(match_time: datetime, num_matches: int, key: OutputGroupingKey) 
         },
         ExpressionAttributeValues={
             ':1': {
-                'N': match_time.strftime('%s')
+                'N': group_info.processing_time.strftime('%s')
             },
             ':2': {
-                'N': '{}'.format(num_matches)
+                'N': '{}'.format(group_info.num_matches)
             },
             ':3': {
-                'SS': [key.log_type]
+                'SS': [group_info.log_type]
             },
         },
         ReturnValues='ALL_NEW'
@@ -184,7 +196,7 @@ def _update_get(match_time: datetime, num_matches: int, key: OutputGroupingKey) 
     alert_count = response['Attributes'][_ALERT_COUNT_ATTR_NAME]['N']
     alert_creation_time = response['Attributes'][_ALERT_CREATION_TIME_ATTR_NAME]['N']
     return AlertInfo(
-        alert_id=_generate_alert_id(key.rule_id, key.dedup, alert_count),
+        alert_id=_generate_alert_id(group_info.rule_id, group_info.dedup, alert_count),
         alert_creation_time=datetime.utcfromtimestamp(int(alert_creation_time)),
-        alert_update_time=match_time
+        alert_update_time=group_info.processing_time
     )

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -54,7 +54,9 @@ def _generate_alert_id(rule_id: str, dedup: str, count: str) -> str:
     return hashlib.md5(key.encode('utf-8')).hexdigest()  # nosec
 
 
-def update_get_alert_info(match_time: datetime, num_matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]) -> AlertInfo:
+def update_get_alert_info(
+    match_time: datetime, num_matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]
+) -> AlertInfo:
     """Updates the alert information and returns the result.
 
     The method will update the alertCreationTime, eventCount of an alert. If a new alert will have to be created,
@@ -66,7 +68,9 @@ def update_get_alert_info(match_time: datetime, num_matches: int, key: OutputGro
         return _update_get(match_time, num_matches, key)
 
 
-def _update_get_conditional(time: datetime, matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]) -> AlertInfo:
+def _update_get_conditional(
+    time: datetime, matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]
+) -> AlertInfo:
     """Performs a conditional update to DDB to verify whether we need to create a new alert.
     The condition will succeed only if:
     1. It is the first time this rule with this dedup string fires
@@ -136,7 +140,7 @@ def _update_get_conditional(time: datetime, matches: int, key: OutputGroupingKey
             'S': _generate_dedup_key(key.rule_id, key.dedup)
         }},
         # Setting proper values for alertCreationTime, alertUpdateTime,
-        UpdateExpression= update_expression,
+        UpdateExpression=update_expression,
         ConditionExpression=condition_expression,
         ExpressionAttributeNames=expresion_attribute_names,
         ExpressionAttributeValues=expression_attribute_values,

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -54,13 +54,13 @@ def _generate_alert_id(rule_id: str, dedup: str, count: str) -> str:
     return hashlib.md5(key.encode('utf-8')).hexdigest()  # nosec
 
 
-def update_get_alert_info(match_time: datetime, num_matches: int, key: OutputGroupingKey, severity: str, version: str) -> AlertInfo:
+def update_get_alert_info(match_time: datetime, num_matches: int, key: OutputGroupingKey, severity: str, version: str, title: Optional[str]) -> AlertInfo:
     """Updates the alert information and returns the result.
 
     The method will update the alertCreationTime, eventCount of an alert. If a new alert will have to be created,
     it will also create a new alertId with the appropriate alertCreationTime. """
     try:
-        return _update_get_conditional(match_time, num_matches, key, severity, version)
+        return _update_get_conditional(match_time, num_matches, key, severity, version, title)
     except _DDB_CLIENT.exceptions.ConditionalCheckFailedException:
         # If conditional update failed on Condition, the event needs to be merged
         return _update_get(match_time, num_matches, key)
@@ -128,7 +128,7 @@ def _update_get_conditional(time: datetime, matches: int, key: OutputGroupingKey
     }
 
     if title:
-        expresion_attribute_names[':12'] = {'S': title}
+        expression_attribute_values[':12'] = {'S': title}
 
     response = _DDB_CLIENT.update_item(
         TableName=_DDB_TABLE_NAME,

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -57,7 +57,8 @@ class Engine:
                     log_type=log_type,
                     dedup=result.dedup_string,  # type: ignore
                     event=event,
-                    severity=rule.rule_severity
+                    severity=rule.rule_severity,
+                    title=result.title
                 )
                 matched.append(match)
 

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional
 import boto3
 
 from . import AlertInfo, EventMatch, OutputGroupingKey, OutputNotification
-from .alert_merger import update_get_alert_info
+from .alert_merger import MatchingGroupInfo, update_get_alert_info
 from .logging import get_logger
 
 _KEY_FORMAT = 'rules/{}/year={:d}/month={:02d}/day={:02d}/hour={:02d}/rule_id={}/{}-{}.json.gz'
@@ -114,11 +114,19 @@ class MatchedEventsBuffer:
 
 
 def _write_to_s3(time: datetime, key: OutputGroupingKey, events: List[EventMatch]) -> None:
-    rule_version = events[0].rule_version  # severity and version of a rule might differ if the rule was modified
-    # while the rules engine was running. We pick the first encountered severity, version and title.
-    rule_severity = events[0].severity
-    rule_title = events[0].title
-    alert_info = update_get_alert_info(time, len(events), key, rule_severity, rule_version, rule_title)
+    # severity and version of a rule might differ if the rule was modified while the rules engine was running.
+    # We pick the first encountered severity, version and title.
+    group_info = MatchingGroupInfo(
+        rule_id=key.rule_id,
+        rule_version=events[0].rule_version,
+        log_type=key.log_type,
+        dedup=key.dedup,
+        severity=events[0].severity,
+        num_matches=len(events),
+        title=events[0].title,
+        processing_time=time
+    )
+    alert_info = update_get_alert_info(group_info)
     data_stream = BytesIO()
     writer = gzip.GzipFile(fileobj=data_stream, mode='wb')
     for event in events:

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -115,9 +115,10 @@ class MatchedEventsBuffer:
 
 def _write_to_s3(time: datetime, key: OutputGroupingKey, events: List[EventMatch]) -> None:
     rule_version = events[0].rule_version  # severity and version of a rule might differ if the rule was modified
-    # while the rules engine was running. We pick the first encountered severity and version.
+    # while the rules engine was running. We pick the first encountered severity, version and title.
     rule_severity = events[0].severity
-    alert_info = update_get_alert_info(time, len(events), key, rule_severity, rule_version)
+    rule_title = events[0].title
+    alert_info = update_get_alert_info(time, len(events), key, rule_severity, rule_version, rule_title)
     data_stream = BytesIO()
     writer = gzip.GzipFile(fileobj=data_stream, mode='wb')
     for event in events:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -132,7 +132,7 @@ class Rule:
                     'maximum title string size is [%d] characters. Title for rule with ID '
                     '[%s] is [%d] characters. Truncating.', MAX_TITLE_SIZE, self.rule_id, len(title_string)
                 )
-                num_characters_to_keep = MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)
+                num_characters_to_keep = MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)
                 return title_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
             return title_string
         # If title is empty string, return None

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -35,6 +35,8 @@ MAX_DEDUP_STRING_SIZE = 1000
 # Maximum size for a title
 MAX_TITLE_SIZE = 1000
 
+TRUNCATED_STRING_SUFFIX = '... (truncated)'
+
 
 @dataclass
 class RuleResult:
@@ -112,7 +114,8 @@ class Rule:
                     'maximum dedup string size is [%d] characters. Dedup string for rule with ID '
                     '[%s] is [%d] characters. Truncating.', MAX_DEDUP_STRING_SIZE, self.rule_id, len(dedup_string)
                 )
-                return dedup_string[:MAX_DEDUP_STRING_SIZE]
+                num_characters_to_keep = MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)
+                return dedup_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
             return dedup_string
         # If dedup string was the empty string, put the default value (rule_id)
         return self.rule_id
@@ -129,7 +132,8 @@ class Rule:
                     'maximum title string size is [%d] characters. Title for rule with ID '
                     '[%s] is [%d] characters. Truncating.', MAX_TITLE_SIZE, self.rule_id, len(title_string)
                 )
-                return title_string[:MAX_TITLE_SIZE]
+                num_characters_to_keep = MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)
+                return title_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
             return title_string
         # If title is empty string, return None
         return None

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -49,8 +49,7 @@ class Rule:
     """Panther rule metadata and imported module."""
     logger = get_logger()
 
-    def __init__(self, rule_id: Optional[str], rule_body: Optional[str], rule_severity: Optional[str],
-                 rule_version: Optional[str]):
+    def __init__(self, rule_id: Optional[str], rule_body: Optional[str], rule_severity: Optional[str], rule_version: Optional[str]):
         """Create new rule.
 
         Args:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -105,7 +105,7 @@ class Rule:
             # If no dedup function defined, return rule id
             return self.rule_id
         dedup_string = _run_command(self._module.dedup, event, str)
-        if dedup_string and dedup_string != '':
+        if dedup_string:
             if len(dedup_string) > MAX_DEDUP_STRING_SIZE:
                 # If dedup_string exceeds max size, truncate it
                 self.logger.warning(
@@ -122,7 +122,7 @@ class Rule:
             return None
 
         title_string = _run_command(self._module.title, event, str)
-        if title_string and title_string != '':
+        if title_string:
             if len(title_string) > MAX_TITLE_SIZE:
                 # If title exceeds max size, truncate it
                 self.logger.warning(

--- a/internal/log_analysis/rules_engine/tests/test_output.py
+++ b/internal/log_analysis/rules_engine/tests/test_output.py
@@ -50,50 +50,50 @@ class TestMatchedEventsBuffer(TestCase):
         buffer.flush()
 
         DDB_MOCK.update_item.assert_called_once_with(
-            ConditionExpression='(#10 < :10) OR (attribute_not_exists(#11))',
+            ConditionExpression='(#1 < :1) OR (attribute_not_exists(#2))',
             ExpressionAttributeNames={
-                '#1': 'ruleId',
-                '#2': 'dedup',
-                '#3': 'alertCreationTime',
-                '#4': 'alertUpdateTime',
-                '#5': 'eventCount',
-                '#6': 'severity',
-                '#7': 'logTypes',
-                '#8': 'ruleVersion',
-                '#9': 'alertCount',
-                '#10': 'alertCreationTime',
-                '#11': 'partitionKey'
+                '#1': 'alertCreationTime',
+                '#2': 'partitionKey',
+                '#3': 'alertCount',
+                '#4': 'ruleId',
+                '#5': 'dedup',
+                '#6': 'alertCreationTime',
+                '#7': 'alertUpdateTime',
+                '#8': 'eventCount',
+                '#9': 'severity',
+                '#10': 'logTypes',
+                '#11': 'ruleVersion'
             },
             ExpressionAttributeValues={
                 ':1': {
-                    'S': 'rule_id'
-                },
-                ':2': {
-                    'S': 'dedup'
+                    'N': mock.ANY
                 },
                 ':3': {
-                    'N': mock.ANY
+                    'N': '1'
                 },
                 ':4': {
-                    'N': mock.ANY
+                    'S': 'rule_id'
                 },
                 ':5': {
-                    'N': '1'
+                    'S': 'dedup'
                 },
                 ':6': {
-                    'S': 'INFO'
+                    'N': mock.ANY
                 },
                 ':7': {
-                    'SS': ['log_type']
+                    'N': mock.ANY
                 },
                 ':8': {
-                    'S': 'rule_version'
-                },
-                ':9': {
                     'N': '1'
                 },
+                ':9': {
+                    'S': 'INFO'
+                },
                 ':10': {
-                    'N': mock.ANY
+                    'SS': ['log_type']
+                },
+                ':11': {
+                    'S': 'rule_version'
                 }
             },
             Key={
@@ -104,7 +104,7 @@ class TestMatchedEventsBuffer(TestCase):
             },
             ReturnValues='ALL_NEW',
             TableName='table_name',
-            UpdateExpression='SET #1=:1, #2=:2, #3=:3, #4=:4, #5=:5, #6=:6, #7=:7, #8=:8\nADD #9 :9'
+            UpdateExpression='ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
         )
 
         S3_MOCK.put_object.assert_called_once_with(Body=mock.ANY, Bucket='s3_bucket', ContentType='gzip', Key=mock.ANY)

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -132,3 +132,10 @@ class TestRule(TestCase):
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
         self.assertIsNotNone(rule_result.exception)
+
+    def test_rule_dedup_returns_empty_string(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
+        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+
+        expected_result = RuleResult(matched=True, dedup_string='id')
+        self.assertEqual(rule.run({}), expected_result)

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -33,7 +33,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_body(self) -> None:
         exception = False
         try:
-            Rule(rule_id='id', rule_body=None, rule_severity='INFO', rule_version='version')
+            Rule(rule_id='test_create_rule_missing_body', rule_body=None, rule_severity='INFO', rule_version='version')
         except AssertionError:
             exception = True
 
@@ -42,7 +42,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_version(self) -> None:
         exception = False
         try:
-            Rule(rule_id='id', rule_body='rule', rule_severity='INFO', rule_version=None)
+            Rule(rule_id='test_create_rule_missing_version', rule_body='rule', rule_severity='INFO', rule_version=None)
         except AssertionError:
             exception = True
 
@@ -51,7 +51,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_severity(self) -> None:
         exception = False
         try:
-            Rule(rule_id='id', rule_body='rule', rule_severity=None, rule_version='version')
+            Rule(rule_id='test_create_rule_missing_severity', rule_body='rule', rule_severity=None, rule_version='version')
         except AssertionError:
             exception = True
 
@@ -61,7 +61,7 @@ class TestRule(TestCase):
         exception = False
         rule_body = 'def another_method(event):\n\treturn False'
         try:
-            Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+            Rule(rule_id='test_create_rule_missing_method', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         except AssertionError:
             exception = True
 
@@ -69,26 +69,26 @@ class TestRule(TestCase):
 
     def test_rule_matches(self) -> None:
         rule_body = 'def rule(event):\n\treturn True'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
-        expected_rule = RuleResult(matched=True, dedup_string='id')
+        rule = Rule(rule_id='test_rule_matches', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_doesnt_match(self) -> None:
         rule_body = 'def rule(event):\n\treturn False'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_doesnt_match', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         expected_rule = RuleResult(matched=False)
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_rule_with_dedup(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_with_dedup', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         expected_rule = RuleResult(matched=True, dedup_string='testdedup')
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_restrict_dedup_size(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'.\
             format(MAX_DEDUP_STRING_SIZE+1)
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_restrict_dedup_size', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
         expected_dedup_string_prefix = ''.join('a' for _ in range(MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)))
         expected_rule = RuleResult(matched=True, dedup_string=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX)
@@ -97,22 +97,24 @@ class TestRule(TestCase):
     def test_restrict_title_size(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "".join("a" for i in range({}))'. \
             format(MAX_TITLE_SIZE+1)
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_restrict_title_size', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
         expected_title_string_prefix = ''.join('a' for _ in range(MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)))
-        expected_rule = RuleResult(matched=True, dedup_string='id', title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX)
+        expected_rule = RuleResult(
+            matched=True, dedup_string='test_restrict_title_size', title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX
+        )
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_empty_dedup_result_to_default(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_empty_dedup_result_to_default', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
-        expected_rule = RuleResult(matched=True, dedup_string='id')
+        expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_rule_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_throws_exception', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -120,7 +122,7 @@ class TestRule(TestCase):
 
     def test_rule_invalid_rule_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn "test"'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_invalid_rule_return', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -128,7 +130,7 @@ class TestRule(TestCase):
 
     def test_dedup_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_dedup_throws_exception', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -136,7 +138,7 @@ class TestRule(TestCase):
 
     def test_rule_invalid_dedup_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_invalid_dedup_return', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -144,21 +146,21 @@ class TestRule(TestCase):
 
     def test_rule_dedup_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_dedup_returns_empty_string', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
-        expected_result = RuleResult(matched=True, dedup_string='id')
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_matches_with_title(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_matches_with_title', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
-        expected_result = RuleResult(matched=True, dedup_string='id', title='title')
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_title_throws_exception', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
@@ -168,7 +170,7 @@ class TestRule(TestCase):
 
     def test_rule_invalid_title_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_invalid_title_return', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
@@ -178,7 +180,7 @@ class TestRule(TestCase):
 
     def test_rule_title_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
-        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_title_returns_empty_string', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
-        expected_result = RuleResult(matched=True, dedup_string='id')
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -71,7 +71,7 @@ class TestRule(TestCase):
         rule_body = 'def rule(event):\n\treturn True'
         rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
         expected_rule = RuleResult(matched=True, dedup_string='id')
-        self.assertEqual(rule.run({}), expected_rule)
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_doesnt_match(self) -> None:
         rule_body = 'def rule(event):\n\treturn False'
@@ -135,6 +135,40 @@ class TestRule(TestCase):
 
     def test_rule_dedup_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
+        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+
+        expected_result = RuleResult(matched=True, dedup_string='id')
+        self.assertEqual(rule.run({}), expected_result)
+
+    def test_rule_matches_with_title(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
+        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+
+        expected_result = RuleResult(matched=True, dedup_string='id', title='title')
+        self.assertEqual(rule.run({}), expected_result)
+
+    def test_rule_title_throws_exception(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
+        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+
+        rule_result = rule.run({})
+        self.assertIsNone(rule_result.matched)
+        self.assertIsNone(rule_result.title)
+        self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNotNone(rule_result.exception)
+
+    def test_rule_invalid_title_return(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
+        rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+
+        rule_result = rule.run({})
+        self.assertIsNone(rule_result.matched)
+        self.assertIsNone(rule_result.title)
+        self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNotNone(rule_result.exception)
+
+    def test_rule_title_returns_empty_string(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
         rule = Rule(rule_id='id', rule_body=rule_body, rule_severity='INFO', rule_version='version')
 
         expected_result = RuleResult(matched=True, dedup_string='id')


### PR DESCRIPTION
## Background

Allowing users to customize alert title using Python

Closes #238 

## Changes

- Rule's can now have an additional `title` method. When a rule matches an event, we run the "title" method to specify the title of the alert. 
- Added unit tests
- web was failing on `npm audit` command. Did `mage setup:web` and that modified the `package-lock.json` and now it passes

## Testing

- Unit tests
- Deployed to my account. A rule with the following body: 
<img width="896" alt="Screen Shot 2020-03-13 at 6 24 02 PM" src="https://user-images.githubusercontent.com/2652630/76644761-e9f61480-6557-11ea-96ee-7e43dde80a4a.png">


Generated the following alert: 

<img width="635" alt="Screen Shot 2020-03-13 at 6 24 21 PM" src="https://user-images.githubusercontent.com/2652630/76644768-ee223200-6557-11ea-85bf-97a952d8b95d.png">

