### PR TITLE
Marking dedup period as required

### DIFF
--- a/api/gateway/analysis/api.yml
+++ b/api/gateway/analysis/api.yml
@@ -1034,6 +1034,7 @@ definitions:
       - tags
       - tests
       - versionId
+      - dedupPeriodMinutes
 
   UpdateRule:
     type: object

--- a/api/gateway/analysis/models/rule.go
+++ b/api/gateway/analysis/models/rule.go
@@ -48,7 +48,8 @@ type Rule struct {
 	CreatedBy UserID `json:"createdBy"`
 
 	// dedup period minutes
-	DedupPeriodMinutes DedupPeriodMinutes `json:"dedupPeriodMinutes,omitempty"`
+	// Required: true
+	DedupPeriodMinutes DedupPeriodMinutes `json:"dedupPeriodMinutes"`
 
 	// description
 	// Required: true
@@ -219,10 +220,6 @@ func (m *Rule) validateCreatedBy(formats strfmt.Registry) error {
 }
 
 func (m *Rule) validateDedupPeriodMinutes(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.DedupPeriodMinutes) { // not required
-		return nil
-	}
 
 	if err := m.DedupPeriodMinutes.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {


### PR DESCRIPTION
## Background

Marking dedup period as required. See discussion: https://github.com/panther-labs/panther/pull/533#discussion_r396813968

## Changes

- Marking dedup period as required. 
Dedup period was already being populated to default value [here](https://github.com/panther-labs/panther/blob/6d3f3887be8c4b9f704986d81d06190df0dcfe7d/internal/core/analysis_api/handlers/bulk_upload.go#L216-L223) and [here](https://github.com/panther-labs/panther/blob/afc9e3f4ced443341b46f8a9f5bbb981924c20bb/internal/core/analysis_api/handlers/create_rule.go#L76-L79). 

## Testing

- `mage test:ci`
- Deployed and was able to list pre-existing rules, edit rule ,update rule, create rule. 
- Verified that I was able to upload rules through analysis tool
```
(venv) kostas@jaguar projects $ pather_analysis_tool upload --path panther-labs/panther-analysis/osquery_rules
[INFO]: Testing analysis packs in panther-labs/panther-analysis/osquery_rules

OSquery.Mac.ALFDisabled
        [PASS] ALF Disabled
        [PASS] ALF Enabled

OSquery.Mac.OSXAttacks
        [PASS] App running on Desktop that is watching keyboard events
        [PASS] App is running from approved path

[INFO]: Zipping analysis packs in panther-labs/panther-analysis/osquery_rules to .
[INFO]: Found credentials in environment variables.
[INFO]: Uploading pack to Panther
[INFO]: Upload success.
[INFO]: API Response:
{
  "modifiedPolicies": 0,
  "modifiedRules": 2,
  "newPolicies": 0,
  "newRules": 0,
  "totalPolicies": 0,
  "totalRules": 2
}

```
