### PR TITLE
Fix swagger/build race, add v1 tags to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 </p>
 
 <p align="center">
-  <i>Panther is currently in beta</i>
-</p>
-
-<p align="center">
   <a href="https://docs.runpanther.io">Documentation</a> |
   <a href="https://docs.runpanther.io/quick-start">Quick Start</a> |
   <a href="https://blog.runpanther.io">Blog</a> |

--- a/docs/gitbook/development.md
+++ b/docs/gitbook/development.md
@@ -90,7 +90,7 @@ To update your deployment of Panther, follow the steps below:
 
 1. Checkout the latest release:
    1. `git fetch origin master`
-   2. `git checkout tags/v0.3.0`
+   2. `git checkout tags/v1.0.0`
 2. Clean the existing build artifacts: `mage clean`
 3. Deploy the latest application changes: `mage deploy`
 

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -29,7 +29,7 @@ Get started with 3 quick steps!
 Clone the latest release of [Panther](https://github.com/panther-labs/panther):
 
 ```bash
-git clone https://github.com/panther-labs/panther --depth 1 --branch v0.3.0
+git clone https://github.com/panther-labs/panther --depth 1 --branch v1.0.0
 cd panther
 ```
 


### PR DESCRIPTION
## Background

If Swagger needs to be built, sometimes there will be a race condition on a fresh deploy:

```
08:07:46        INFO    build:api: generating Go SDK for 4 APIs (api/gateway/*/api.yml)
08:07:46        FATAL   failed to read deployments/bootstrap.yml: open deployments/bootstrap.yml: no such file or directory
```

This happens because `build:api` (swagger) has to change the working directory (due to a bug in swagger). If the bootstrap stack is trying to deploy while the directory is different, it will fail.

The fix is to build swagger apis before starting the bootstrap goroutine

Closes: #492 

## Changes

- Update v1 in documentation
- Build swagger before starting bootstrap goroutine
    - Technically, `build:api` now happens twice, since `build:lambda` also calls it, but the second time no changes will need to be made so it will return immediately (without changing directories)

## Testing

- `touch api/gateway/*/api.yml`
- `mage -v deploy`

No error in the deploy, first swagger build happens by itself, second swagger build shows no changes
