### PR TITLE
Add all-contributors spec

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,5 @@
+{
+  "files": [
+    "README.md"
+  ]
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,3 +11,9 @@ Prior to contributing code, you will be required to sign our [Contributor Licens
 1. Test your change locally and also (for larger changes) in a live Panther deployment
 1. Ensure no new build artifacts, personal information, or credentials are included in the request
 1. Submit a PR, providing sufficient context for the reviewers to understand your change
+
+## All Contributors
+
+If you have contributed to the repo and you can't see yourself in our [Contributors section](https://github.com/panther-labs/panther#contributors), please
+follow [the instructions](https://allcontributors.org/docs/en/bot/usage) to manually add yourself to
+it.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,4 +16,4 @@ Prior to contributing code, you will be required to sign our [Contributor Licens
 
 If you have contributed to the repo and you can't see yourself in our [Contributors section](https://github.com/panther-labs/panther#contributors), please
 follow [the instructions](https://allcontributors.org/docs/en/bot/usage) to manually add yourself to
-it.
+it. The available contribution types can be found [here](https://allcontributors.org/docs/en/emoji-key).


### PR DESCRIPTION
## Background

Add an easy way to manage people that have contributed to the platform

## Changes

- Update `CONTRIBUTING.MD`
- Add `.all-contributorsrc`

## Testing

N/A
