### PR TITLE
Log processor assumes role retrieved from sources api 

### DIFF
--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -45,6 +45,7 @@ type LambdaInput struct {
 type CheckIntegrationInput struct {
 	AWSAccountID    *string `genericapi:"redact" json:"awsAccountId" validate:"required,len=12,numeric"`
 	IntegrationType *string `json:"integrationType" validate:"required,oneof=aws-scan aws-s3"`
+	IntegrationLabel *string `json:"integrationLabel" validate:"required,integrationLabel"`
 
 	// Checks for cloudsec integrations
 	EnableCWESetup    *bool `json:"enableCWESetup"`

--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -43,8 +43,8 @@ type LambdaInput struct {
 
 // CheckIntegrationInput is used to check the health of a potential configuration.
 type CheckIntegrationInput struct {
-	AWSAccountID    *string `genericapi:"redact" json:"awsAccountId" validate:"required,len=12,numeric"`
-	IntegrationType *string `json:"integrationType" validate:"required,oneof=aws-scan aws-s3"`
+	AWSAccountID     *string `genericapi:"redact" json:"awsAccountId" validate:"required,len=12,numeric"`
+	IntegrationType  *string `json:"integrationType" validate:"required,oneof=aws-scan aws-s3"`
 	IntegrationLabel *string `json:"integrationLabel" validate:"required,integrationLabel"`
 
 	// Checks for cloudsec integrations

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -42,7 +42,7 @@ type SourceIntegrationMetadata struct {
 	S3Prefix           *string    `json:"s3Prefix,omitempty"`
 	KmsKey             *string    `json:"kmsKey,omitempty"`
 	LogTypes           []*string  `json:"logTypes,omitempty"`
-	LogProcessingRole *string `json:"logProcessingRole,omitempty"`
+	LogProcessingRole  *string    `json:"logProcessingRole,omitempty"`
 }
 
 // SourceIntegrationStatus provides context that the full scan works and that events are being received.

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -42,6 +42,7 @@ type SourceIntegrationMetadata struct {
 	S3Prefix           *string    `json:"s3Prefix,omitempty"`
 	KmsKey             *string    `json:"kmsKey,omitempty"`
 	LogTypes           []*string  `json:"logTypes,omitempty"`
+	LogProcessingRole *string `json:"logProcessingRole,omitempty"`
 }
 
 // SourceIntegrationStatus provides context that the full scan works and that events are being received.

--- a/deployments/core/source_api.yml
+++ b/deployments/core/source_api.yml
@@ -134,7 +134,7 @@ Resources:
                 - !Sub arn:${AWS::Partition}:iam::*:role/PantherAuditRole
                 - !Sub arn:${AWS::Partition}:iam::*:role/PantherRemediationRole
                 - !Sub arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole
-                - !Sub arn:${AWS::Partition}:iam::*:role/PantherLogProcessingRole
+                - !Sub arn:${AWS::Partition}:iam::*:role/PantherLogProcessingRole-*
         - Id: GetPublicTemplates
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -173,6 +173,12 @@ Resources:
               Condition:
                 Bool:
                   aws:SecureTransport: true
+        - Id: InvokeSnapshotAPI
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: lambda:InvokeFunction
+              Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-source-api
         - Id: AccessSqsKms
           Version: 2012-10-17
           Statement:

--- a/deployments/log_analysis/log_processor.yml
+++ b/deployments/log_analysis/log_processor.yml
@@ -169,7 +169,7 @@ Resources:
           Statement:
             - Effect: Allow
               Action: sts:AssumeRole
-              Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherLogProcessingRole
+              Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherLogProcessingRole-*
               Condition:
                 Bool:
                   aws:SecureTransport: true

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -35,13 +35,13 @@ import (
 )
 
 const (
-	auditRoleFormat         = "arn:aws:iam::%s:role/PantherAuditRole"
-	cweRoleFormat           = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
-	remediationRoleFormat   = "arn:aws:iam::%s:role/PantherRemediationRole"
+	auditRoleFormat       = "arn:aws:iam::%s:role/PantherAuditRole"
+	cweRoleFormat         = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
+	remediationRoleFormat = "arn:aws:iam::%s:role/PantherRemediationRole"
 )
 
 var (
-	evaluateIntegrationFunc = evaluateIntegration
+	evaluateIntegrationFunc       = evaluateIntegration
 	checkIntegrationInternalError = &genericapi.InternalError{Message: "Failed to validate source. Please try again later"}
 )
 
@@ -53,7 +53,7 @@ func (API) CheckIntegration(input *models.CheckIntegrationInput) (*models.Source
 		IntegrationType: aws.StringValue(input.IntegrationType),
 	}
 
-	switch aws.StringValue(input.IntegrationType)  {
+	switch aws.StringValue(input.IntegrationType) {
 	case models.IntegrationTypeAWSScan:
 		_, out.AuditRoleStatus = getCredentialsWithStatus(fmt.Sprintf(auditRoleFormat, *input.AWSAccountID))
 		if aws.BoolValue(input.EnableCWESetup) {

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -31,16 +31,19 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
 const (
 	auditRoleFormat         = "arn:aws:iam::%s:role/PantherAuditRole"
-	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole"
 	cweRoleFormat           = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
 	remediationRoleFormat   = "arn:aws:iam::%s:role/PantherRemediationRole"
 )
 
-var evaluateIntegrationFunc = evaluateIntegration
+var (
+	evaluateIntegrationFunc = evaluateIntegration
+	checkIntegrationInternalError = &genericapi.InternalError{Message: "Failed to validate source. Please try again later"}
+)
 
 // CheckIntegration adds a set of new integrations in a batch.
 func (API) CheckIntegration(input *models.CheckIntegrationInput) (*models.SourceIntegrationHealth, error) {
@@ -50,21 +53,26 @@ func (API) CheckIntegration(input *models.CheckIntegrationInput) (*models.Source
 		IntegrationType: aws.StringValue(input.IntegrationType),
 	}
 
-	if *input.IntegrationType == models.IntegrationTypeAWSScan {
-		_, out.AuditRoleStatus = getCredentialsWithStatus(aws.String(fmt.Sprintf(auditRoleFormat, *input.AWSAccountID)))
+	switch aws.StringValue(input.IntegrationType)  {
+	case models.IntegrationTypeAWSScan:
+		_, out.AuditRoleStatus = getCredentialsWithStatus(fmt.Sprintf(auditRoleFormat, *input.AWSAccountID))
 		if aws.BoolValue(input.EnableCWESetup) {
-			_, out.CWERoleStatus = getCredentialsWithStatus(aws.String(fmt.Sprintf(cweRoleFormat, *input.AWSAccountID)))
+			_, out.CWERoleStatus = getCredentialsWithStatus(fmt.Sprintf(cweRoleFormat, *input.AWSAccountID))
 		}
 		if aws.BoolValue(input.EnableRemediation) {
-			_, out.RemediationRoleStatus = getCredentialsWithStatus(aws.String(fmt.Sprintf(remediationRoleFormat, *input.AWSAccountID)))
+			_, out.RemediationRoleStatus = getCredentialsWithStatus(fmt.Sprintf(remediationRoleFormat, *input.AWSAccountID))
 		}
-	} else {
+
+	case models.IntegrationTypeAWS3:
 		var roleCreds *credentials.Credentials
-		roleCreds, out.ProcessingRoleStatus = getCredentialsWithStatus(aws.String(fmt.Sprintf(logProcessingRoleFormat, *input.AWSAccountID)))
+		logProcessingRole := generateLogProcessingRoleArn(*input.AWSAccountID, *input.IntegrationLabel)
+		roleCreds, out.ProcessingRoleStatus = getCredentialsWithStatus(logProcessingRole)
 		if aws.BoolValue(out.ProcessingRoleStatus.Healthy) {
 			out.S3BucketStatus = checkBucket(roleCreds, input.S3Bucket)
 			out.KMSKeyStatus = checkKey(roleCreds, input.KmsKey)
 		}
+	default:
+		return nil, checkIntegrationInternalError
 	}
 
 	return out, nil
@@ -115,15 +123,12 @@ func checkBucket(roleCredentials *credentials.Credentials, bucket *string) model
 	}
 }
 
-func getCredentialsWithStatus(
-	roleARN *string,
-) (*credentials.Credentials, models.SourceIntegrationItemStatus) {
-
-	zap.L().Debug("checking role", zap.String("roleArn", *roleARN))
+func getCredentialsWithStatus(roleARN string) (*credentials.Credentials, models.SourceIntegrationItemStatus) {
+	zap.L().Debug("checking role", zap.String("roleArn", roleARN))
 	// Setup new credentials with the role
 	roleCredentials := stscreds.NewCredentials(
 		sess,
-		*roleARN,
+		roleARN,
 	)
 
 	// Use the role to make sure it's good

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -34,12 +34,6 @@ import (
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-const (
-	auditRoleFormat       = "arn:aws:iam::%s:role/PantherAuditRole"
-	cweRoleFormat         = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
-	remediationRoleFormat = "arn:aws:iam::%s:role/PantherRemediationRole"
-)
-
 var (
 	evaluateIntegrationFunc       = evaluateIntegration
 	checkIntegrationInternalError = &genericapi.InternalError{Message: "Failed to validate source. Please try again later"}

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -126,7 +126,7 @@ func getCredentialsWithStatus(roleARN string) (*credentials.Credentials, models.
 	)
 
 	// Use the role to make sure it's good
-	stsClient := sts.New(sess, &aws.Config{Credentials: roleCredentials})
+	stsClient := sts.New(sess, aws.NewConfig().WithCredentials(roleCredentials))
 	_, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		return roleCredentials, models.SourceIntegrationItemStatus{

--- a/internal/core/source_api/api/get_integration_template.go
+++ b/internal/core/source_api/api/get_integration_template.go
@@ -59,6 +59,9 @@ const (
 	s3PrefixReplace = "Value: '%s' # S3Prefix"
 	kmsKeyFind      = "Value: '' # KmsKey"
 	kmsKeyReplace   = "Value: '%s' # KmsKey"
+
+	// The format of log procesing role
+	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole-%s"
 )
 
 var (
@@ -98,7 +101,7 @@ func (API) GetIntegrationTemplate(input *models.GetIntegrationTemplateInput) (*m
 	} else {
 		// Log Analysis replacements
 		formattedTemplate = strings.Replace(formattedTemplate, roleSuffixIDFind,
-			fmt.Sprintf(roleSuffixReplace, generateSuffix(input)), 1)
+			fmt.Sprintf(roleSuffixReplace, generateRoleSuffix(*input.IntegrationLabel)), 1)
 
 		formattedTemplate = strings.Replace(formattedTemplate, s3BucketFind,
 			fmt.Sprintf(s3BucketReplace, *input.S3Bucket), 1)
@@ -160,7 +163,12 @@ func getTemplate(integrationType *string) (string, error) {
 	return templateBodyString, nil
 }
 
-func generateSuffix(input *models.GetIntegrationTemplateInput) string {
-	sanitized := strings.ReplaceAll(*input.IntegrationLabel, " ", "-")
+// Generates the ARN of the log processing role
+func generateLogProcessingRoleArn(awsAccountID string, label string, ) string {
+	return fmt.Sprintf(logProcessingRoleFormat, awsAccountID, generateRoleSuffix(label))
+}
+
+func generateRoleSuffix(label string) string {
+	sanitized := strings.ReplaceAll(label, " ", "-")
 	return strings.ToLower(sanitized)
 }

--- a/internal/core/source_api/api/get_integration_template.go
+++ b/internal/core/source_api/api/get_integration_template.go
@@ -62,9 +62,9 @@ const (
 
 	// The format of log processing role
 	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole-%s"
-	auditRoleFormat       = "arn:aws:iam::%s:role/PantherAuditRole"
-	cweRoleFormat         = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
-	remediationRoleFormat = "arn:aws:iam::%s:role/PantherRemediationRole"
+	auditRoleFormat         = "arn:aws:iam::%s:role/PantherAuditRole"
+	cweRoleFormat           = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
+	remediationRoleFormat   = "arn:aws:iam::%s:role/PantherRemediationRole"
 )
 
 var (

--- a/internal/core/source_api/api/get_integration_template.go
+++ b/internal/core/source_api/api/get_integration_template.go
@@ -164,7 +164,7 @@ func getTemplate(integrationType *string) (string, error) {
 }
 
 // Generates the ARN of the log processing role
-func generateLogProcessingRoleArn(awsAccountID string, label string, ) string {
+func generateLogProcessingRoleArn(awsAccountID string, label string) string {
 	return fmt.Sprintf(logProcessingRoleFormat, awsAccountID, generateRoleSuffix(label))
 }
 

--- a/internal/core/source_api/api/get_integration_template.go
+++ b/internal/core/source_api/api/get_integration_template.go
@@ -60,8 +60,11 @@ const (
 	kmsKeyFind      = "Value: '' # KmsKey"
 	kmsKeyReplace   = "Value: '%s' # KmsKey"
 
-	// The format of log procesing role
+	// The format of log processing role
 	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole-%s"
+	auditRoleFormat       = "arn:aws:iam::%s:role/PantherAuditRole"
+	cweRoleFormat         = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole"
+	remediationRoleFormat = "arn:aws:iam::%s:role/PantherRemediationRole"
 )
 
 var (

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -47,7 +47,7 @@ func (api API) PutIntegration(input *models.PutIntegrationInput) (*models.Source
 	passing, err := evaluateIntegrationFunc(api, &models.CheckIntegrationInput{
 		AWSAccountID:      input.AWSAccountID,
 		IntegrationType:   input.IntegrationType,
-		IntegrationLabel: input.IntegrationLabel,
+		IntegrationLabel:  input.IntegrationLabel,
 		EnableCWESetup:    input.CWEEnabled,
 		EnableRemediation: input.RemediationEnabled,
 		S3Bucket:          input.S3Bucket,
@@ -213,10 +213,10 @@ func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceInt
 		RemediationEnabled: input.RemediationEnabled,
 		ScanIntervalMins:   input.ScanIntervalMins,
 		// For log analysis integrations
-		S3Bucket: input.S3Bucket,
-		S3Prefix: input.S3Prefix,
-		KmsKey:   input.KmsKey,
-		LogTypes: input.LogTypes,
+		S3Bucket:          input.S3Bucket,
+		S3Prefix:          input.S3Prefix,
+		KmsKey:            input.KmsKey,
+		LogTypes:          input.LogTypes,
 		LogProcessingRole: logProcessingRole,
 	}
 }

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -47,6 +47,7 @@ func (api API) PutIntegration(input *models.PutIntegrationInput) (*models.Source
 	passing, err := evaluateIntegrationFunc(api, &models.CheckIntegrationInput{
 		AWSAccountID:      input.AWSAccountID,
 		IntegrationType:   input.IntegrationType,
+		IntegrationLabel: input.IntegrationLabel,
 		EnableCWESetup:    input.CWEEnabled,
 		EnableRemediation: input.RemediationEnabled,
 		S3Bucket:          input.S3Bucket,
@@ -196,6 +197,11 @@ func ScanAllResources(integrations []*models.SourceIntegrationMetadata) error {
 }
 
 func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceIntegrationMetadata {
+	var logProcessingRole *string
+	if *input.IntegrationType == models.IntegrationTypeAWS3 {
+		logProcessingRole = aws.String(generateLogProcessingRoleArn(*input.AWSAccountID, *input.IntegrationLabel))
+	}
+
 	return &models.SourceIntegrationMetadata{
 		AWSAccountID:       input.AWSAccountID,
 		CreatedAtTime:      aws.Time(time.Now()),
@@ -211,5 +217,6 @@ func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceInt
 		S3Prefix: input.S3Prefix,
 		KmsKey:   input.KmsKey,
 		LogTypes: input.LogTypes,
+		LogProcessingRole: logProcessingRole,
 	}
 }

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -43,6 +43,7 @@ func (api API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettings
 		IntegrationType: integration.IntegrationType,
 
 		// From update integration request
+		IntegrationLabel: input.IntegrationLabel,
 		EnableCWESetup:    input.CWEEnabled,
 		EnableRemediation: input.RemediationEnabled,
 		S3Bucket:          input.S3Bucket,

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -43,7 +43,7 @@ func (api API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettings
 		IntegrationType: integration.IntegrationType,
 
 		// From update integration request
-		IntegrationLabel: input.IntegrationLabel,
+		IntegrationLabel:  input.IntegrationLabel,
 		EnableCWESetup:    input.CWEEnabled,
 		EnableRemediation: input.RemediationEnabled,
 		S3Bucket:          input.S3Bucket,

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -122,7 +122,7 @@ func readS3Object(s3Object *S3ObjectInfo, topicArn string) (dataStream *common.D
 			zap.String("key", s3Object.S3ObjectKey))
 	}()
 
-	s3Client, err := getS3Client(s3Object.S3Bucket, topicArn)
+	s3Client, err := getS3Client(s3Object)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to get S3 client for s3://%s/%s",
 			s3Object.S3Bucket, s3Object.S3ObjectKey)

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -103,7 +103,7 @@ func handleNotificationMessage(notification *SnsNotification) (result []*common.
 	}
 	for _, s3Object := range s3Objects {
 		var dataStream *common.DataStream
-		dataStream, err = readS3Object(s3Object, notification.TopicArn)
+		dataStream, err = readS3Object(s3Object)
 		if err != nil {
 			return
 		}
@@ -112,7 +112,7 @@ func handleNotificationMessage(notification *SnsNotification) (result []*common.
 	return result, err
 }
 
-func readS3Object(s3Object *S3ObjectInfo, topicArn string) (dataStream *common.DataStream, err error) {
+func readS3Object(s3Object *S3ObjectInfo) (dataStream *common.DataStream, err error) {
 	operation := common.OpLogManager.Start("readS3Object", common.OpLogS3ServiceDim)
 	defer func() {
 		operation.Stop()

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -89,7 +89,7 @@ func init() {
 }
 
 // getS3Client Fetches S3 client with permissions to read data from the account
-// that owns the SNS Topic
+// that conatins the event
 func getS3Client(s3Object *S3ObjectInfo) (s3iface.S3API, error) {
 	roleArn, err := getRoleArn(s3Object)
 	if err != nil {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -47,7 +47,7 @@ const (
 	sourceCacheDuration = 5 * time.Minute
 
 	s3BucketLocationCacheSize = 1000
-	s3ClientCacheSize = 1000
+	s3ClientCacheSize         = 1000
 )
 
 type s3ClientCacheKey struct {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -44,7 +44,7 @@ const (
 	sessionDurationSeconds = 3600
 	sourceAPIFunctionName  = "panther-source-api"
 	// How frequently to query the sources_api for new integrations
-	sourceCacheDuration = 10 * time.Minute
+	sourceCacheDuration = 5 * time.Minute
 )
 
 type s3ClientCacheKey struct {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -89,7 +89,7 @@ func init() {
 }
 
 // getS3Client Fetches S3 client with permissions to read data from the account
-// that conatins the event
+// that contains the event
 func getS3Client(s3Object *S3ObjectInfo) (s3iface.S3API, error) {
 	roleArn, err := getRoleArn(s3Object)
 	if err != nil {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -45,6 +45,9 @@ const (
 	sourceAPIFunctionName  = "panther-source-api"
 	// How frequently to query the sources_api for new integrations
 	sourceCacheDuration = 5 * time.Minute
+
+	s3BucketLocationCacheSize = 1000
+	s3ClientCacheSize = 1000
 )
 
 type s3ClientCacheKey struct {
@@ -77,12 +80,12 @@ var (
 
 func init() {
 	var err error
-	s3ClientCache, err = lru.NewARC(1000)
+	s3ClientCache, err = lru.NewARC(s3ClientCacheSize)
 	if err != nil {
 		panic("Failed to create client cache")
 	}
 
-	bucketCache, err = lru.NewARC(1000)
+	bucketCache, err = lru.NewARC(s3BucketLocationCacheSize)
 	if err != nil {
 		panic("Failed to create bucket cache")
 	}

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -44,7 +44,7 @@ const (
 	sessionDurationSeconds = 3600
 	sourceAPIFunctionName  = "panther-source-api"
 	// How frequently to query the sources_api for new integrations
-	sourceCacheDuration = 5 * time.Minute
+	sourceCacheDuration = 10 * time.Minute
 )
 
 type s3ClientCacheKey struct {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -1,0 +1,175 @@
+package sources
+
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/pkg/testutils"
+)
+
+var (
+	integration = &models.SourceIntegration{
+		SourceIntegrationMetadata: &models.SourceIntegrationMetadata{
+			AWSAccountID:      aws.String("1234567890123"),
+			S3Bucket:          aws.String("test-bucket"),
+			S3Prefix:          aws.String("prefix"),
+			LogProcessingRole: aws.String("arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix"),
+		},
+	}
+)
+
+func TestGetS3Client(t *testing.T) {
+	// resetting cache
+	sourceCache.cacheUpdateTime = time.Unix(0, 0)
+	lambdaMock := &testutils.LambdaMock{}
+	lambdaClient = lambdaMock
+
+	s3Mock := &testutils.S3Mock{}
+	newS3ClientFunc = func(region *string, creds *credentials.Credentials) (result s3iface.S3API) {
+		return s3Mock
+	}
+
+	marshaledResult, err := jsoniter.Marshal([]*models.SourceIntegration{integration})
+	require.NoError(t, err)
+	lambdaOutput := &lambda.InvokeOutput{
+		Payload: marshaledResult,
+	}
+
+	expectedGetBucketLocationInput := &s3.GetBucketLocationInput{Bucket: aws.String("test-bucket")}
+
+	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
+	s3Mock.On("GetBucketLocation", expectedGetBucketLocationInput).Return(
+		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
+
+	newCredentialsFunc = func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
+
+	s3Object := &S3ObjectInfo{
+		S3Bucket:    "test-bucket",
+		S3ObjectKey: "prefix/key",
+	}
+	result, err := getS3Client(s3Object)
+	require.NoError(t, err)
+	require.Equal(t, s3Mock, result)
+
+	// Subsequent calls should use cache
+	result, err = getS3Client(s3Object)
+	require.NoError(t, err)
+	require.Equal(t, s3Mock, result)
+
+	s3Mock.AssertExpectations(t)
+	lambdaMock.AssertExpectations(t)
+}
+
+func TestGetS3ClientUnknownBucket(t *testing.T) {
+	// resetting cache
+	sourceCache.cacheUpdateTime = time.Unix(0, 0)
+	lambdaMock := &testutils.LambdaMock{}
+	lambdaClient = lambdaMock
+
+	s3Mock := &testutils.S3Mock{}
+	newS3ClientFunc = func(region *string, creds *credentials.Credentials) (result s3iface.S3API) {
+		return s3Mock
+	}
+
+	marshaledResult, err := jsoniter.Marshal([]*models.SourceIntegration{integration})
+	require.NoError(t, err)
+	lambdaOutput := &lambda.InvokeOutput{
+		Payload: marshaledResult,
+	}
+
+	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
+
+	newCredentialsFunc = func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
+
+	s3Object := &S3ObjectInfo{
+		S3Bucket:    "test-bucket-unknown",
+		S3ObjectKey: "prefix/key",
+	}
+
+	result, err := getS3Client(s3Object)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	s3Mock.AssertExpectations(t)
+	lambdaMock.AssertExpectations(t)
+}
+
+func TestGetS3ClientSourceNoPrefix(t *testing.T) {
+	// resetting cache
+	sourceCache.cacheUpdateTime = time.Unix(0, 0)
+	lambdaMock := &testutils.LambdaMock{}
+	lambdaClient = lambdaMock
+
+	s3Mock := &testutils.S3Mock{}
+	newS3ClientFunc = func(region *string, creds *credentials.Credentials) (result s3iface.S3API) {
+		return s3Mock
+	}
+
+	integration = &models.SourceIntegration{
+		SourceIntegrationMetadata: &models.SourceIntegrationMetadata{
+			AWSAccountID:      aws.String("1234567890123"),
+			S3Bucket:          aws.String("test-bucket"),
+			LogProcessingRole: aws.String("arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix"),
+		},
+	}
+
+	marshaledResult, err := jsoniter.Marshal([]*models.SourceIntegration{integration})
+	require.NoError(t, err)
+	lambdaOutput := &lambda.InvokeOutput{
+		Payload: marshaledResult,
+	}
+
+	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
+	s3Mock.On("GetBucketLocation", mock.Anything).Return(
+		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
+
+	newCredentialsFunc = func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
+
+	s3Object := &S3ObjectInfo{
+		S3Bucket:    "test-bucket",
+		S3ObjectKey: "test",
+	}
+
+	result, err := getS3Client(s3Object)
+	require.NoError(t, err)
+	require.Equal(t, s3Mock, result)
+
+	s3Mock.AssertExpectations(t)
+	lambdaMock.AssertExpectations(t)
+}

--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -71,10 +71,6 @@ func TestGetS3Client(t *testing.T) {
 	s3Mock.On("GetBucketLocation", expectedGetBucketLocationInput).Return(
 		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
 
-	newCredentialsFunc = func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-		return &credentials.Credentials{}
-	}
-
 	s3Object := &S3ObjectInfo{
 		S3Bucket:    "test-bucket",
 		S3ObjectKey: "prefix/key",
@@ -111,9 +107,10 @@ func TestGetS3ClientUnknownBucket(t *testing.T) {
 
 	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
 
-	newCredentialsFunc = func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-		return &credentials.Credentials{}
-	}
+	newCredentialsFunc =
+		func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+			return &credentials.Credentials{}
+		}
 
 	s3Object := &S3ObjectInfo{
 		S3Bucket:    "test-bucket-unknown",
@@ -154,12 +151,11 @@ func TestGetS3ClientSourceNoPrefix(t *testing.T) {
 	}
 
 	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
-	s3Mock.On("GetBucketLocation", mock.Anything).Return(
-		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
 
-	newCredentialsFunc = func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-		return &credentials.Credentials{}
-	}
+	newCredentialsFunc =
+		func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+			return &credentials.Credentials{}
+		}
 
 	s3Object := &S3ObjectInfo{
 		S3Bucket:    "test-bucket",

--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -81,12 +81,12 @@ func TestGetS3Client(t *testing.T) {
 	}
 	result, err := getS3Client(s3Object)
 	require.NoError(t, err)
-	require.Equal(t, s3Mock, result)
+	require.NotNil(t, result)
 
 	// Subsequent calls should use cache
 	result, err = getS3Client(s3Object)
 	require.NoError(t, err)
-	require.Equal(t, s3Mock, result)
+	require.NotNil(t, result)
 
 	s3Mock.AssertExpectations(t)
 	lambdaMock.AssertExpectations(t)
@@ -168,7 +168,7 @@ func TestGetS3ClientSourceNoPrefix(t *testing.T) {
 
 	result, err := getS3Client(s3Object)
 	require.NoError(t, err)
-	require.Equal(t, s3Mock, result)
+	require.NotNil(t, result)
 
 	s3Mock.AssertExpectations(t)
 	lambdaMock.AssertExpectations(t)

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -17,6 +17,8 @@ package testutils
  */
 
 import (
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/stretchr/testify/mock"
@@ -30,4 +32,19 @@ type S3Mock struct {
 func (m *S3Mock) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*s3.GetObjectOutput), args.Error(1)
+}
+
+func (m *S3Mock) GetBucketLocation(input *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*s3.GetBucketLocationOutput), args.Error(1)
+}
+
+type LambdaMock struct {
+	lambdaiface.LambdaAPI
+	mock.Mock
+}
+
+func (m *LambdaMock) Invoke(input *lambda.InvokeInput) (*lambda.InvokeOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*lambda.InvokeOutput), args.Error(1)
 }


### PR DESCRIPTION
## Background

The last backend change to support the new onboarding flow. 
In the new flow, we have one CFN stack per log source onboarded. This means we are having one IAM Role per log source. IAM roles have as suffix the integration label (lowercased, with empty spaces replaced with `-`)

This change modifies the log processor so that it assumes the appropriate role for the S3 object it is about to process. 

## Changes

- Sources API now stores the LogProcessing role ARN in the sources DB
- Log processor maintains a cache of log sources. When it receives an S3 Object it checks it if comes from a known S3 bucket+ S3 prefix. If it comes, it assumes the given role and reads data from S3. If it doesn't come from a known s3 bucket, we throw an exception. The message will eventually be retried. This protects us from the case where a log source has been onboarded but the cache in the log processor hasn't been updated with the latest integrations.  
- Added missing unit tests

## Testing

- Unit tests
- Deployed to my account. When I had configured no source the log processor was reporting errors. When the integration was added, log processor started processing events.  

@rleighton  do you mind taking a look at the log processor changes. 
