### PR TITLE
Check swagger and git tags when deploying

### DIFF
--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -109,12 +109,11 @@ Your AWS credentials _must_ be exported as environment variables for the docker 
 
 #### Step 3
 
-Run `mage deploy`
+Run `mage setup:swagger deploy`
 
-- If you've made any changes to the source files or want to run tests, you may need to first install development dependencies with `mage setup:all`
 - If you use `aws-vault`, you must be authenticated with MFA. Otherwise, IAM role creation will fail with `InvalidClientTokenId`
-- The initial deployment will take 20-30 minutes. If your credentials timeout, you can safely redeploy to pick up where you left off.
-- Near the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
+- The initial deployment will take ~10 minutes with a fast internet connection. If your credentials timeout, you can safely redeploy to pick up where you left off.
+- At the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
 - You'll get an email from `no-reply@verificationemail.com` with your temporary password. If you don't see it, be sure to check your spam folder.
 
 #### Log In

--- a/internal/core/users_api/api/cognito_trigger.go
+++ b/internal/core/users_api/api/cognito_trigger.go
@@ -32,7 +32,7 @@ import (
 const passwordResetTemplate = `
 <br />Hi %s,
 <br />
-<br />A password reset has been requested for this email address. If you did not request a password reset, you can ignore this email.
+<br />A password reset has been triggered for this email address.
 <br />
 <br />To set a new password for your Panther account, please click here:
 <br />https://%s/password-reset?token=%s&email=%s

--- a/tools/mage/setup_namespace.go
+++ b/tools/mage/setup_namespace.go
@@ -90,6 +90,17 @@ func (Setup) Python() {
 	}
 }
 
+// Install go-swagger for SDK generation
+func (Setup) Swagger() {
+	env, err := sh.Output("uname")
+	if err != nil {
+		logger.Fatalf("couldn't determine environment: %v", err)
+	}
+	if err = installSwagger(env); err != nil {
+		logger.Fatal(err)
+	}
+}
+
 // Web Npm install
 func (Setup) Web() {
 	if err := sh.RunV("npm", "i"); err != nil {


### PR DESCRIPTION
## Background
A few very small fixes to close some issues

## Changes

- To be safe, Swagger is now required for deployment (relying on timestamps to not run swagger has proved unreliable). Closes: #455 
- `mage deploy` warns you if you're not deploying a tagged release. Closes: #454 
- Reword password reset email - it is required. Closes: #308 

## Testing

- `mage test:go`
