### PR TITLE
Returning original error

### DIFF
--- a/tools/mage/util_cfn.go
+++ b/tools/mage/util_cfn.go
@@ -42,7 +42,7 @@ func getStackOutputs(awsSession *session.Session, name string) (map[string]strin
 	input := &cfn.DescribeStacksInput{StackName: &name}
 	response, err := cfnClient.DescribeStacks(input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to describe stack %s: %v", name, err)
+		return nil, err
 	}
 
 	return flattenStackOutputs(response), nil


### PR DESCRIPTION
## Background

Deploying on a clean account was not succeeding. 

## Changes

- Mage uses a utility method to identify if the error returned when describing a stack is that a stack doesn't exist. The utility method is here: https://github.com/panther-labs/panther/blob/master/tools/mage/util_cfn.go#L131-L138

Updated code to return original exception

## Testing

- Was able to deploy
