### PR TITLE
Fix remediation role construction

### DIFF
--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -701,7 +701,6 @@ Resources:
       Environment:
         Variables:
           LOGGING_LEVEL: !If [DebugEnabled, DEBUG, INFO]
-          ROLE_FORMAT: !Sub arn:${AWS::Partition}:iam::{}:role/PantherRemediationRole-${AWS::Region}
       Layers: !If
         - AttachLayers
         - !Split # CFN doesn't have list append, so convert to/from CSV string to prepend base layers

--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -701,6 +701,7 @@ Resources:
       Environment:
         Variables:
           LOGGING_LEVEL: !If [DebugEnabled, DEBUG, INFO]
+          ROLE_FORMAT: !Sub arn:${AWS::Partition}:iam::{}:role/PantherRemediationRole-${AWS::Region}
       Layers: !If
         - AttachLayers
         - !Split # CFN doesn't have list append, so convert to/from CSV string to prepend base layers

--- a/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
@@ -16,7 +16,6 @@
 
 from abc import abstractmethod
 from functools import lru_cache
-import os
 from typing import Any, Dict
 
 import boto3

--- a/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
@@ -16,6 +16,7 @@
 
 from abc import abstractmethod
 from functools import lru_cache
+import os
 from typing import Any, Dict
 
 import boto3
@@ -29,6 +30,7 @@ from ..common.exceptions import RemediationException, RemediationNotAuthorized
 
 _STS_CLIENT_MAP: Dict[str, BaseClient] = {}
 _DEFAULT_STS_REGION = 'us-east-1'
+_ROLE_FORMAT = os.getenv('ROLE_FORMAT')
 
 
 class RemediationBase:
@@ -128,7 +130,7 @@ class RemediationBase:
             """Refresh credentials by invoking STS AssumeRole operation"""
             cls.logger.info("Refreshing credentials for account %s and region %s", account_id, region)
             params = {
-                'RoleArn': 'arn:aws:iam::{}:role/PantherRemediationRole'.format(account_id),
+                'RoleArn': _ROLE_FORMAT.format(account_id),
                 'RoleSessionName': 'RemediationSession',
                 'DurationSeconds': 3600,
             }

--- a/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
@@ -30,7 +30,6 @@ from ..common.exceptions import RemediationException, RemediationNotAuthorized
 
 _STS_CLIENT_MAP: Dict[str, BaseClient] = {}
 _DEFAULT_STS_REGION = 'us-east-1'
-_ROLE_FORMAT = os.getenv('ROLE_FORMAT')
 
 
 class RemediationBase:
@@ -130,7 +129,7 @@ class RemediationBase:
             """Refresh credentials by invoking STS AssumeRole operation"""
             cls.logger.info("Refreshing credentials for account %s and region %s", account_id, region)
             params = {
-                'RoleArn': _ROLE_FORMAT.format(account_id),
+                'RoleArn': 'arn:aws:iam::{}:role/PantherRemediationRole-{}'.format(account_id, region),
                 'RoleSessionName': 'RemediationSession',
                 'DurationSeconds': 3600,
             }


### PR DESCRIPTION
## Background

Remediation role ARN construction was not updated after changing to regionally suffixed roles.

## Changes

- Change role generation to take suffix into account

## Testing

- Deployed internally and observed remediations work
