### PR TITLE
Improving stability when running rules

### DIFF
--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -1,19 +1,3 @@
-# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
-# Copyright (C) 2020 Panther Labs Inc
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import os
 import sys
 import tempfile

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -126,7 +126,7 @@ class Rule:
         try:
             dedup_string = _run_command(self._module.dedup, event, str)
         except Exception as err:  # pylint: disable=broad-except
-            self.logger.warning('dedup_string method raised exception. Defaulting to rule ID. Exception: %s', err)
+            self.logger.warning('dedup method raised exception. Defaulting dedup string to "%s". Exception: %s', self.rule_id, err)
             return self.rule_id
 
         if dedup_string:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -95,7 +95,7 @@ class Rule:
         if not hasattr(self._module, 'rule'):
             raise AssertionError("rule needs to have a method named 'rule'")
 
-        if hasattr(self._module, 'dedup_string'):
+        if hasattr(self._module, 'dedup'):
             self._has_dedup = True
         else:
             self._has_dedup = False
@@ -124,9 +124,9 @@ class Rule:
             # If no dedup function defined, return rule id
             return self.rule_id
         try:
-            dedup_string = _run_command(self._module.dedup_string, event, str)
-        except Exception as err:
-            self.logger.warning('dedup_string method raised exception. Defaulting to rule ID', err)
+            dedup_string = _run_command(self._module.dedup, event, str)
+        except Exception as err:  # pylint: disable=broad-except
+            self.logger.warning('dedup_string method raised exception. Defaulting to rule ID. Exception: %s', err)
             return self.rule_id
 
         if dedup_string:
@@ -147,8 +147,8 @@ class Rule:
             return None
         try:
             title_string = _run_command(self._module.title, event, str)
-        except Exception as err:
-            self.logger.warning('title method raised exception. Using default', err)
+        except Exception as err:  # pylint: disable=broad-except
+            self.logger.warning('title method raised exception. Using default. Exception: %s', err)
             return None
 
         if title_string:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -1,3 +1,19 @@
+# Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import os
 import sys
 import tempfile

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -84,13 +84,13 @@ class TestRule(TestCase):
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_with_dedup(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn "testdedup"'
         rule = Rule({'id': 'test_rule_with_dedup', 'body': rule_body, 'severity': 'INFO'})
         expected_rule = RuleResult(matched=True, dedup_string='testdedup')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_dedup_size(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'.\
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn "".join("a" for i in range({}))'.\
             format(MAX_DEDUP_STRING_SIZE+1)
         rule = Rule({'id': 'test_restrict_dedup_size', 'body': rule_body, 'severity': 'INFO'})
 
@@ -110,7 +110,7 @@ class TestRule(TestCase):
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_empty_dedup_result_to_default(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn ""'
         rule = Rule({'id': 'test_empty_dedup_result_to_default', 'body': rule_body, 'severity': 'INFO'})
 
         expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
@@ -133,23 +133,21 @@ class TestRule(TestCase):
         self.assertIsNotNone(rule_result.exception)
 
     def test_dedup_throws_exception(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\traise Exception("test")'
         rule = Rule({'id': 'test_dedup_throws_exception', 'body': rule_body, 'severity': 'INFO'})
-        rule_result = rule.run({})
-        self.assertIsNone(rule_result.matched)
-        self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNotNone(rule_result.exception)
+
+        expected_rule = RuleResult(matched=True, dedup_string='test_dedup_throws_exception')
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_invalid_dedup_return(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn {}'
         rule = Rule({'id': 'test_rule_invalid_dedup_return', 'body': rule_body, 'severity': 'INFO'})
-        rule_result = rule.run({})
-        self.assertIsNone(rule_result.matched)
-        self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNotNone(rule_result.exception)
+
+        expected_rule = RuleResult(matched=True, dedup_string='test_rule_invalid_dedup_return')
+        self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_dedup_returns_empty_string(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_dedup_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
         expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')
@@ -166,21 +164,15 @@ class TestRule(TestCase):
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
         rule = Rule({'id': 'test_rule_title_throws_exception', 'body': rule_body, 'severity': 'INFO'})
 
-        rule_result = rule.run({})
-        self.assertIsNone(rule_result.matched)
-        self.assertIsNone(rule_result.title)
-        self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNotNone(rule_result.exception)
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_throws_exception')
+        self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_invalid_title_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
         rule = Rule({'id': 'test_rule_invalid_title_return', 'body': rule_body, 'severity': 'INFO'})
 
-        rule_result = rule.run({})
-        self.assertIsNone(rule_result.matched)
-        self.assertIsNone(rule_result.title)
-        self.assertIsNone(rule_result.dedup_string)
-        self.assertIsNotNone(rule_result.exception)
+        expected_result = RuleResult(matched=True, dedup_string='test_rule_invalid_title_return')
+        self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -84,13 +84,13 @@ class TestRule(TestCase):
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_with_dedup(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn "testdedup"'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
         rule = Rule({'id': 'test_rule_with_dedup', 'body': rule_body, 'severity': 'INFO'})
         expected_rule = RuleResult(matched=True, dedup_string='testdedup')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_dedup_size(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn "".join("a" for i in range({}))'.\
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'.\
             format(MAX_DEDUP_STRING_SIZE+1)
         rule = Rule({'id': 'test_restrict_dedup_size', 'body': rule_body, 'severity': 'INFO'})
 
@@ -110,7 +110,7 @@ class TestRule(TestCase):
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_empty_dedup_result_to_default(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn ""'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
         rule = Rule({'id': 'test_empty_dedup_result_to_default', 'body': rule_body, 'severity': 'INFO'})
 
         expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
@@ -133,21 +133,21 @@ class TestRule(TestCase):
         self.assertIsNotNone(rule_result.exception)
 
     def test_dedup_throws_exception(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\traise Exception("test")'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
         rule = Rule({'id': 'test_dedup_throws_exception', 'body': rule_body, 'severity': 'INFO'})
 
         expected_rule = RuleResult(matched=True, dedup_string='test_dedup_throws_exception')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_invalid_dedup_return(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn {}'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
         rule = Rule({'id': 'test_rule_invalid_dedup_return', 'body': rule_body, 'severity': 'INFO'})
 
         expected_rule = RuleResult(matched=True, dedup_string='test_rule_invalid_dedup_return')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_dedup_returns_empty_string(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup_string(event):\n\treturn ""'
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_dedup_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
         expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')


### PR DESCRIPTION
## Background

Fixes #460 
In case title or dedup functions throw exception, we use default values instead of dropping event. 
This is meant to improve system stability and to make sure that no crucial events will be ignored. 

## Changes

- Switching to use default values for alert title and dedup string in case the dedup function or title function throw exception

## Testing

- Unit testing. 
