### PR TITLE
Fix deployment role

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -55,6 +55,7 @@ Resources:
               - apigateway:*
               - appsync:*
               - athena:*
+              - cloudformation:Describe*
               - cloudformation:List*
               - cloudwatch:*
               - cognito-idp:*
@@ -63,6 +64,8 @@ Resources:
               - ecs:*
               - events:*
               - glue:*
+              - guardduty:CreatePublishingDestination
+              - guardduty:ListDetectors
               - kms:CreateKey
               - kms:List*
               - lambda:*EventSourceMapping
@@ -75,6 +78,7 @@ Resources:
             Action: cloudformation:*
             Resource:
               - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/panther-*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stackset/panther-*
               - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
           - Effect: Allow
             Action: dynamodb:*
@@ -87,6 +91,7 @@ Resources:
               - ec2:AuthorizeSecurityGroupEgress
               - ec2:AuthorizeSecurityGroupIngress
               - ec2:AttachInternetGateway
+              - ec2:CreateFlowLogs
               - ec2:CreateInternetGateway
               - ec2:CreateRoute
               - ec2:CreateRouteTable
@@ -94,6 +99,7 @@ Resources:
               - ec2:CreateSubnet
               - ec2:CreateTags
               - ec2:CreateVpc
+              - ec2:DeleteFlowLogs
               - ec2:DeleteInternetGateway
               - ec2:DeleteRoute
               - ec2:DeleteRouteTable
@@ -123,7 +129,10 @@ Resources:
             Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action: iam:*
-            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/panther-*
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/panther-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/Panther*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:server-certificate/panther/*"
           - Effect: Allow
             Action: kms:*
             Resource:

--- a/deployments/auxiliary/terraform/panther-deployment-role.tf
+++ b/deployments/auxiliary/terraform/panther-deployment-role.tf
@@ -58,6 +58,7 @@ resource "aws_iam_policy" "deployment" {
         "apigateway:*",
         "appsync:*",
         "athena:*",
+        "cloudformation:Describe*",
         "cloudformation:List*",
         "cloudwatch:*",
         "cognito-idp:*",
@@ -66,6 +67,8 @@ resource "aws_iam_policy" "deployment" {
         "ecs:*",
         "events:*",
         "glue:*",
+        "guardduty:CreatePublishingDestination",
+        "guardduty:ListDetectors",
         "kms:CreateKey",
         "kms:List*",
         "lambda:*EventSourceMapping",
@@ -81,6 +84,7 @@ resource "aws_iam_policy" "deployment" {
       "Action": "cloudformation:*",
       "Resource": [
         "arn:${var.aws_partition}:cloudformation:${var.aws_region}:${var.aws_account_id}:stack/panther-*",
+        "arn:${var.aws_partition}:cloudformation:${var.aws_region}:${var.aws_account_id}:stackset/panther-*",
         "arn:${var.aws_partition}:cloudformation:${var.aws_region}:aws:transform/Serverless-2016-10-31"
       ],
       "Effect": "Allow"
@@ -99,12 +103,14 @@ resource "aws_iam_policy" "deployment" {
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:AttachInternetGateway",
         "ec2:CreateInternetGateway",
+        "ec2:CreateFlowLogs",
         "ec2:CreateRoute",
         "ec2:CreateRouteTable",
         "ec2:CreateSecurityGroup",
         "ec2:CreateSubnet",
         "ec2:CreateTags",
         "ec2:CreateVpc",
+        "ec2:DeleteFlowLogs",
         "ec2:DeleteInternetGateway",
         "ec2:DeleteRoute",
         "ec2:DeleteRouteTable",
@@ -141,7 +147,11 @@ resource "aws_iam_policy" "deployment" {
     },
     {
       "Action": "iam:*",
-      "Resource": "arn:${var.aws_partition}:iam::${var.aws_account_id}:role/panther-*",
+      "Resource": [
+        "arn:${var.aws_partition}:iam::${var.aws_account_id}:role/panther-*",
+        "arn:${var.aws_partition}:iam::${var.aws_account_id}:role/Panther*",
+        "arn:${var.aws_partition}:iam::${var.aws_account_id}:server-certificate/panther/*",
+      ],
       "Effect": "Allow"
     },
     {

--- a/docs/gitbook/troubleshooting.md
+++ b/docs/gitbook/troubleshooting.md
@@ -6,20 +6,14 @@ This section acts as a quick Q&A on issues that you may face during your Panther
 
 Don't worry. You can safely re-deploy Panther by running `mage deploy` and it will pick up where it left off.
 
-Alternatively, if you 're using temporary credentials, please add a longer timeout.
-
-## Deployment Failed
-
-`open deployments/bootstrap.yml: no such file or directory`
-
-This is an issue with Docker and the way volumes work.
-
-To resolve that, please step close the container (Ctrl+D on Mac) and reconnect to it by typing `./dev.sh` so that the container can pick up all the necessary files.
-
-Running `mage deploy` should resolve the issue.
+Alternatively, if you're using temporary credentials, please add a longer timeout.
 
 ## Mistyped Email During `mage deploy`
 
-Don't worry, these things happen!
+Don't worry, these things happen! From the AWS console in the deployed region:
 
-Simply go to Cognito and create a new user by specifying all the necessary fields.
+1. Go to Cognito => Manage User Pools
+2. Click on the incorrect user
+3. Disable then delete the user
+
+Then just run `mage deploy` to setup the first user again.


### PR DESCRIPTION
## Background

We haven't updated the deployment role in awhile, and there are some new resources involved in deploy and teardown that we need to add permissions for.

## Changes

- Add support for GuardDuty, CloudFormation stack sets, VPC flow logs, and IAM server certificates in the deployment role
- Troubleshooting documentation
    - The error mentioned in the deploy process was actually fixed by #556 
    - I mistyped an email in the deploy process, adding some clarification for how to remove the user from Cognito. They can re-add the user in Cognito, as originally suggested, but that won't add custom attributes (name), and in enterprise it won't work at all (they need a role). So it's easier to just people to redeploy in this case, it only takes about a minute now.

## Testing

- Deploy and teardown using the deployment policy
