### PR TITLE
Generating and storing CFN stack name

### DIFF
--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -43,7 +43,7 @@ type SourceIntegrationMetadata struct {
 	KmsKey             *string    `json:"kmsKey,omitempty"`
 	LogTypes           []*string  `json:"logTypes,omitempty"`
 	LogProcessingRole  *string    `json:"logProcessingRole,omitempty"`
-	CfnStackName       *string    `json:"cfnStackname,omitempty"`
+	StackName          *string    `json:"stackname,omitempty"`
 }
 
 // SourceIntegrationStatus provides context that the full scan works and that events are being received.

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -43,7 +43,7 @@ type SourceIntegrationMetadata struct {
 	KmsKey             *string    `json:"kmsKey,omitempty"`
 	LogTypes           []*string  `json:"logTypes,omitempty"`
 	LogProcessingRole  *string    `json:"logProcessingRole,omitempty"`
-	StackName          *string    `json:"stackname,omitempty"`
+	StackName          *string    `json:"stackName,omitempty"`
 }
 
 // SourceIntegrationStatus provides context that the full scan works and that events are being received.

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -43,6 +43,7 @@ type SourceIntegrationMetadata struct {
 	KmsKey             *string    `json:"kmsKey,omitempty"`
 	LogTypes           []*string  `json:"logTypes,omitempty"`
 	LogProcessingRole  *string    `json:"logProcessingRole,omitempty"`
+	CfnStackName       *string    `json:"cfnStackname,omitempty"`
 }
 
 // SourceIntegrationStatus provides context that the full scan works and that events are being received.
@@ -79,5 +80,6 @@ type SourceIntegrationItemStatus struct {
 }
 
 type SourceIntegrationTemplate struct {
-	Body *string `json:"body"`
+	Body      *string `json:"body"`
+	StackName *string `json:"stackName"`
 }

--- a/internal/core/source_api/api/get_integration_template_test.go
+++ b/internal/core/source_api/api/get_integration_template_test.go
@@ -52,6 +52,7 @@ func TestCloudSecTemplate(t *testing.T) {
 	expectedTemplate, err := ioutil.ReadFile("./testdata/panther-cloudsec-iam-updated.yml")
 	require.NoError(t, err)
 	require.YAMLEq(t, string(expectedTemplate), *result.Body)
+	require.Equal(t, "panther-cloudsec-setup", *result.StackName)
 }
 
 func TestLogAnalysisTemplate(t *testing.T) {
@@ -75,4 +76,5 @@ func TestLogAnalysisTemplate(t *testing.T) {
 	expectedTemplate, err := ioutil.ReadFile("./testdata/panther-log-analysis-iam-updated.yml")
 	require.NoError(t, err)
 	require.YAMLEq(t, string(expectedTemplate), *result.Body)
+	require.Equal(t, "panther-log-analysis-setup-testlabel-", *result.StackName)
 }

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -223,5 +223,6 @@ func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceInt
 		KmsKey:            input.KmsKey,
 		LogTypes:          input.LogTypes,
 		LogProcessingRole: logProcessingRole,
+		CfnStackName:      aws.String(getStackName(*input.IntegrationType, *input.IntegrationLabel)),
 	}
 }

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -223,6 +223,6 @@ func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceInt
 		KmsKey:            input.KmsKey,
 		LogTypes:          input.LogTypes,
 		LogProcessingRole: logProcessingRole,
-		CfnStackName:      aws.String(getStackName(*input.IntegrationType, *input.IntegrationLabel)),
+		StackName:         aws.String(getStackName(*input.IntegrationType, *input.IntegrationLabel)),
 	}
 }


### PR DESCRIPTION
## Background

The frontend is currently generating the CFN stack name for an integration when a user clicks the "Launch Stack" button. This stack name is used subsequently in order to provided guidance to the users when they need to edit/update their sources. 
The problem is, the frontend was currently generating the stack name using the IntegrationLabel. If a user however updates the label of an integration, then the instructions provided by the frontend will be wrong since they will be using the *current* label, not the label with which the source was created. 

After discussion with @3nvi  we decided to move the stack-name generate mechanism to the backend and make sure the backend keeps the CFN stack name that will be used when instructing users to update their templates. 

## Changes

- Sources_api now generating the CFN stack name
- Sources_api now returning CFN stack name in the "getTemplate" method

## Testing

- Unit tests. 
- Deployed and verified it works in my account. 
