### PR TITLE
Fixing stability issues

### DIFF
--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -47,19 +47,6 @@ Infra:
   PythonLayerVersionArn: ''
 
 Monitoring:
-  # Enable S3 access logs for Panther buckets.
-  # Doing so is a strongly recommend security practice, but can come at a high cost
-  # when processing large volumes of data.
-  #
-  # Access logs are sent either to the S3AccessLogsBucket below or a the panther audit bucket created for you.
-  EnableS3AccessLogs: true
-
-  # Optionally use an existing S3 bucket for storing S3 access logs.
-  # If not specified, the generated panther audit logs bucket is used for access logs as well.
-  #
-  # Has no effect if EnableS3AccessLogs=false above.
-  S3AccessLogsBucket: ''
-
   # This is the arn for the SNS topic you want associated with Panther system alarms.
   # If this is not set alarms will be associated with the SNS topic `panther-alarms`.
   AlarmSnsTopicArn: ''
@@ -74,6 +61,19 @@ Monitoring:
   TracingMode: ''
 
 Setup:
+  # Enable S3 access logs for Panther buckets.
+  # Doing so is a strongly recommend security practice, but can come at a high cost
+  # when processing large volumes of data.
+  #
+  # Access logs are sent either to the S3AccessLogsBucket below or a the panther audit bucket created for you.
+  EnableS3AccessLogs: true
+
+  # Optionally use an existing S3 bucket for storing S3 access logs.
+  # If not specified, the generated panther audit logs bucket is used for access logs as well.
+  #
+  # Has no effect if EnableS3AccessLogs=false above.
+  S3AccessLogsBucket: ''
+
   # List of policy/rule sets to install if the existing ruleset is empty
   # (e.g. when Panther is first deployed).
   #

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -61,6 +61,15 @@ Monitoring:
   TracingMode: ''
 
 Setup:
+  # List of policy/rule sets to install if the existing ruleset is empty
+  # (e.g. when Panther is first deployed).
+  #
+  # Entries can be URLs or file:// paths that point to a .zip file.
+  # If the analysis-api is non-empty, this setting is ignored and you can instead
+  # use the BulkUpload functionality from the web app to upload new or modified rule sets.
+  InitialAnalysisSets:
+    - https://github.com/panther-labs/panther-analysis/releases/latest/download/panther-analysis-all.zip
+
   # Enable S3 access logs for Panther buckets.
   # Doing so is a strongly recommend security practice, but can come at a high cost
   # when processing large volumes of data.
@@ -73,15 +82,6 @@ Setup:
   #
   # Has no effect if EnableS3AccessLogs=false above.
   S3AccessLogsBucket: ''
-
-  # List of policy/rule sets to install if the existing ruleset is empty
-  # (e.g. when Panther is first deployed).
-  #
-  # Entries can be URLs or file:// paths that point to a .zip file.
-  # If the analysis-api is non-empty, this setting is ignored and you can instead
-  # use the BulkUpload functionality from the web app to upload new or modified rule sets.
-  InitialAnalysisSets:
-    - https://github.com/panther-labs/panther-analysis/releases/latest/download/panther-analysis-all.zip
 
   # Whether or not the Panther deployment should automatically onboard itself as a data source.
   OnboardSelf: true

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -63,6 +63,9 @@ func SendAlert(event *AlertDedupEvent) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get alert information")
 	}
+	if alert == nil {
+		return nil
+	}
 	msgBody, err := jsoniter.MarshalToString(alert)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal alert notification")
@@ -92,6 +95,10 @@ func getAlert(alert *AlertDedupEvent) (*alertModel.Alert, error) {
 	})
 
 	if err != nil {
+		if err.Error() == (&policiesoperations.GetRuleNotFound{}).Error() {
+			return nil, nil
+		}
+
 		return nil, errors.Wrapf(err, "failed to fetch information for ruleID %s", alert.RuleID)
 	}
 

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -225,6 +225,17 @@ func TestSendAlertFailureToGetRule(t *testing.T) {
 	assert.Error(t, SendAlert(testAlertDedupEvent))
 }
 
+func TestSendAlertRuleDoesntExist(t *testing.T) {
+	sqsMock := &mockSqs{}
+	sqsClient = sqsMock
+
+	mockRoundTripper := &mockRoundTripper{}
+	httpClient = &http.Client{Transport: mockRoundTripper}
+
+	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(testRuleResponse, http.StatusNotFound), nil).Once()
+	assert.NoError(t, SendAlert(testAlertDedupEvent))
+}
+
 func TestSendAlertFailureToSendSqsMessage(t *testing.T) {
 	sqsMock := &mockSqs{}
 	sqsClient = sqsMock

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -212,6 +212,8 @@ func TestSendAlertWithoutTitle(t *testing.T) {
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(testRuleResponse, http.StatusOK), nil).Once()
 	sqsMock.On("SendMessage", expectedSendMessageInput).Return(&sqs.SendMessageOutput{}, nil)
 	assert.NoError(t, SendAlert(testEvent))
+	sqsMock.AssertExpectations(t)
+	mockRoundTripper.AssertExpectations(t)
 }
 
 func TestSendAlertFailureToGetRule(t *testing.T) {
@@ -223,6 +225,8 @@ func TestSendAlertFailureToGetRule(t *testing.T) {
 
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(testRuleResponse, http.StatusInternalServerError), nil).Once()
 	assert.Error(t, SendAlert(testAlertDedupEvent))
+	sqsMock.AssertExpectations(t)
+	mockRoundTripper.AssertExpectations(t)
 }
 
 func TestSendAlertRuleDoesntExist(t *testing.T) {
@@ -234,6 +238,8 @@ func TestSendAlertRuleDoesntExist(t *testing.T) {
 
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(testRuleResponse, http.StatusNotFound), nil).Once()
 	assert.NoError(t, SendAlert(testAlertDedupEvent))
+	sqsMock.AssertExpectations(t)
+	mockRoundTripper.AssertExpectations(t)
 }
 
 func TestSendAlertFailureToSendSqsMessage(t *testing.T) {
@@ -246,6 +252,8 @@ func TestSendAlertFailureToSendSqsMessage(t *testing.T) {
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse(testRuleResponse, http.StatusOK), nil).Once()
 	sqsMock.On("SendMessage", mock.Anything).Return(&sqs.SendMessageOutput{}, errors.New("error"))
 	assert.Error(t, SendAlert(testAlertDedupEvent))
+	sqsMock.AssertExpectations(t)
+	mockRoundTripper.AssertExpectations(t)
 }
 
 func generateResponse(body interface{}, httpCode int) *http.Response {

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -29,9 +29,9 @@ _RULES_CACHE_DURATION = timedelta(minutes=5)
 
 class Engine:
     """The engine that runs Python rules."""
-    logger = get_logger()
 
     def __init__(self, analysis_api: AnalysisAPIClient) -> None:
+        self.logger = get_logger()
         self._last_update = datetime.utcfromtimestamp(0)
         self.log_type_to_rules: Dict[str, List[Rule]] = collections.defaultdict(list)
         self._analysis_client = analysis_api
@@ -46,6 +46,7 @@ class Engine:
         matched: List[EventMatch] = []
 
         for rule in self.log_type_to_rules[log_type]:
+            self.logger.debug('running rule [%s]', rule.rule_id)
             result = rule.run(event)
             if result.exception:
                 self.logger.error('failed to run rule %s %s %s', rule.rule_id, type(result).__name__, repr(result.exception))

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -100,7 +100,7 @@ class Rule:
         else:
             self._has_dedup = False
 
-        self._default_dedup = 'defaultDedupString:{}'.format(self.rule_id)
+        self._default_dedup_string = 'defaultDedupString:{}'.format(self.rule_id)
 
         if hasattr(self._module, 'title'):
             self._has_title = True
@@ -123,13 +123,13 @@ class Rule:
 
     def _get_dedup(self, event: Dict[str, Any]) -> str:
         if not self._has_dedup:
-            # If no dedup function defined, return rule id
-            return self._default_dedup
+            # If no dedup function defined, return default dedup string
+            return self._default_dedup_string
         try:
             dedup_string = self._run_command(self._module.dedup, event, str)
         except Exception as err:  # pylint: disable=broad-except
             self.logger.warning('dedup method raised exception. Defaulting dedup string to "%s". Exception: %s', self.rule_id, err)
-            return self._default_dedup
+            return self._default_dedup_string
 
         if dedup_string:
             if len(dedup_string) > MAX_DEDUP_STRING_SIZE:
@@ -141,8 +141,8 @@ class Rule:
                 num_characters_to_keep = MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)
                 return dedup_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
             return dedup_string
-        # If dedup string was the empty string, put the default value (rule_id)
-        return self._default_dedup
+        # If dedup string was the empty string, return default dedup string
+        return self._default_dedup_string
 
     def _get_title(self, event: Dict[str, Any]) -> Optional[str]:
         if not self._has_title:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -100,6 +100,8 @@ class Rule:
         else:
             self._has_dedup = False
 
+        self._default_dedup = 'defaultDedupString:{}'.format(self.rule_id)
+
         if hasattr(self._module, 'title'):
             self._has_title = True
         else:
@@ -111,7 +113,7 @@ class Rule:
         dedup_string: Optional[str] = None
         title: Optional[str] = None
         try:
-            rule_result = _run_command(self._module.rule, event, bool)
+            rule_result = self._run_command(self._module.rule, event, bool)
             if rule_result:
                 dedup_string = self._get_dedup(event)
                 title = self._get_title(event)
@@ -122,12 +124,12 @@ class Rule:
     def _get_dedup(self, event: Dict[str, Any]) -> str:
         if not self._has_dedup:
             # If no dedup function defined, return rule id
-            return 'defaultDedupString:' + self.rule_id
+            return self._default_dedup
         try:
-            dedup_string = _run_command(self._module.dedup, event, str)
+            dedup_string = self._run_command(self._module.dedup, event, str)
         except Exception as err:  # pylint: disable=broad-except
             self.logger.warning('dedup method raised exception. Defaulting dedup string to "%s". Exception: %s', self.rule_id, err)
-            return self.rule_id
+            return self._default_dedup
 
         if dedup_string:
             if len(dedup_string) > MAX_DEDUP_STRING_SIZE:
@@ -140,13 +142,13 @@ class Rule:
                 return dedup_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
             return dedup_string
         # If dedup string was the empty string, put the default value (rule_id)
-        return 'defaultDedupString:' + self.rule_id
+        return self._default_dedup
 
     def _get_title(self, event: Dict[str, Any]) -> Optional[str]:
         if not self._has_title:
             return None
         try:
-            title_string = _run_command(self._module.title, event, str)
+            title_string = self._run_command(self._module.title, event, str)
         except Exception as err:  # pylint: disable=broad-except
             self.logger.warning('title method raised exception. Using default. Exception: %s', err)
             return None
@@ -191,15 +193,16 @@ class Rule:
             sys.modules[self.rule_id] = mod
         return mod
 
-
-def _run_command(function: Callable, event: Dict[str, Any], expected_type: Any) -> Any:
-    result = function(event)
-    if not isinstance(result, expected_type):
-        raise Exception(
-            'rule fuction [{}] returned [{}], expected [{}]'.format(function.__name__,
-                                                                    type(result).__name__, expected_type.__name__)
-        )
-    return result
+    def _run_command(self, function: Callable, event: Dict[str, Any], expected_type: Any) -> Any:
+        result = function(event)
+        if not isinstance(result, expected_type):
+            raise Exception(
+                'rule [{}] fuction [{}] returned [{}], expected [{}]'.format(
+                    self.rule_id, function.__name__,
+                    type(result).__name__, expected_type.__name__
+                )
+            )
+        return result
 
 
 def _rule_id_to_path(rule_id: str) -> str:

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -138,14 +138,14 @@ class TestRule(TestCase):
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
         rule = Rule({'id': 'test_dedup_throws_exception', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_rule = RuleResult(matched=True, dedup_string='test_dedup_throws_exception')
+        expected_rule = RuleResult(matched=True, dedup_string='defaultDedupString:test_dedup_throws_exception')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_invalid_dedup_return(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
         rule = Rule({'id': 'test_rule_invalid_dedup_return', 'body': rule_body, 'severity': 'INFO'})
 
-        expected_rule = RuleResult(matched=True, dedup_string='test_rule_invalid_dedup_return')
+        expected_rule = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_invalid_dedup_return')
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_rule_dedup_returns_empty_string(self) -> None:

--- a/pkg/awsglue/partition.go
+++ b/pkg/awsglue/partition.go
@@ -103,7 +103,7 @@ type PartitionColumnInfo struct {
 
 // Creates a new partition in Glue using the client provided.
 func (gp *GluePartition) CreatePartition(client glueiface.GlueAPI) error {
-	return NewGlueTableMetadata(models.LogData, gp.tableName, "", GlueTableHourly, nil).CreateJSONPartition(client, gp.hour)
+	return NewGlueTableMetadata(gp.datatype, gp.tableName, "", GlueTableHourly, nil).CreateJSONPartition(client, gp.hour)
 }
 
 // Gets the partition from S3bucket and S3 object key info.

--- a/tools/config/config.go
+++ b/tools/config/config.go
@@ -45,14 +45,14 @@ type Monitoring struct {
 	AlarmSnsTopicArn           string `yaml:"AlarmSnsTopicArn"`
 	CloudWatchLogRetentionDays int    `yaml:"CloudWatchLogRetentionDays"`
 	Debug                      bool   `yaml:"Debug"`
-	EnableS3AccessLogs         bool   `yaml:"EnableS3AccessLogs"`
-	S3AccessLogsBucket         string `yaml:"S3AccessLogsBucket"`
 	TracingMode                string `yaml:"TracingMode"`
 }
 
 type Setup struct {
 	InitialAnalysisSets []string `yaml:"InitialAnalysisSets"`
 	OnboardSelf         bool     `yaml:"OnboardSelf"`
+	EnableS3AccessLogs  bool     `yaml:"EnableS3AccessLogs"`
+	S3AccessLogsBucket  string   `yaml:"S3AccessLogsBucket"`
 	EnableCloudTrail    bool     `yaml:"EnableCloudTrail"`
 	EnableGuardDuty     bool     `yaml:"EnableGuardDuty"`
 }

--- a/tools/config/config.go
+++ b/tools/config/config.go
@@ -49,12 +49,12 @@ type Monitoring struct {
 }
 
 type Setup struct {
-	InitialAnalysisSets []string `yaml:"InitialAnalysisSets"`
 	OnboardSelf         bool     `yaml:"OnboardSelf"`
 	EnableS3AccessLogs  bool     `yaml:"EnableS3AccessLogs"`
-	S3AccessLogsBucket  string   `yaml:"S3AccessLogsBucket"`
 	EnableCloudTrail    bool     `yaml:"EnableCloudTrail"`
 	EnableGuardDuty     bool     `yaml:"EnableGuardDuty"`
+	S3AccessLogsBucket  string   `yaml:"S3AccessLogsBucket"`
+	InitialAnalysisSets []string `yaml:"InitialAnalysisSets"`
 }
 
 type Web struct {

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -200,8 +200,8 @@ func bootstrap(awsSession *session.Session, settings *config.PantherConfig) map[
 	// Deploy first bootstrap stack
 	go func() {
 		params := map[string]string{
-			"EnableS3AccessLogs":         strconv.FormatBool(settings.Monitoring.EnableS3AccessLogs),
-			"AccessLogsBucket":           settings.Monitoring.S3AccessLogsBucket,
+			"EnableS3AccessLogs":         strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
+			"AccessLogsBucket":           settings.Setup.S3AccessLogsBucket,
 			"CertificateArn":             certificateArn(awsSession, settings),
 			"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
 			"CustomDomain":               settings.Web.CustomDomain,

--- a/tools/mage/deploy_onboard.go
+++ b/tools/mage/deploy_onboard.go
@@ -139,12 +139,15 @@ func registerPantherAccount(awsSession *session.Session, settings *config.Panthe
 	}
 
 	if registerLogProcessing {
-		logTypes := []string{"AWS.S3ServerAccess", "AWS.VPCFlow", "AWS.ALB"}
+		logTypes := []string{"AWS.VPCFlow", "AWS.ALB"}
 		if settings.Setup.EnableCloudTrail {
 			logTypes = append(logTypes, "AWS.CloudTrail")
 		}
 		if settings.Setup.EnableGuardDuty {
 			logTypes = append(logTypes, "AWS.GuardDuty")
+		}
+		if settings.Setup.EnableS3AccessLogs {
+			logTypes = append(logTypes, "AWS.S3ServerAccess")
 		}
 
 		input := &models.LambdaInput{


### PR DESCRIPTION
## Background

While testing log alerting I encountered two issues: 
- If the rule was deleted before the alert was propagated, the alert-log-forwarder would keep retrying to fetch the rule .
- Rule's engine was not handling properly the case were a user had written an invalid dedup function. 
- Data Catalog updater was not updating rules matches properly

## Changes

- Fixed above issues. 
- Improved logging in some cases
- Moved onboarding configuration for S3 Server Access logs to be in the same section as CT and GD onboarding since this seems more appropriate. It is not about "monitoring" of the app (in the sense that it monitors the app stability) it is more about log onboarding/auditing of accesses to panther resources&the account where panther is deployed. 
- Fixed data catalog updater

## Testing

- Unit tests
- Deployed and verified normal behavior in my account
- Did a teardown. Set `EnableS3AccessLogs` to `false`. Deployed fresh and seen that audit logs where not enabled. 
- Did a teardown. Set `EnableS3AccessLogs` to `true`. Deployed fresh and seen that audit logs where  enabled. 