### PR TITLE
New opstool: s3queue

### DIFF
--- a/cmd/opstools/s3queue/s3queue.go
+++ b/cmd/opstools/s3queue/s3queue.go
@@ -1,0 +1,176 @@
+package s3queue
+
+import (
+	"fmt"
+	"math"
+	"net/url"
+	"sync"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+const (
+	concurrency          = 10
+	pageSize             = 1000
+	fakeTopicArnTemplate = "arn:aws:sns:us-east-1:%s:panther-fake-s3queue-topic" // account is added for sqs messages
+)
+
+type Stats struct {
+	NumFiles uint64
+	NumBytes uint64
+}
+
+type cloudTrailNotification struct {
+	S3Bucket    *string   `json:"s3Bucket"`
+	S3ObjectKey []*string `json:"s3ObjectKey"`
+}
+
+func S3Queue(sess *session.Session, account, s3path, queueName string, limit uint64, stats *Stats) (err error) {
+	return s3Queue(s3.New(sess), sqs.New(sess), account, s3path, queueName, limit, stats)
+}
+
+func s3Queue(s3Client s3iface.S3API, sqsClient sqsiface.SQSAPI, account, s3path, queueName string,
+	limit uint64, stats *Stats) (failed error) {
+
+	queueURL, err := sqsClient.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: &queueName,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "could not get queue url for %s", queueName)
+	}
+
+	// the account id is taken from this  arn to assume role for reading in the log processor
+	topicARN := fmt.Sprintf(fakeTopicArnTemplate, account)
+
+	errChan := make(chan error)
+	notifyChan := make(chan *cloudTrailNotification, 1000)
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			queueNotifications(sqsClient, topicARN, queueURL.QueueUrl, notifyChan, errChan)
+			wg.Done()
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		listPath(s3Client, s3path, limit, notifyChan, errChan, stats)
+		wg.Done()
+	}()
+
+	go func() {
+		for err := range errChan { // return last error
+			failed = err
+		}
+	}()
+
+	wg.Wait()
+	close(errChan)
+
+	return failed
+}
+
+// Given an s3path (e.g., s3://mybucket/myprefix) list files and send to notifyChan
+func listPath(s3Client s3iface.S3API, s3path string, limit uint64,
+	notifyChan chan *cloudTrailNotification, errChan chan error, stats *Stats) {
+
+	if limit == 0 {
+		limit = math.MaxUint64
+	}
+
+	defer func() {
+		close(notifyChan) // signal to reader that we are done
+	}()
+
+	parsedPath, err := url.Parse(s3path)
+	if err != nil {
+		errChan <- errors.Errorf("bad s3 url: %s,", err)
+		return
+	}
+
+	if parsedPath.Scheme != "s3" {
+		errChan <- errors.Errorf("not s3 protocol (expecting s3://): %s,", s3path)
+		return
+	}
+
+	bucket := parsedPath.Host
+	if bucket == "" {
+		errChan <- errors.Errorf("missing bucket: %s,", s3path)
+		return
+	}
+	var prefix string
+	if len(parsedPath.Path) > 0 {
+		prefix = parsedPath.Path[1:] // remove leading '/'
+	}
+
+	// list files w/pagination
+	inputParams := &s3.ListObjectsV2Input{
+		Bucket:  aws.String(bucket),
+		Prefix:  aws.String(prefix),
+		MaxKeys: aws.Int64(pageSize),
+	}
+	err = s3Client.ListObjectsV2Pages(inputParams, func(page *s3.ListObjectsV2Output, morePages bool) bool {
+		for _, value := range page.Contents {
+			if *value.Size > 0 { // we only care about objects with size
+				stats.NumFiles++
+				stats.NumBytes += (uint64)(*value.Size)
+				notifyChan <- &cloudTrailNotification{
+					S3Bucket:    &bucket,
+					S3ObjectKey: []*string{value.Key},
+				}
+				if stats.NumFiles >= limit {
+					break
+				}
+			}
+		}
+		return stats.NumFiles < limit // "To stop iterating, return false from the fn function."
+	})
+	if err != nil {
+		errChan <- err
+	}
+}
+
+// post message per file as-if it was a CloudTrail notification
+func queueNotifications(sqsClient sqsiface.SQSAPI, topicARN string, queueURL *string,
+	notifyChan chan *cloudTrailNotification, errChan chan error) {
+
+	for cloudTrailNotification := range notifyChan {
+		ctnJSON, err := jsoniter.MarshalToString(cloudTrailNotification)
+		if err != nil {
+			errChan <- errors.Wrapf(err, "failed to marshal %#v", cloudTrailNotification)
+			return
+		}
+
+		// make it look like an SNS notification
+		snsNotification := events.SNSEntity{
+			Type:     "Notification",
+			TopicArn: topicARN,
+			Message:  ctnJSON,
+		}
+		message, err := jsoniter.MarshalToString(snsNotification)
+		if err != nil {
+			errChan <- errors.Wrapf(err, "failed to marshal %#v", snsNotification)
+			return
+		}
+
+		sendMessageInput := &sqs.SendMessageInput{
+			MessageBody: &message,
+			QueueUrl:    queueURL,
+		}
+		_, err = sqsClient.SendMessage(sendMessageInput)
+		if err != nil {
+			errChan <- errors.Wrapf(err, "failed to send %#v", cloudTrailNotification)
+			return
+		}
+	}
+}

--- a/cmd/opstools/s3queue/s3queue/main.go
+++ b/cmd/opstools/s3queue/s3queue/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/pkg/errors"
+
+	"github.com/panther-labs/panther/cmd/opstools/s3queue"
+)
+
+const (
+	banner = "lists s3 objects and posts s3 notifications to log processor queue"
+)
+
+var (
+	REGION  = flag.String("region", "", "The AWS region where the queues and bucket exist (optional, defaults to session env vars).")
+	ACCOUNT = flag.String("account", "", "The AWS account id where the bucket exists (optional, defaults to session account).")
+	S3PATH  = flag.String("s3path", "", "The s3 path to list (e.g., s3://<bucket>/<prefix>).")
+	LIMIT   = flag.Uint64("limit", 0, "If non-zero, then limit the number of files to this number.")
+	TOQ     = flag.String("queue", "panther-input-data-notifications-queue", "The name of the log processor queue to send notifications.")
+)
+
+func usage() {
+	fmt.Fprintf(flag.CommandLine.Output(),
+		"%s %s\nUsage:\n",
+		filepath.Base(os.Args[0]), banner)
+	flag.PrintDefaults()
+}
+
+func init() {
+	flag.Usage = usage
+}
+
+func main() {
+	flag.Parse()
+
+	sess, err := session.NewSession()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+
+	if *REGION != "" { //override
+		sess.Config.Region = REGION
+	}
+
+	if *ACCOUNT == "" {
+		identity, err := sts.New(sess).GetCallerIdentity(&sts.GetCallerIdentityInput{})
+		if err != nil {
+			log.Fatalf("failed to get caller identity: %v", err)
+		}
+		ACCOUNT = identity.Account
+	}
+
+	validateFlags()
+
+	startTime := time.Now()
+	if *LIMIT > 0 {
+		log.Printf("sending %d files from %s to %s", *LIMIT, *S3PATH, *TOQ)
+	} else {
+		log.Printf("sending files from %s to %s", *S3PATH, *TOQ)
+	}
+
+	stats := &s3queue.Stats{}
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+		caught := <-sig // wait for it
+		log.Fatalf("caught %v, sent %d files (%.2fMB) to %s in %v",
+			caught, stats.NumFiles, float32(stats.NumBytes)/(1024.0*1024.0), *TOQ, time.Since(startTime))
+	}()
+
+	err = s3queue.S3Queue(sess, *ACCOUNT, *S3PATH, *TOQ, *LIMIT, stats)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("sent %d files (%.2fMB) to %s in %v",
+			stats.NumFiles, float32(stats.NumBytes)/(1024.0*1024.0), *TOQ, time.Since(startTime))
+	}
+}
+
+func validateFlags() {
+	var err error
+	defer func() {
+		if err != nil {
+			fmt.Printf("%s\n", err)
+			flag.Usage()
+			os.Exit(-2)
+		}
+	}()
+
+	if *S3PATH == "" {
+		err = errors.New("-s3path not set")
+		return
+	}
+	if *TOQ == "" {
+		err = errors.New("-queue not set")
+		return
+	}
+}

--- a/cmd/opstools/s3queue/s3queue/main.go
+++ b/cmd/opstools/s3queue/s3queue/main.go
@@ -22,8 +22,8 @@ const (
 )
 
 var (
-	REGION  = flag.String("region", "", "The AWS region where the queues and bucket exist (optional, defaults to session env vars).")
-	ACCOUNT = flag.String("account", "", "The AWS account id where the bucket exists (optional, defaults to session account).")
+	REGION  = flag.String("region", "", "The AWS region (optional, defaults to session env vars) where the queues and bucket exist.")
+	ACCOUNT = flag.String("account", "", "The AWS account id (optional, defaults to session account) where the bucket exists.")
 	S3PATH  = flag.String("s3path", "", "The s3 path to list (e.g., s3://<bucket>/<prefix>).")
 	LIMIT   = flag.Uint64("limit", 0, "If non-zero, then limit the number of files to this number.")
 	TOQ     = flag.String("queue", "panther-input-data-notifications-queue", "The name of the log processor queue to send notifications.")

--- a/cmd/opstools/s3queue/s3queue_test.go
+++ b/cmd/opstools/s3queue/s3queue_test.go
@@ -15,9 +15,15 @@ import (
 
 const (
 	testAccount   = "012345678912"
-	testS3Path    = "s3://foo/bar/"
+	testBucket    = "foo"
+	testKey       = "bar"
+	testS3Path    = "s3://" + testBucket + "/" + testKey
 	testQueueName = "testQueue"
 )
+
+func init() {
+	concurrency = 1
+}
 
 func TestS3Queue(t *testing.T) {
 	s3Client := &mockS3{}
@@ -25,13 +31,14 @@ func TestS3Queue(t *testing.T) {
 		Contents: []*s3.Object{
 			{
 				Size: aws.Int64(1), // 1 object of some size
+				Key:  aws.String(testKey),
 			},
 		},
 	}
 	s3Client.On("ListObjectsV2Pages", mock.Anything, mock.Anything).Return(page, nil).Once()
 	sqsClient := &mockSQS{}
 	sqsClient.On("GetQueueUrl", mock.Anything).Return(&sqs.GetQueueUrlOutput{QueueUrl: aws.String("arn")}, nil).Once()
-	sqsClient.On("SendMessage", mock.Anything, mock.Anything).Return(&sqs.SendMessageOutput{}, nil).Once()
+	sqsClient.On("SendMessageBatch", mock.Anything).Return(&sqs.SendMessageBatchOutput{}, nil).Once()
 
 	stats := &Stats{}
 	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 0, stats)
@@ -48,16 +55,18 @@ func TestS3QueueLimit(t *testing.T) {
 		Contents: []*s3.Object{ // 2 objects
 			{
 				Size: aws.Int64(1),
+				Key:  aws.String(testKey),
 			},
 			{
 				Size: aws.Int64(1),
+				Key:  aws.String(testKey),
 			},
 		},
 	}
 	s3Client.On("ListObjectsV2Pages", mock.Anything, mock.Anything).Return(page, nil).Once()
 	sqsClient := &mockSQS{}
 	sqsClient.On("GetQueueUrl", mock.Anything).Return(&sqs.GetQueueUrlOutput{QueueUrl: aws.String("arn")}, nil).Once()
-	sqsClient.On("SendMessage", mock.Anything, mock.Anything).Return(&sqs.SendMessageOutput{}, nil).Once()
+	sqsClient.On("SendMessageBatch", mock.Anything).Return(&sqs.SendMessageBatchOutput{}, nil).Once()
 
 	stats := &Stats{}
 	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, stats)
@@ -65,6 +74,31 @@ func TestS3QueueLimit(t *testing.T) {
 	s3Client.AssertExpectations(t)
 	sqsClient.AssertExpectations(t)
 	assert.Equal(t, uint64(1), stats.NumFiles)
+}
+
+func TestS3QueueBatch(t *testing.T) {
+	var contents []*s3.Object
+	for i := 0; i < (2*10)+1; i++ { // batch size is 10, so 2 full batches and one partial
+		contents = append(contents, &s3.Object{
+			Size: aws.Int64(1), // 1 object of some size
+			Key:  aws.String(testKey),
+		})
+	}
+	s3Client := &mockS3{}
+	page := &s3.ListObjectsV2Output{
+		Contents: contents,
+	}
+	s3Client.On("ListObjectsV2Pages", mock.Anything, mock.Anything).Return(page, nil).Once()
+	sqsClient := &mockSQS{}
+	sqsClient.On("GetQueueUrl", mock.Anything).Return(&sqs.GetQueueUrlOutput{QueueUrl: aws.String("arn")}, nil).Once()
+	sqsClient.On("SendMessageBatch", mock.Anything).Return(&sqs.SendMessageBatchOutput{}, nil).Times(3)
+
+	stats := &Stats{}
+	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 0, stats)
+	require.NoError(t, err)
+	s3Client.AssertExpectations(t)
+	sqsClient.AssertExpectations(t)
+	assert.Equal(t, uint64(len(contents)), stats.NumFiles)
 }
 
 type mockS3 struct {
@@ -89,7 +123,7 @@ func (m *mockSQS) GetQueueUrl(input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutp
 	return args.Get(0).(*sqs.GetQueueUrlOutput), args.Error(1)
 }
 
-func (m *mockSQS) SendMessage(input *sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
+func (m *mockSQS) SendMessageBatch(input *sqs.SendMessageBatchInput) (*sqs.SendMessageBatchOutput, error) {
 	args := m.Called(input)
-	return args.Get(0).(*sqs.SendMessageOutput), args.Error(1)
+	return args.Get(0).(*sqs.SendMessageBatchOutput), args.Error(1)
 }

--- a/cmd/opstools/s3queue/s3queue_test.go
+++ b/cmd/opstools/s3queue/s3queue_test.go
@@ -1,0 +1,95 @@
+package s3queue
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAccount   = "012345678912"
+	testS3Path    = "s3://foo/bar/"
+	testQueueName = "testQueue"
+)
+
+func TestS3Queue(t *testing.T) {
+	s3Client := &mockS3{}
+	page := &s3.ListObjectsV2Output{
+		Contents: []*s3.Object{
+			{
+				Size: aws.Int64(1), // 1 object of some size
+			},
+		},
+	}
+	s3Client.On("ListObjectsV2Pages", mock.Anything, mock.Anything).Return(page, nil).Once()
+	sqsClient := &mockSQS{}
+	sqsClient.On("GetQueueUrl", mock.Anything).Return(&sqs.GetQueueUrlOutput{QueueUrl: aws.String("arn")}, nil).Once()
+	sqsClient.On("SendMessage", mock.Anything, mock.Anything).Return(&sqs.SendMessageOutput{}, nil).Once()
+
+	stats := &Stats{}
+	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 0, stats)
+	require.NoError(t, err)
+	s3Client.AssertExpectations(t)
+	sqsClient.AssertExpectations(t)
+	assert.Equal(t, uint64(1), stats.NumFiles)
+}
+
+func TestS3QueueLimit(t *testing.T) {
+	// list 2 objects but limit send to 1
+	s3Client := &mockS3{}
+	page := &s3.ListObjectsV2Output{
+		Contents: []*s3.Object{ // 2 objects
+			{
+				Size: aws.Int64(1),
+			},
+			{
+				Size: aws.Int64(1),
+			},
+		},
+	}
+	s3Client.On("ListObjectsV2Pages", mock.Anything, mock.Anything).Return(page, nil).Once()
+	sqsClient := &mockSQS{}
+	sqsClient.On("GetQueueUrl", mock.Anything).Return(&sqs.GetQueueUrlOutput{QueueUrl: aws.String("arn")}, nil).Once()
+	sqsClient.On("SendMessage", mock.Anything, mock.Anything).Return(&sqs.SendMessageOutput{}, nil).Once()
+
+	stats := &Stats{}
+	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, stats)
+	require.NoError(t, err)
+	s3Client.AssertExpectations(t)
+	sqsClient.AssertExpectations(t)
+	assert.Equal(t, uint64(1), stats.NumFiles)
+}
+
+type mockS3 struct {
+	s3iface.S3API
+	mock.Mock
+}
+
+func (m *mockS3) ListObjectsV2Pages(input *s3.ListObjectsV2Input, f func(page *s3.ListObjectsV2Output, morePages bool) bool) error {
+	args := m.Called(input, f)
+	f(args.Get(0).(*s3.ListObjectsV2Output), false)
+	return args.Error(1)
+}
+
+type mockSQS struct {
+	sqsiface.SQSAPI
+	mock.Mock
+}
+
+// nolint (golint)
+func (m *mockSQS) GetQueueUrl(input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.GetQueueUrlOutput), args.Error(1)
+}
+
+func (m *mockSQS) SendMessage(input *sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.SendMessageOutput), args.Error(1)
+}

--- a/cmd/opstools/testutils/testutils.go
+++ b/cmd/opstools/testutils/testutils.go
@@ -1,0 +1,89 @@
+package testutils
+
+import (
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/pkg/errors"
+)
+
+func CreateQueue(client sqsiface.SQSAPI, qname string) (err error) {
+	_, err = client.CreateQueue(&sqs.CreateQueueInput{
+		QueueName: &qname,
+	})
+	return err
+}
+
+func DeleteQueue(client sqsiface.SQSAPI, qname string) (err error) {
+	deleteQueueURL, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: &qname,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "cannot get delete queue url for %s", qname)
+	}
+	_, err = client.DeleteQueue(&sqs.DeleteQueueInput{
+		QueueUrl: deleteQueueURL.QueueUrl,
+	})
+	return err
+}
+
+func CountMessagesInQueue(client sqsiface.SQSAPI, qname string,
+	messageBatchSize, visibilityTimeoutSeconds int64) (totalMessages int, err error) {
+
+	countQueueURL, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: &qname,
+	})
+	if err != nil {
+		return 0, errors.Wrapf(err, "cannot get count queue url for %s", qname)
+	}
+
+	// drain the queue, counting
+	for {
+		resp, err := client.ReceiveMessage(&sqs.ReceiveMessageInput{
+			MaxNumberOfMessages: aws.Int64(messageBatchSize),
+			VisibilityTimeout:   aws.Int64(visibilityTimeoutSeconds),
+			QueueUrl:            countQueueURL.QueueUrl,
+		})
+
+		if err != nil {
+			return 0, errors.Wrap(err, qname)
+		}
+
+		totalMessages += len(resp.Messages)
+		if len(resp.Messages) == 0 {
+			return totalMessages, nil
+		}
+	}
+}
+
+func AddMessagesToQueue(client sqsiface.SQSAPI, qname string, nBatches, messageBatchSize int) (err error) {
+	addQueueURL, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: &qname,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "cannot get add queue url for %s", qname)
+	}
+
+	for batch := 0; batch < nBatches; batch++ {
+		var sendMessageBatchRequestEntries []*sqs.SendMessageBatchRequestEntry
+		for i := 0; i < messageBatchSize; i++ {
+			id := aws.String(strconv.Itoa(i))
+			sendMessageBatchRequestEntries = append(sendMessageBatchRequestEntries, &sqs.SendMessageBatchRequestEntry{
+				Id:          id,
+				MessageBody: id,
+			})
+		}
+
+		_, err = client.SendMessageBatch(&sqs.SendMessageBatchInput{
+			Entries:  sendMessageBatchRequestEntries,
+			QueueUrl: addQueueURL.QueueUrl,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failure sending test messages")
+		}
+	}
+
+	return nil
+}

--- a/docs/gitbook/operations/ops-home.md
+++ b/docs/gitbook/operations/ops-home.md
@@ -30,11 +30,14 @@ To configure alarms to send to your team, follow the guides below:
 - [PagerDuty Integration](https://support.pagerduty.com/docs/aws-cloudwatch-integration-guide)
 
 ## Tools
-Panther comes with some operational tools useful for managing the Panther infrastructure. To build:
+Panther comes with some operational tools useful for managing the Panther infrastructure. These are statically compiled
+executables for linux, mac (aka darwin) and windows. They can be copied/installed onto operational support hosts. 
+To build:
 
 ```yaml
 mage build:opstools
 ```
 
 * **requeue**: a tool to copy messages from a dead letter queue back to the originating queue.
+* **s3queue**: a tool to list files under an S3 path and send to the log processor input queue for processing (useful for backfill of data)
 


### PR DESCRIPTION
## Background
There is a need operationally for customers to backfill data into log processing. This tool will list an S3 bucket and push processing notifications into log processing.

This tool is also useful for testing log processing as specific files can be pushed through the processing.

## Changes
* Added ops tool s3queue
* Refactored test code
* Added ability to cross compile so customers can run both on desktop and on ec2 instances.

## Testing
mage test:ci
I've been using this for load testing log processing.
