### PR TITLE
Modified rules-engine to use the dedup time period returned by the analysis-api

### DIFF
--- a/api/gateway/analysis/api.yml
+++ b/api/gateway/analysis/api.yml
@@ -816,6 +816,8 @@ definitions:
         $ref: '#/definitions/suppressions'
       versionId:
         $ref: '#/definitions/versionId'
+      dedupPeriodMinutes:
+        $ref: '#/definitions/dedupPeriodMinutes'
 
   ##### ListPolicies #####
   PolicyList:

--- a/api/gateway/analysis/models/enabled_policy.go
+++ b/api/gateway/analysis/models/enabled_policy.go
@@ -36,6 +36,9 @@ type EnabledPolicy struct {
 	// body
 	Body Body `json:"body,omitempty"`
 
+	// dedup period minutes
+	DedupPeriodMinutes DedupPeriodMinutes `json:"dedupPeriodMinutes,omitempty"`
+
 	// id
 	ID ID `json:"id,omitempty"`
 
@@ -57,6 +60,10 @@ func (m *EnabledPolicy) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateBody(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDedupPeriodMinutes(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -95,6 +102,22 @@ func (m *EnabledPolicy) validateBody(formats strfmt.Registry) error {
 	if err := m.Body.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("body")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *EnabledPolicy) validateDedupPeriodMinutes(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DedupPeriodMinutes) { // not required
+		return nil
+	}
+
+	if err := m.DedupPeriodMinutes.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("dedupPeriodMinutes")
 		}
 		return err
 	}

--- a/internal/core/analysis_api/handlers/get_enabled_policies.go
+++ b/internal/core/analysis_api/handlers/get_enabled_policies.go
@@ -53,6 +53,7 @@ func GetEnabledPolicies(request *events.APIGatewayProxyRequest) *events.APIGatew
 			Severity:      policy.Severity,
 			Suppressions:  policy.Suppressions,
 			VersionID:     policy.VersionID,
+			DedupPeriodMinutes: policy.DedupPeriodMinutes,
 		})
 		return nil
 	})
@@ -83,6 +84,7 @@ func buildEnabledScan(ruleType string) (*dynamodb.ScanInput, error) {
 		expression.Name("severity"),
 		expression.Name("suppressions"),
 		expression.Name("versionId"),
+		expression.Name("dedupPeriodMinutes"),
 	)
 
 	expr, err := expression.NewBuilder().

--- a/internal/core/analysis_api/handlers/get_enabled_policies.go
+++ b/internal/core/analysis_api/handlers/get_enabled_policies.go
@@ -47,12 +47,12 @@ func GetEnabledPolicies(request *events.APIGatewayProxyRequest) *events.APIGatew
 	policies := make([]*models.EnabledPolicy, 0, 100)
 	err = scanPages(scanInput, func(policy *tableItem) error {
 		policies = append(policies, &models.EnabledPolicy{
-			Body:          policy.Body,
-			ID:            policy.ID,
-			ResourceTypes: policy.ResourceTypes,
-			Severity:      policy.Severity,
-			Suppressions:  policy.Suppressions,
-			VersionID:     policy.VersionID,
+			Body:               policy.Body,
+			ID:                 policy.ID,
+			ResourceTypes:      policy.ResourceTypes,
+			Severity:           policy.Severity,
+			Suppressions:       policy.Suppressions,
+			VersionID:          policy.VersionID,
 			DedupPeriodMinutes: policy.DedupPeriodMinutes,
 		})
 		return nil

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -1160,11 +1160,11 @@ func getEnabledRules(t *testing.T) {
 	expected := &models.EnabledPolicies{
 		Policies: []*models.EnabledPolicy{
 			{
-				Body:          rule.Body,
-				ID:            rule.ID,
-				ResourceTypes: rule.LogTypes,
-				Severity:      rule.Severity,
-				VersionID:     rule.VersionID,
+				Body:               rule.Body,
+				ID:                 rule.ID,
+				ResourceTypes:      rule.LogTypes,
+				Severity:           rule.Severity,
+				VersionID:          rule.VersionID,
 				DedupPeriodMinutes: rule.DedupPeriodMinutes,
 			},
 		},

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -1165,6 +1165,7 @@ func getEnabledRules(t *testing.T) {
 				ResourceTypes: rule.LogTypes,
 				Severity:      rule.Severity,
 				VersionID:     rule.VersionID,
+				DedupPeriodMinutes: rule.DedupPeriodMinutes,
 			},
 		},
 	}

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+
 # pylint: disable=too-many-instance-attributes
 @dataclass
 class EventMatch:

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class EventMatch:
     """Represents an event that matched a rule"""
@@ -25,6 +25,7 @@ class EventMatch:
     rule_version: str
     log_type: str
     dedup: str
+    dedup_period_mins: int
     severity: str
     event: Dict[str, Any]
     title: Optional[str] = None

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -18,6 +18,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
+from .logging import get_logger
 
 import boto3
 
@@ -83,7 +84,8 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     1. It is the first time this rule with this dedup string fires
     2. This rule with the same dedup string has fired before, but after the dedup period has expired
     """
-
+    logger = get_logger()
+    logger.info('doing conditional update with %d', group_info.dedup_period_mins)
     condition_expression = '(#1 < :1) OR (attribute_not_exists(#2))'
     update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
 

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -39,10 +39,6 @@ _ALERT_SEVERITY_ATTR_NAME = 'severity'
 _ALERT_LOG_TYPES = 'logTypes'
 _ALERT_TITLE = 'title'
 
-# TODO Once rules store alert merge period, retrieve it from there
-# Currently grouping in 1hr periods
-_ALERT_MERGE_PERIOD_SECONDS = 3600
-
 
 # pylint: disable=too-many-instance-attributes
 @dataclass
@@ -52,6 +48,7 @@ class MatchingGroupInfo:
     rule_version: str
     log_type: str
     dedup: str
+    dedup_period_mins: int
     severity: str
     num_matches: int
     title: Optional[str]
@@ -84,7 +81,7 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     """Performs a conditional update to DDB to verify whether we need to create a new alert.
     The condition will succeed only if:
     1. It is the first time this rule with this dedup string fires
-    2. This rule with the same dedup string has fired before, but it fired more than _ALERT_MERGE_PERIOD_SECONDS earlier
+    2. This rule with the same dedup string has fired before, but after the dedup period has expired
     """
 
     condition_expression = '(#1 < :1) OR (attribute_not_exists(#2))'
@@ -110,9 +107,11 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
         expresion_attribute_names['#12'] = _ALERT_TITLE
 
     expression_attribute_values = {
-        ':1': {
-            'N': '{}'.format(int(group_info.processing_time.timestamp()) - _ALERT_MERGE_PERIOD_SECONDS)
-        },
+        ':1':
+            {
+                # Converting dedup_period_mins to seconds
+                'N': '{}'.format(int(group_info.processing_time.timestamp()) - group_info.dedup_period_mins * 60)
+            },
         ':3': {
             'N': '1'
         },

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -18,7 +18,6 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
-from .logging import get_logger
 
 import boto3
 
@@ -84,8 +83,6 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     1. It is the first time this rule with this dedup string fires
     2. This rule with the same dedup string has fired before, but after the dedup period has expired
     """
-    logger = get_logger()
-    logger.info('doing conditional update with %d', group_info.dedup_period_mins)
     condition_expression = '(#1 < :1) OR (attribute_not_exists(#2))'
     update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
 

--- a/internal/log_analysis/rules_engine/src/analysis_api.py
+++ b/internal/log_analysis/rules_engine/src/analysis_api.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-from typing import Dict, List
+from typing import Dict, List, Any
 
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
@@ -36,7 +36,7 @@ class AnalysisAPIClient:
         analysis_api_path = os.environ['ANALYSIS_API_PATH']
         self.url = 'https://' + analysis_api_fqdn + '/' + analysis_api_path
 
-    def get_enabled_rules(self) -> List[Dict[str, str]]:
+    def get_enabled_rules(self) -> List[Dict[str, Any]]:
         """Gets information for all enabled rules."""
         request = AWSRequest(method='GET', url=self.url + '/enabled', params={'type': 'RULE'})
         self.signer.add_auth(request)

--- a/internal/log_analysis/rules_engine/src/analysis_api.py
+++ b/internal/log_analysis/rules_engine/src/analysis_api.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -82,13 +82,7 @@ class Engine:
         for raw_rule in rules:
             if raw_rule.get('id') == COMMON_MODULE_RULE_ID:
                 try:
-                    Rule(
-                        rule_id=raw_rule.get('id'),
-                        body=raw_rule.get('body'),
-                        severity=raw_rule.get('severity'),
-                        version=raw_rule.get('versionId'),
-                        dedup_period_mins=raw_rule.get('dedupPeriodMinutes')
-                    )
+                    Rule(raw_rule)
                 except Exception as err:  # pylint: disable=broad-except
                     self.logger.error('Failed to import rule %s', err)
                 rules.remove(raw_rule)
@@ -96,13 +90,7 @@ class Engine:
 
         for raw_rule in rules:
             try:
-                rule = Rule(
-                    rule_id=raw_rule.get('id'),
-                    body=raw_rule.get('body'),
-                    severity=raw_rule.get('severity'),
-                    version=raw_rule.get('versionId'),
-                    dedup_period_mins=raw_rule.get('dedupPeriodMinutes')
-                )
+                rule = Rule(raw_rule)
             except Exception as err:  # pylint: disable=broad-except
                 self.logger.error('Failed to import rule %s', err)
                 continue

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -56,6 +56,7 @@ class Engine:
                     rule_version=rule.rule_version,
                     log_type=log_type,
                     dedup=result.dedup_string,  # type: ignore
+                    dedup_period_mins=result.dedup_period_mins,  # type: ignore
                     event=event,
                     severity=rule.rule_severity,
                     title=result.title
@@ -83,9 +84,10 @@ class Engine:
                 try:
                     Rule(
                         rule_id=raw_rule.get('id'),
-                        rule_body=raw_rule.get('body'),
-                        rule_severity=raw_rule.get('severity'),
-                        rule_version=raw_rule.get('versionId')
+                        body=raw_rule.get('body'),
+                        severity=raw_rule.get('severity'),
+                        version=raw_rule.get('versionId'),
+                        dedup_period_mins=raw_rule.get('dedupPeriodMinutes')
                     )
                 except Exception as err:  # pylint: disable=broad-except
                     self.logger.error('Failed to import rule %s', err)
@@ -96,9 +98,10 @@ class Engine:
             try:
                 rule = Rule(
                     rule_id=raw_rule.get('id'),
-                    rule_body=raw_rule.get('body'),
-                    rule_severity=raw_rule.get('severity'),
-                    rule_version=raw_rule.get('versionId')
+                    body=raw_rule.get('body'),
+                    severity=raw_rule.get('severity'),
+                    version=raw_rule.get('versionId'),
+                    dedup_period_mins=raw_rule.get('dedupPeriodMinutes')
                 )
             except Exception as err:  # pylint: disable=broad-except
                 self.logger.error('Failed to import rule %s', err)
@@ -113,7 +116,7 @@ class Engine:
         self.logger.info('Imported %d rules in %d seconds', import_count, end - start)
         self._last_update = datetime.utcnow()
 
-    def _get_rules(self) -> List[Dict[str, str]]:
+    def _get_rules(self) -> List[Dict[str, Any]]:
         """Retrieves all enabled rules.
 
         Returns:

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -56,7 +56,7 @@ class Engine:
                     rule_version=rule.rule_version,
                     log_type=log_type,
                     dedup=result.dedup_string,  # type: ignore
-                    dedup_period_mins=rule.rule_dedup_period_mins,  # type: ignore
+                    dedup_period_mins=rule.rule_dedup_period_mins,
                     event=event,
                     severity=rule.rule_severity,
                     title=result.title

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -84,7 +84,7 @@ class Engine:
                 try:
                     Rule(raw_rule)
                 except Exception as err:  # pylint: disable=broad-except
-                    self.logger.error('Failed to import rule %s. Error: [%s]',raw_rule.get('id'),  err)
+                    self.logger.error('Failed to import rule %s. Error: [%s]', raw_rule.get('id'), err)
                 rules.remove(raw_rule)
                 break
 
@@ -92,7 +92,7 @@ class Engine:
             try:
                 rule = Rule(raw_rule)
             except Exception as err:  # pylint: disable=broad-except
-                self.logger.error('Failed to import rule %s. Error: [%s]',raw_rule.get('id'),  err)
+                self.logger.error('Failed to import rule %s. Error: [%s]', raw_rule.get('id'), err)
                 continue
 
             import_count = import_count + 1

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -56,7 +56,7 @@ class Engine:
                     rule_version=rule.rule_version,
                     log_type=log_type,
                     dedup=result.dedup_string,  # type: ignore
-                    dedup_period_mins=result.dedup_period_mins,  # type: ignore
+                    dedup_period_mins=rule.rule_dedup_period_mins,  # type: ignore
                     event=event,
                     severity=rule.rule_severity,
                     title=result.title

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -84,7 +84,7 @@ class Engine:
                 try:
                     Rule(raw_rule)
                 except Exception as err:  # pylint: disable=broad-except
-                    self.logger.error('Failed to import rule %s', err)
+                    self.logger.error('Failed to import rule %s. Error: [%s]',raw_rule.get('id'),  err)
                 rules.remove(raw_rule)
                 break
 
@@ -92,7 +92,7 @@ class Engine:
             try:
                 rule = Rule(raw_rule)
             except Exception as err:  # pylint: disable=broad-except
-                self.logger.error('Failed to import rule %s', err)
+                self.logger.error('Failed to import rule %s. Error: [%s]',raw_rule.get('id'),  err)
                 continue
 
             import_count = import_count + 1

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -52,12 +52,13 @@ def direct_analysis(request: Dict[str, Any]) -> Dict[str, Any]:
         raise RuntimeError('exactly one rule expected, found {}'.format(len(request['rules'])))
 
     raw_rule = request['rules'][0]
-    rule_severity = raw_rule.get('severity', 'INFO')
+    if not 'severity' in raw_rule:
+        raw_rule['severity'] = 'INFO'
     # It is possible that during direct analysis the rule doesn't include a severity
-    # in this case, we set it to a default value
+    # Setting it to a default value
     rule_exception: Optional[Exception] = None
     try:
-        test_rule = Rule(rule_id=raw_rule.get('id'), version='default', body=raw_rule.get('body'), severity=rule_severity)
+        test_rule = Rule(raw_rule)
     except Exception as err:  # pylint: disable=broad-except
         rule_exception = err
 

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -55,7 +55,7 @@ def direct_analysis(request: Dict[str, Any]) -> Dict[str, Any]:
     if not 'severity' in raw_rule:
         raw_rule['severity'] = 'INFO'
     # It is possible that during direct analysis the rule doesn't include a severity
-    # Setting it to a default value
+    # in this case, we set it to a default value
     rule_exception: Optional[Exception] = None
     try:
         test_rule = Rule(raw_rule)

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -57,7 +57,7 @@ def direct_analysis(request: Dict[str, Any]) -> Dict[str, Any]:
     # in this case, we set it to a default value
     rule_exception: Optional[Exception] = None
     try:
-        test_rule = Rule(rule_id=raw_rule.get('id'), rule_version='default', rule_body=raw_rule.get('body'), rule_severity=rule_severity)
+        test_rule = Rule(rule_id=raw_rule.get('id'), version='default', body=raw_rule.get('body'), severity=rule_severity)
     except Exception as err:  # pylint: disable=broad-except
         rule_exception = err
 

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -115,7 +115,7 @@ class MatchedEventsBuffer:
 
 def _write_to_s3(time: datetime, key: OutputGroupingKey, events: List[EventMatch]) -> None:
     # 'severity', 'version', 'title', 'dedup_period' of a rule might differ if the rule was modified
-    # while the rules engine was running. We pick the first encountered values.
+    # while the rules engine was running. We pick the first encountered set of values.
     group_info = MatchingGroupInfo(
         rule_id=key.rule_id,
         rule_version=events[0].rule_version,

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -114,13 +114,14 @@ class MatchedEventsBuffer:
 
 
 def _write_to_s3(time: datetime, key: OutputGroupingKey, events: List[EventMatch]) -> None:
-    # severity and version of a rule might differ if the rule was modified while the rules engine was running.
-    # We pick the first encountered severity, version and title.
+    # 'severity', 'version', 'title', 'dedup_period' of a rule might differ if the rule was modified
+    # while the rules engine was running. We pick the first encountered values.
     group_info = MatchingGroupInfo(
         rule_id=key.rule_id,
         rule_version=events[0].rule_version,
         log_type=key.log_type,
         dedup=key.dedup,
+        dedup_period_mins=events[0].dedup_period_mins,
         severity=events[0].severity,
         num_matches=len(events),
         title=events[0].title,

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -48,7 +48,6 @@ class RuleResult:
     exception: Optional[Exception] = None
     matched: Optional[bool] = None
     dedup_string: Optional[str] = None
-    dedup_period_mins: Optional[int] = None
     title: Optional[str] = None
 
 
@@ -111,16 +110,14 @@ class Rule:
 
         dedup_string: Optional[str] = None
         title: Optional[str] = None
-        dedup_period_mins: Optional[int] = None
         try:
             rule_result = _run_command(self._module.rule, event, bool)
             if rule_result:
                 dedup_string = self._get_dedup(event)
                 title = self._get_title(event)
-                dedup_period_mins = self.rule_dedup_period_mins
         except Exception as err:  # pylint: disable=broad-except
             return RuleResult(exception=err)
-        return RuleResult(matched=rule_result, dedup_string=dedup_string, title=title, dedup_period_mins=dedup_period_mins)
+        return RuleResult(matched=rule_result, dedup_string=dedup_string, title=title)
 
     def _get_dedup(self, event: Dict[str, Any]) -> str:
         if not self._has_dedup:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+import json
 import os
 import sys
 import tempfile
@@ -90,6 +90,8 @@ class Rule:
         else:
             self.rule_dedup_period_mins = config['dedupPeriodMinutes']
 
+        get_logger().info('tsa %s', json.dumps(config))
+        get_logger().info('Loaded rule %s with %d', self.rule_id, self.rule_dedup_period_mins)
         self._store_rule()
         self._module = self._import_rule_as_module()
 
@@ -120,7 +122,6 @@ class Rule:
                 dedup_period_mins = self.rule_dedup_period_mins
         except Exception as err:  # pylint: disable=broad-except
             return RuleResult(exception=err)
-
         return RuleResult(matched=rule_result, dedup_string=dedup_string, title=title, dedup_period_mins=dedup_period_mins)
 
     def _get_dedup(self, event: Dict[str, Any]) -> str:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import json
+
 import os
 import sys
 import tempfile
@@ -90,8 +90,6 @@ class Rule:
         else:
             self.rule_dedup_period_mins = config['dedupPeriodMinutes']
 
-        get_logger().info('tsa %s', json.dumps(config))
-        get_logger().info('Loaded rule %s with %d', self.rule_id, self.rule_dedup_period_mins)
         self._store_rule()
         self._module = self._import_rule_as_module()
 

--- a/internal/log_analysis/rules_engine/tests/test_engine.py
+++ b/internal/log_analysis/rules_engine/tests/test_engine.py
@@ -70,7 +70,8 @@ class TestEngine(TestCase):
                 'resourceTypes': ['log'],
                 'body': 'def rule(event):\n\treturn True',
                 'severity': 'INFO',
-                'versionId': 'version'
+                'versionId': 'version',
+                'dedupPeriodMinutes': 120
             },  # This rule should match the event
             {
                 'id': 'rule_id_2',
@@ -84,7 +85,15 @@ class TestEngine(TestCase):
         result = engine.analyze('log', {})
 
         expected_event_matches = [
-            EventMatch(rule_id='rule_id_1', rule_version='version', log_type='log', severity='INFO', dedup='rule_id_1', event={})
+            EventMatch(
+                rule_id='rule_id_1',
+                rule_version='version',
+                log_type='log',
+                severity='INFO',
+                dedup='rule_id_1',
+                dedup_period_mins=120,
+                event={}
+            )
         ]
         self.assertEqual(result, expected_event_matches)
 
@@ -115,8 +124,24 @@ class TestEngine(TestCase):
         result = engine.analyze('log', {})
 
         expected_event_matches = [
-            EventMatch(rule_id='rule_id_1', rule_version='version', log_type='log', severity='INFO', dedup='rule_id_1', event={}),
-            EventMatch(rule_id='rule_id_3', rule_version='version', log_type='log', severity='INFO', dedup='rule_id_3', event={})
+            EventMatch(
+                rule_id='rule_id_1',
+                rule_version='version',
+                log_type='log',
+                severity='INFO',
+                dedup='rule_id_1',
+                event={},
+                dedup_period_mins=60
+            ),
+            EventMatch(
+                rule_id='rule_id_3',
+                rule_version='version',
+                log_type='log',
+                severity='INFO',
+                dedup='rule_id_3',
+                event={},
+                dedup_period_mins=60
+            )
         ]
 
         self.assertEqual(result, expected_event_matches)

--- a/internal/log_analysis/rules_engine/tests/test_output.py
+++ b/internal/log_analysis/rules_engine/tests/test_output.py
@@ -41,7 +41,15 @@ class TestMatchedEventsBuffer(TestCase):
 
     def test_add_and_flush_event_generate_new_alert(self) -> None:
         buffer = MatchedEventsBuffer()
-        event_match = EventMatch('rule_id', 'rule_version', 'log_type', 'dedup', 'INFO', {'data_key': 'data_value'})
+        event_match = EventMatch(
+            rule_id='rule_id',
+            rule_version='rule_version',
+            log_type='log_type',
+            dedup='dedup',
+            dedup_period_mins=100,
+            severity='INFO',
+            event={'data_key': 'data_value'}
+        )
         buffer.add_event(event_match)
 
         self.assertEqual(len(buffer.data), 1)
@@ -147,8 +155,28 @@ class TestMatchedEventsBuffer(TestCase):
 
     def test_add_same_rule_different_log(self) -> None:
         buffer = MatchedEventsBuffer()
-        buffer.add_event(EventMatch('id', 'version', 'log1', 'dedup', 'INFO', {'key1': 'value1'}))
-        buffer.add_event(EventMatch('id', 'version', 'log2', 'dedup', 'INFO', {'key2': 'value2'}))
+        buffer.add_event(
+            EventMatch(
+                rule_id='id',
+                rule_version='version',
+                log_type='log1',
+                dedup='dedup',
+                dedup_period_mins=100,
+                severity='INFO',
+                event={'key1': 'value1'}
+            )
+        )
+        buffer.add_event(
+            EventMatch(
+                rule_id='id',
+                rule_version='version',
+                log_type='log2',
+                dedup='dedup',
+                dedup_period_mins=100,
+                severity='INFO',
+                event={'key2': 'value2'}
+            )
+        )
 
         self.assertEqual(len(buffer.data), 2)
 
@@ -189,8 +217,28 @@ class TestMatchedEventsBuffer(TestCase):
 
     def test_add_same_log_different_rules(self) -> None:
         buffer = MatchedEventsBuffer()
-        buffer.add_event(EventMatch('id1', 'version', 'log', 'dedup', 'INFO', {'key1': 'value1'}))
-        buffer.add_event(EventMatch('id2', 'version', 'log', 'dedup', 'INFO', {'key2': 'value2'}))
+        buffer.add_event(
+            EventMatch(
+                rule_id='id1',
+                rule_version='version',
+                log_type='log',
+                dedup='dedup',
+                dedup_period_mins=100,
+                severity='INFO',
+                event={'key1': 'value1'}
+            )
+        )
+        buffer.add_event(
+            EventMatch(
+                rule_id='id2',
+                rule_version='version',
+                log_type='log',
+                dedup='dedup',
+                dedup_period_mins=100,
+                severity='INFO',
+                event={'key2': 'value2'}
+            )
+        )
 
         self.assertEqual(len(buffer.data), 2)
 
@@ -231,8 +279,28 @@ class TestMatchedEventsBuffer(TestCase):
 
     def test_group_events_together(self) -> None:
         buffer = MatchedEventsBuffer()
-        buffer.add_event(EventMatch('id', 'version', 'log', 'dedup', 'INFO', {'key1': 'value1'}))
-        buffer.add_event(EventMatch('id', 'version', 'log', 'dedup', 'INFO', {'key2': 'value2'}))
+        buffer.add_event(
+            EventMatch(
+                rule_id='id',
+                rule_version='version',
+                log_type='log',
+                dedup='dedup',
+                dedup_period_mins=100,
+                severity='INFO',
+                event={'key1': 'value1'}
+            )
+        )
+        buffer.add_event(
+            EventMatch(
+                rule_id='id',
+                rule_version='version',
+                log_type='log',
+                dedup='dedup',
+                dedup_period_mins=100,
+                severity='INFO',
+                event={'key2': 'value2'}
+            )
+        )
 
         self.assertEqual(len(buffer.data), 1)
 
@@ -270,7 +338,15 @@ class TestMatchedEventsBuffer(TestCase):
         buffer = MatchedEventsBuffer()
         # Reducing max_bytes so that it will cause the overflow condition to trigger earlier
         buffer.max_bytes = 50
-        event_match = EventMatch('rule_id', 'rule_version', 'log_type', 'dedup', 'INFO', {'data_key': 'data_value'})
+        event_match = EventMatch(
+            rule_id='rule_id',
+            rule_version='rule_version',
+            log_type='log_type',
+            dedup='dedup',
+            dedup_period_mins=100,
+            severity='INFO',
+            event={'data_key': 'data_value'}
+        )
 
         DDB_MOCK.update_item.return_value = {'Attributes': {'alertCount': {'N': '1'}}}
 

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -48,6 +48,12 @@ class TestRule(TestCase):
 
         self.assertTrue(exception)
 
+    def test_rule_default_dedup_time(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True'
+        rule = Rule({'id': 'test_rule_default_dedup_time', 'body': rule_body, 'severity': 'INFO'})
+
+        self.assertEqual(60, rule.rule_dedup_period_mins)
+
     def test_create_rule_missing_method(self) -> None:
         exception = False
         rule_body = 'def another_method(event):\n\treturn False'
@@ -60,8 +66,15 @@ class TestRule(TestCase):
 
     def test_rule_matches(self) -> None:
         rule_body = 'def rule(event):\n\treturn True'
-        rule = Rule({'id': 'test_rule_matches', 'body': rule_body, 'severity': 'INFO'})
-        expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches', dedup_period_mins=60)
+        rule = Rule({'id': 'test_rule_matches', 'body': rule_body, 'severity': 'INFO', 'dedupPeriodMinutes': 100, 'versionId': 'test'})
+
+        self.assertEqual('test_rule_matches', rule.rule_id)
+        self.assertEqual(rule_body, rule.rule_body)
+        self.assertEqual('test', rule.rule_version)
+        self.assertEqual('INFO', rule.rule_severity)
+        self.assertEqual(100, rule.rule_dedup_period_mins)
+
+        expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_doesnt_match(self) -> None:
@@ -73,7 +86,7 @@ class TestRule(TestCase):
     def test_rule_with_dedup(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
         rule = Rule({'id': 'test_rule_with_dedup', 'body': rule_body, 'severity': 'INFO'})
-        expected_rule = RuleResult(matched=True, dedup_string='testdedup', dedup_period_mins=60)
+        expected_rule = RuleResult(matched=True, dedup_string='testdedup')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_dedup_size(self) -> None:
@@ -82,7 +95,7 @@ class TestRule(TestCase):
         rule = Rule({'id': 'test_restrict_dedup_size', 'body': rule_body, 'severity': 'INFO'})
 
         expected_dedup_string_prefix = ''.join('a' for _ in range(MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)))
-        expected_rule = RuleResult(matched=True, dedup_period_mins=60, dedup_string=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX)
+        expected_rule = RuleResult(matched=True, dedup_string=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX)
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_title_size(self) -> None:
@@ -92,10 +105,7 @@ class TestRule(TestCase):
 
         expected_title_string_prefix = ''.join('a' for _ in range(MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)))
         expected_rule = RuleResult(
-            matched=True,
-            dedup_string='test_restrict_title_size',
-            title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX,
-            dedup_period_mins=60
+            matched=True, dedup_string='test_restrict_title_size', title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX
         )
         self.assertEqual(expected_rule, rule.run({}))
 
@@ -103,7 +113,7 @@ class TestRule(TestCase):
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
         rule = Rule({'id': 'test_empty_dedup_result_to_default', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default', dedup_period_mins=60)
+        expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_throws_exception(self) -> None:
@@ -112,7 +122,6 @@ class TestRule(TestCase):
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_invalid_rule_return(self) -> None:
@@ -121,7 +130,6 @@ class TestRule(TestCase):
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_dedup_throws_exception(self) -> None:
@@ -130,7 +138,6 @@ class TestRule(TestCase):
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_invalid_dedup_return(self) -> None:
@@ -139,21 +146,20 @@ class TestRule(TestCase):
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_dedup_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_dedup_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string', dedup_period_mins=60)
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_matches_with_title(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
         rule = Rule({'id': 'test_rule_matches_with_title', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title', dedup_period_mins=60)
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_throws_exception(self) -> None:
@@ -164,7 +170,6 @@ class TestRule(TestCase):
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.title)
         self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_invalid_title_return(self) -> None:
@@ -175,19 +180,11 @@ class TestRule(TestCase):
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.title)
         self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_title_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_title_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string', dedup_period_mins=60)
-        self.assertEqual(rule.run({}), expected_result)
-
-    def test_rule_title_returns_correct_time(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True'
-        rule = Rule({'id': 'test_rule_title_returns_correct_time', 'body': rule_body, 'severity': 'INFO', 'dedupPeriodMinutes': 100})
-
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_correct_time', dedup_period_mins=100)
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -24,7 +24,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_id(self) -> None:
         exception = False
         try:
-            Rule(rule_id=None, rule_body='rule', rule_severity='INFO', rule_version='version')
+            Rule(rule_id=None, body='rule', severity='INFO', version='version')
         except AssertionError:
             exception = True
 
@@ -33,7 +33,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_body(self) -> None:
         exception = False
         try:
-            Rule(rule_id='test_create_rule_missing_body', rule_body=None, rule_severity='INFO', rule_version='version')
+            Rule(rule_id='test_create_rule_missing_body', body=None, severity='INFO', version='version')
         except AssertionError:
             exception = True
 
@@ -42,7 +42,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_version(self) -> None:
         exception = False
         try:
-            Rule(rule_id='test_create_rule_missing_version', rule_body='rule', rule_severity='INFO', rule_version=None)
+            Rule(rule_id='test_create_rule_missing_version', body='rule', severity='INFO', version=None)
         except AssertionError:
             exception = True
 
@@ -51,7 +51,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_severity(self) -> None:
         exception = False
         try:
-            Rule(rule_id='test_create_rule_missing_severity', rule_body='rule', rule_severity=None, rule_version='version')
+            Rule(rule_id='test_create_rule_missing_severity', body='rule', severity=None, version='version')
         except AssertionError:
             exception = True
 
@@ -61,7 +61,7 @@ class TestRule(TestCase):
         exception = False
         rule_body = 'def another_method(event):\n\treturn False'
         try:
-            Rule(rule_id='test_create_rule_missing_method', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+            Rule(rule_id='test_create_rule_missing_method', body=rule_body, severity='INFO', version='version')
         except AssertionError:
             exception = True
 
@@ -69,26 +69,26 @@ class TestRule(TestCase):
 
     def test_rule_matches(self) -> None:
         rule_body = 'def rule(event):\n\treturn True'
-        rule = Rule(rule_id='test_rule_matches', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_matches', body=rule_body, severity='INFO', version='version')
         expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_doesnt_match(self) -> None:
         rule_body = 'def rule(event):\n\treturn False'
-        rule = Rule(rule_id='test_rule_doesnt_match', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_doesnt_match', body=rule_body, severity='INFO', version='version')
         expected_rule = RuleResult(matched=False)
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_rule_with_dedup(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
-        rule = Rule(rule_id='test_rule_with_dedup', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_with_dedup', body=rule_body, severity='INFO', version='version')
         expected_rule = RuleResult(matched=True, dedup_string='testdedup')
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_restrict_dedup_size(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'.\
             format(MAX_DEDUP_STRING_SIZE+1)
-        rule = Rule(rule_id='test_restrict_dedup_size', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_restrict_dedup_size', body=rule_body, severity='INFO', version='version')
 
         expected_dedup_string_prefix = ''.join('a' for _ in range(MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)))
         expected_rule = RuleResult(matched=True, dedup_string=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX)
@@ -97,7 +97,7 @@ class TestRule(TestCase):
     def test_restrict_title_size(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "".join("a" for i in range({}))'. \
             format(MAX_TITLE_SIZE+1)
-        rule = Rule(rule_id='test_restrict_title_size', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_restrict_title_size', body=rule_body, severity='INFO', version='version')
 
         expected_title_string_prefix = ''.join('a' for _ in range(MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)))
         expected_rule = RuleResult(
@@ -107,14 +107,14 @@ class TestRule(TestCase):
 
     def test_empty_dedup_result_to_default(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
-        rule = Rule(rule_id='test_empty_dedup_result_to_default', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_empty_dedup_result_to_default', body=rule_body, severity='INFO', version='version')
 
         expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
         self.assertEqual(rule.run({}), expected_rule)
 
     def test_rule_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='test_rule_throws_exception', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_throws_exception', body=rule_body, severity='INFO', version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -122,7 +122,7 @@ class TestRule(TestCase):
 
     def test_rule_invalid_rule_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn "test"'
-        rule = Rule(rule_id='test_rule_invalid_rule_return', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_invalid_rule_return', body=rule_body, severity='INFO', version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -130,7 +130,7 @@ class TestRule(TestCase):
 
     def test_dedup_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='test_dedup_throws_exception', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_dedup_throws_exception', body=rule_body, severity='INFO', version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -138,7 +138,7 @@ class TestRule(TestCase):
 
     def test_rule_invalid_dedup_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
-        rule = Rule(rule_id='test_rule_invalid_dedup_return', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_invalid_dedup_return', body=rule_body, severity='INFO', version='version')
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
@@ -146,21 +146,21 @@ class TestRule(TestCase):
 
     def test_rule_dedup_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
-        rule = Rule(rule_id='test_rule_dedup_returns_empty_string', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_dedup_returns_empty_string', body=rule_body, severity='INFO', version='version')
 
         expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_matches_with_title(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
-        rule = Rule(rule_id='test_rule_matches_with_title', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_matches_with_title', body=rule_body, severity='INFO', version='version')
 
         expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='test_rule_title_throws_exception', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_title_throws_exception', body=rule_body, severity='INFO', version='version')
 
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
@@ -170,7 +170,7 @@ class TestRule(TestCase):
 
     def test_rule_invalid_title_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
-        rule = Rule(rule_id='test_rule_invalid_title_return', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_invalid_title_return', body=rule_body, severity='INFO', version='version')
 
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
@@ -180,7 +180,7 @@ class TestRule(TestCase):
 
     def test_rule_title_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
-        rule = Rule(rule_id='test_rule_title_returns_empty_string', rule_body=rule_body, rule_severity='INFO', rule_version='version')
+        rule = Rule(rule_id='test_rule_title_returns_empty_string', body=rule_body, severity='INFO', version='version')
 
         expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -184,3 +184,10 @@ class TestRule(TestCase):
 
         expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string', dedup_period_mins=60)
         self.assertEqual(rule.run({}), expected_result)
+
+    def test_rule_title_returns_correct_time(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True'
+        rule = Rule({'id': 'test_rule_title_returns_correct_time', 'body': rule_body, 'severity': 'INFO', 'dedupPeriodMinutes': 100})
+
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_correct_time', dedup_period_mins=100)
+        self.assertEqual(rule.run({}), expected_result)

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -24,7 +24,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_id(self) -> None:
         exception = False
         try:
-            Rule(rule_id=None, body='rule', severity='INFO', version='version')
+            Rule({'body': 'rule', 'severity': 'INFO', 'versionId': 'version'})
         except AssertionError:
             exception = True
 
@@ -33,16 +33,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_body(self) -> None:
         exception = False
         try:
-            Rule(rule_id='test_create_rule_missing_body', body=None, severity='INFO', version='version')
-        except AssertionError:
-            exception = True
-
-        self.assertTrue(exception)
-
-    def test_create_rule_missing_version(self) -> None:
-        exception = False
-        try:
-            Rule(rule_id='test_create_rule_missing_version', body='rule', severity='INFO', version=None)
+            Rule({'id': 'test_create_rule_missing_body', 'severity': 'INFO', 'versionId': 'version'})
         except AssertionError:
             exception = True
 
@@ -51,7 +42,7 @@ class TestRule(TestCase):
     def test_create_rule_missing_severity(self) -> None:
         exception = False
         try:
-            Rule(rule_id='test_create_rule_missing_severity', body='rule', severity=None, version='version')
+            Rule({'id': 'test_create_rule_missing_severity', 'body': 'body', 'versionId': 'version'})
         except AssertionError:
             exception = True
 
@@ -61,7 +52,7 @@ class TestRule(TestCase):
         exception = False
         rule_body = 'def another_method(event):\n\treturn False'
         try:
-            Rule(rule_id='test_create_rule_missing_method', body=rule_body, severity='INFO', version='version')
+            Rule({'id': 'test_create_rule_missing_method', 'body': rule_body, 'severity': 'INFO'})
         except AssertionError:
             exception = True
 
@@ -69,118 +60,127 @@ class TestRule(TestCase):
 
     def test_rule_matches(self) -> None:
         rule_body = 'def rule(event):\n\treturn True'
-        rule = Rule(rule_id='test_rule_matches', body=rule_body, severity='INFO', version='version')
-        expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches')
+        rule = Rule({'id': 'test_rule_matches', 'body': rule_body, 'severity': 'INFO'})
+        expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches', dedup_period_mins=60)
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_doesnt_match(self) -> None:
         rule_body = 'def rule(event):\n\treturn False'
-        rule = Rule(rule_id='test_rule_doesnt_match', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_doesnt_match', 'body': rule_body, 'severity': 'INFO'})
         expected_rule = RuleResult(matched=False)
-        self.assertEqual(rule.run({}), expected_rule)
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_with_dedup(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
-        rule = Rule(rule_id='test_rule_with_dedup', body=rule_body, severity='INFO', version='version')
-        expected_rule = RuleResult(matched=True, dedup_string='testdedup')
-        self.assertEqual(rule.run({}), expected_rule)
+        rule = Rule({'id': 'test_rule_with_dedup', 'body': rule_body, 'severity': 'INFO'})
+        expected_rule = RuleResult(matched=True, dedup_string='testdedup', dedup_period_mins=60)
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_dedup_size(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'.\
             format(MAX_DEDUP_STRING_SIZE+1)
-        rule = Rule(rule_id='test_restrict_dedup_size', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_restrict_dedup_size', 'body': rule_body, 'severity': 'INFO'})
 
         expected_dedup_string_prefix = ''.join('a' for _ in range(MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)))
-        expected_rule = RuleResult(matched=True, dedup_string=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX)
-        self.assertEqual(rule.run({}), expected_rule)
+        expected_rule = RuleResult(matched=True, dedup_period_mins=60, dedup_string=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX)
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_title_size(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "".join("a" for i in range({}))'. \
             format(MAX_TITLE_SIZE+1)
-        rule = Rule(rule_id='test_restrict_title_size', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_restrict_title_size', 'body': rule_body, 'severity': 'INFO'})
 
         expected_title_string_prefix = ''.join('a' for _ in range(MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)))
         expected_rule = RuleResult(
-            matched=True, dedup_string='test_restrict_title_size', title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX
+            matched=True,
+            dedup_string='test_restrict_title_size',
+            title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX,
+            dedup_period_mins=60
         )
-        self.assertEqual(rule.run({}), expected_rule)
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_empty_dedup_result_to_default(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
-        rule = Rule(rule_id='test_empty_dedup_result_to_default', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_empty_dedup_result_to_default', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
-        self.assertEqual(rule.run({}), expected_rule)
+        expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default', dedup_period_mins=60)
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='test_rule_throws_exception', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_throws_exception', 'body': rule_body, 'severity': 'INFO'})
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_invalid_rule_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn "test"'
-        rule = Rule(rule_id='test_rule_invalid_rule_return', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_invalid_rule_return', 'body': rule_body, 'severity': 'INFO'})
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_dedup_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='test_dedup_throws_exception', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_dedup_throws_exception', 'body': rule_body, 'severity': 'INFO'})
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_invalid_dedup_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
-        rule = Rule(rule_id='test_rule_invalid_dedup_return', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_invalid_dedup_return', 'body': rule_body, 'severity': 'INFO'})
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_dedup_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
-        rule = Rule(rule_id='test_rule_dedup_returns_empty_string', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_dedup_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string', dedup_period_mins=60)
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_matches_with_title(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
-        rule = Rule(rule_id='test_rule_matches_with_title', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_matches_with_title', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title')
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title', dedup_period_mins=60)
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
-        rule = Rule(rule_id='test_rule_title_throws_exception', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_title_throws_exception', 'body': rule_body, 'severity': 'INFO'})
 
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.title)
         self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_invalid_title_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
-        rule = Rule(rule_id='test_rule_invalid_title_return', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_invalid_title_return', 'body': rule_body, 'severity': 'INFO'})
 
         rule_result = rule.run({})
         self.assertIsNone(rule_result.matched)
         self.assertIsNone(rule_result.title)
         self.assertIsNone(rule_result.dedup_string)
+        self.assertIsNone(rule_result.dedup_period_mins)
         self.assertIsNotNone(rule_result.exception)
 
     def test_rule_title_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
-        rule = Rule(rule_id='test_rule_title_returns_empty_string', body=rule_body, severity='INFO', version='version')
+        rule = Rule({'id': 'test_rule_title_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string')
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string', dedup_period_mins=60)
         self.assertEqual(rule.run({}), expected_result)


### PR DESCRIPTION
## Background

Finalizing the backend changes that will make it possible to configure the dedup time period. 
Closes #348 

## Changes

- Modified the `GetEnabledPolicies` (used to return rules) to return the optional `dedupPeriodMinutes` property
- Modified rules-engine to use that property when doing the deduplication. In case no value is specified, it falls back to 60'. This gives us backwards compatibility with rules that have no value configured. 
- Updated the way Rule is initialized to avoid excessive number of constructor arguments (and make sure the python linter is not complaining)

## Testing

- Unit tests for new functionality
- Integration tests for new analysis-api functionality
- Deployed to my account and seen the new functionality working. 
