### PR TITLE
Changing default dedup string value

### DIFF
--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -122,7 +122,7 @@ class Rule:
     def _get_dedup(self, event: Dict[str, Any]) -> str:
         if not self._has_dedup:
             # If no dedup function defined, return rule id
-            return self.rule_id
+            return 'defaultDedupString:' + self.rule_id
         try:
             dedup_string = _run_command(self._module.dedup, event, str)
         except Exception as err:  # pylint: disable=broad-except
@@ -140,7 +140,7 @@ class Rule:
                 return dedup_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
             return dedup_string
         # If dedup string was the empty string, put the default value (rule_id)
-        return self.rule_id
+        return 'defaultDedupString:' + self.rule_id
 
     def _get_title(self, event: Dict[str, Any]) -> Optional[str]:
         if not self._has_title:

--- a/internal/log_analysis/rules_engine/tests/test_engine.py
+++ b/internal/log_analysis/rules_engine/tests/test_engine.py
@@ -90,7 +90,7 @@ class TestEngine(TestCase):
                 rule_version='version',
                 log_type='log',
                 severity='INFO',
-                dedup='rule_id_1',
+                dedup='defaultDedupString:rule_id_1',
                 dedup_period_mins=120,
                 event={}
             )
@@ -129,7 +129,7 @@ class TestEngine(TestCase):
                 rule_version='version',
                 log_type='log',
                 severity='INFO',
-                dedup='rule_id_1',
+                dedup='defaultDedupString:rule_id_1',
                 event={},
                 dedup_period_mins=60
             ),
@@ -138,7 +138,7 @@ class TestEngine(TestCase):
                 rule_version='version',
                 log_type='log',
                 severity='INFO',
-                dedup='rule_id_3',
+                dedup='defaultDedupString:rule_id_3',
                 event={},
                 dedup_period_mins=60
             )

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -74,7 +74,7 @@ class TestRule(TestCase):
         self.assertEqual('INFO', rule.rule_severity)
         self.assertEqual(100, rule.rule_dedup_period_mins)
 
-        expected_rule = RuleResult(matched=True, dedup_string='test_rule_matches')
+        expected_rule = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_matches')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_doesnt_match(self) -> None:
@@ -105,7 +105,9 @@ class TestRule(TestCase):
 
         expected_title_string_prefix = ''.join('a' for _ in range(MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)))
         expected_rule = RuleResult(
-            matched=True, dedup_string='test_restrict_title_size', title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX
+            matched=True,
+            dedup_string='defaultDedupString:test_restrict_title_size',
+            title=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX
         )
         self.assertEqual(expected_rule, rule.run({}))
 
@@ -113,7 +115,7 @@ class TestRule(TestCase):
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
         rule = Rule({'id': 'test_empty_dedup_result_to_default', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_rule = RuleResult(matched=True, dedup_string='test_empty_dedup_result_to_default')
+        expected_rule = RuleResult(matched=True, dedup_string='defaultDedupString:test_empty_dedup_result_to_default')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_throws_exception(self) -> None:
@@ -150,33 +152,33 @@ class TestRule(TestCase):
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_dedup_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_dedup_returns_empty_string')
+        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_dedup_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_matches_with_title(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
         rule = Rule({'id': 'test_rule_matches_with_title', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_matches_with_title', title='title')
+        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_matches_with_title', title='title')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_throws_exception(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
         rule = Rule({'id': 'test_rule_title_throws_exception', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_throws_exception')
+        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_title_throws_exception')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_invalid_title_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
         rule = Rule({'id': 'test_rule_invalid_title_return', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_invalid_title_return')
+        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_invalid_title_return')
         self.assertEqual(rule.run({}), expected_result)
 
     def test_rule_title_returns_empty_string(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_title_returns_empty_string', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_result = RuleResult(matched=True, dedup_string='test_rule_title_returns_empty_string')
+        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_title_returns_empty_string')
         self.assertEqual(rule.run({}), expected_result)


### PR DESCRIPTION
## Background

Currently the default dedup string value is the rule id, which even though is a good way to distinguish, it can be confusing to people when looking the alerts through the UI (and seeing the dedup string having same value as rule id). 

 
## Changes

- Updating default dedup string to have different value: `defaultDedupString:` + rule ID

## Testing

- unit testing
