### PR TITLE
Whitelist StartSchemaCreation in aws event processor

### DIFF
--- a/internal/compliance/aws_event_processor/processor/process.go
+++ b/internal/compliance/aws_event_processor/processor/process.go
@@ -70,6 +70,9 @@ var (
 		"ExportCertificate":     {},
 		"ResendValidationEmail": {},
 
+		// appsync
+		"StartSchemaCreation": {},
+
 		// cloudformation
 		"DeleteChangeSet":          {},
 		"DetectStackDrift":         {},


### PR DESCRIPTION
## Changes
- add appsync StartSchemaCreation to whitelist (sets off alarms during deployments)

## Testing
mage test:ci
