### PR TITLE
Add 'version' to swagger command

### DIFF
--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -171,7 +171,7 @@ func deployPrecheck(awsRegion string) {
 	}
 
 	// Ensure swagger is available
-	if _, err := sh.Output(filepath.Join(setupDirectory, "swagger")); err != nil {
+	if _, err := sh.Output(filepath.Join(setupDirectory, "swagger"), "version"); err != nil {
 		logger.Fatalf("swagger is not available (%v): try 'mage setup:swagger'", err)
 	}
 


### PR DESCRIPTION
## Background
#472 actually doesn't work because you need to run `swagger version` , not just `swagger`. I had the fix locally but forgot to push it before merging!

## Testing

- `mage deploy` worked
