### PR TITLE
Pinning template to specific version

### DIFF
--- a/tools/mage/deploy_onboard.go
+++ b/tools/mage/deploy_onboard.go
@@ -38,7 +38,7 @@ const (
 	logProcessingLabel = "panther-account" // this must be lowercase, no spaces to work correctly, see genLogProcessingLabel()
 
 	// CloudSec IAM Roles, DO NOT CHANGE! panther-cloudsec-iam.yml CF depends on these names
-	realTimeEventStackSetURL             = "https://s3-us-west-2.amazonaws.com/panther-public-cloudformation-templates/panther-cloudwatch-events/latest/template.yml" // nolint:lll
+	realTimeEventStackSetURL             = "https://s3-us-west-2.amazonaws.com/panther-public-cloudformation-templates/panther-cloudwatch-events/v0.1.8/template.yml" // nolint:lll
 	realTimeEventsStackSet               = "panther-real-time-events"
 	realTimeEventsExecutionRoleName      = "PantherCloudFormationStackSetExecutionRole"
 	realTimeEventsAdministrationRoleName = "PantherCloudFormationStackSetAdminRole"


### PR DESCRIPTION
## Background

Pinning real-time events template to specific version. This is needed since in case the template is updated, users running older versions of the software might fail to deploy since latest template might be incompatible

## Changes

- I've set the version to the latest one in the S3 bucket. 

## Testing

- Deployed. Seen stackset deployed. 
