### PR TITLE
Move npm audit outside of mage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,14 @@ commands:
 
 # The pool of jobs that that our CI will be able to run
 jobs:
+  audit_modules:
+    executor: panther-buildpack
+    steps:
+      - setup_frontend
+      - run:
+          name: Audit NPM packages
+          command: npm audit
+
   validate_frontend:
     executor: panther-buildpack
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,5 +59,6 @@ workflows:
   version: 2
   pipeline:
     jobs:
+      - audit_modules
       - validate_frontend
       - validate_backend

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -249,12 +249,6 @@ func testWeb() bool {
 		pass = false
 	}
 
-	logger.Info("test:web: npm audit")
-	if err := sh.RunV("npm", "audit"); err != nil {
-		logger.Errorf("npm audit failed: %v", err)
-		pass = false
-	}
-
 	return pass
 }
 


### PR DESCRIPTION
## Background

This PR removes `npm audit` call from `mage test:ci` and adds it as a separate non-required check

## Changes

- Alter `mage test:ci`
- Create separate circleci optional check

## Testing

- CI of this PR
