### PR TITLE
[readme] add explicit link to Slack and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 <p align="center">
   <a href="https://docs.runpanther.io">Documentation</a> |
   <a href="https://docs.runpanther.io/quick-start">Quick Start</a> |
-  <a href="https://blog.runpanther.io">Blog</a>
+  <a href="https://blog.runpanther.io">Blog</a> |
+  <a href="https://panther-labs-oss-slackin.herokuapp.com/">Chat with us on Slack!</a>
 </p>
 
 <p align="center">
@@ -66,6 +67,8 @@ def rule(event):
 ## Deployment
 
 Follow our [Quick Start Guide](https://docs.runpanther.io/quick-start) to deploy Panther in your AWS account in a matter of minutes!
+
+Use our [Tutorials](https://github.com/panther-labs/tutorials) to configure logging and data ingestion.
 
 ## Screenshots
 


### PR DESCRIPTION
## Background

Make it easier to sign up for Slack and find out about our tutorials!

## Testing

<img width="662" alt="Screen Shot 2020-03-13 at 2 57 21 PM" src="https://user-images.githubusercontent.com/11466941/76662354-f61fa900-653a-11ea-8144-ebbb58240562.png">

