### PR TITLE
Fixing fluentd parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/numerics"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )
 
@@ -33,13 +34,13 @@ Reference: https://docs.fluentd.org/parser/syslog#rfc3164-log`
 
 // nolint:lll
 type RFC3164 struct {
-	Priority  *uint8                      `json:"pri" validate:"required" description:"Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message."`
-	Hostname  *string                     `json:"host,omitempty" description:"Hostname identifies the machine that originally sent the syslog message."`
-	Ident     *string                     `json:"ident,omitempty" description:"Appname identifies the device or application that originated the syslog message."`
-	ProcID    *string                     `json:"pid,omitempty" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
-	Message   *string                     `json:"message,omitempty" description:"Message contains free-form text that provides information about the event."`
-	Timestamp *timestamp.FluentdTimestamp `json:"time,omitempty" description:"Timestamp of the syslog message in UTC."`
-	Tag       *string                     `json:"tag,omitempty" description:"Tag of the syslog message"`
+	Priority  *uint8                      `json:"pri" description:"Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message."`
+	Hostname  *string                     `json:"host,omitempty" validate:"required" description:"Hostname identifies the machine that originally sent the syslog message."`
+	Ident     *string                     `json:"ident,omitempty" validate:"required" description:"Appname identifies the device or application that originated the syslog message."`
+	ProcID    *numerics.Integer           `json:"pid,omitempty" validate:"required" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
+	Message   *string                     `json:"message,omitempty" validate:"required" description:"Message contains free-form text that provides information about the event."`
+	Timestamp *timestamp.FluentdTimestamp `json:"time,omitempty" validate:"required" description:"Timestamp of the syslog message in UTC."`
+	Tag       *string                     `json:"tag,omitempty" validate:"required" description:"Tag of the syslog message"`
 	// NOTE: added to end of struct to allow expansion later
 	parsers.PantherLog
 }

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/numerics"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/testutil"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )
@@ -38,7 +39,7 @@ func TestRFC3164(t *testing.T) {
 		Priority:  aws.Uint8(6),
 		Hostname:  aws.String("ip-172-31-84-73"),
 		Ident:     aws.String("sudo"),
-		ProcID:    aws.String("11111"),
+		ProcID:    (*numerics.Integer)(aws.Int(11111)),
 		Message:   aws.String("pam_unix(sudo:session): session closed for user root"),
 		Tag:       aws.String("syslog.authpriv.info"),
 		Timestamp: (*timestamp.FluentdTimestamp)(&expectedTime),
@@ -49,6 +50,27 @@ func TestRFC3164(t *testing.T) {
 	expectedRFC3164.AppendAnyDomainNamePtrs(expectedRFC3164.Hostname)
 	expectedRFC3164.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
 	checkRFC3164(t, log, expectedRFC3164)
+}
+
+func TestRFC3164WithoutPriority(t *testing.T) {
+	// nolint:lll
+	log := `{"host":"ip-172-31-91-66","ident":"systemd-timesyncd","pid":"565","message":"Network configuration changed, trying to establish connection.","tag":"syslog.cron.info","time":"2020-03-23 16:14:06 +0000"}`
+
+	expectedTime := time.Date(2020, 3, 23, 16, 14, 6, 0, time.UTC)
+	expectedEvent := &RFC3164{
+		Hostname:  aws.String("ip-172-31-91-66"),
+		Ident:     aws.String("systemd-timesyncd"),
+		ProcID:    (*numerics.Integer)(aws.Int(565)),
+		Message:   aws.String("Network configuration changed, trying to establish connection."),
+		Tag:       aws.String("syslog.cron.info"),
+		Timestamp: (*timestamp.FluentdTimestamp)(&expectedTime),
+	}
+
+	// panther fields
+	expectedEvent.PantherLogType = aws.String("Fluentd.Syslog3164")
+	expectedEvent.AppendAnyDomainNamePtrs(expectedEvent.Hostname)
+	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+	checkRFC3164(t, log, expectedEvent)
 }
 
 func TestRFC3164TypeType(t *testing.T) {

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
@@ -25,23 +25,24 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/numerics"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )
 
-var RFC5424Desc = `Fluentd syslog parser for the RFC3164 format (ie. BSD-syslog messages)
-Reference: https://docs.fluentd.org/parser/syslog#rfc3164-log`
+var RFC5424Desc = `Fluentd syslog parser for the RFC5424 format (ie. BSD-syslog messages)
+Reference: https://docs.fluentd.org/parser/syslog#rfc5424-log`
 
 // nolint:lll
 type RFC5424 struct {
-	Priority  *uint8                      `json:"pri" validate:"required" description:"Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message."`
-	Hostname  *string                     `json:"host,omitempty" description:"Hostname identifies the machine that originally sent the syslog message."`
-	Ident     *string                     `json:"ident,omitempty" description:"Appname identifies the device or application that originated the syslog message."`
-	ProcID    *string                     `json:"pid,omitempty" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
-	MsgID     *string                     `json:"msgid,omitempty" description:"MsgID identifies the type of message. For example, a firewall might use the MsgID 'TCPIN' for incoming TCP traffic."`
-	ExtraData *string                     `json:"extradata,omitempty" description:"ExtraData contains syslog strucured data as string"`
-	Message   *string                     `json:"message,omitempty" description:"Message contains free-form text that provides information about the event."`
-	Timestamp *timestamp.FluentdTimestamp `json:"time,omitempty" description:"Timestamp of the syslog message in UTC."`
-	Tag       *string                     `json:"tag,omitempty" description:"Tag of the syslog message"`
+	Priority  *uint8                      `json:"pri,omitempty" description:"Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message."`
+	Hostname  *string                     `json:"host,omitempty" validate:"required" description:"Hostname identifies the machine that originally sent the syslog message."`
+	Ident     *string                     `json:"ident,omitempty" validate:"required" description:"Appname identifies the device or application that originated the syslog message."`
+	ProcID    *numerics.Integer           `json:"pid,omitempty" validate:"required" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
+	MsgID     *string                     `json:"msgid,omitempty" validate:"required" description:"MsgID identifies the type of message. For example, a firewall might use the MsgID 'TCPIN' for incoming TCP traffic."`
+	ExtraData *string                     `json:"extradata,omitempty" validate:"required" description:"ExtraData contains syslog strucured data as string"`
+	Message   *string                     `json:"message,omitempty" validate:"required" description:"Message contains free-form text that provides information about the event."`
+	Timestamp *timestamp.FluentdTimestamp `json:"time,omitempty" validate:"required" description:"Timestamp of the syslog message in UTC."`
+	Tag       *string                     `json:"tag,omitempty" validate:"required" description:"Tag of the syslog message"`
 	// NOTE: added to end of struct to allow expansion later
 	parsers.PantherLog
 }

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/numerics"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/testutil"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"
 )
@@ -38,7 +39,7 @@ func TestRFC5424(t *testing.T) {
 		Priority:  aws.Uint8(16),
 		Hostname:  aws.String("192.168.0.1"),
 		Ident:     aws.String("fluentd"),
-		ProcID:    aws.String("11111"),
+		ProcID:    (*numerics.Integer)(aws.Int(11111)),
 		MsgID:     aws.String("ID24224"),
 		ExtraData: aws.String("[exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"]"),
 		Message:   aws.String("[error] Syslog test"),
@@ -49,6 +50,30 @@ func TestRFC5424(t *testing.T) {
 	// panther fields
 	expectedRFC5424.PantherLogType = aws.String("Fluentd.Syslog5424")
 	expectedRFC5424.AppendAnyIPAddressPtrs(expectedRFC5424.Hostname)
+	expectedRFC5424.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+	checkRFC5424(t, log, expectedRFC5424)
+}
+
+func TestRFC5424Domain(t *testing.T) {
+	// nolint:lll
+	log := `{"pri": 16, "host": "ip-192-168-0-1", "ident": "fluentd", "pid": "11111", "msgid": "ID24224", "extradata": "[exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"]","message": "[error] Syslog test", "tag":"syslog.authpriv.info","time":"2020-03-23 16:14:06 +0000"}`
+
+	expectedTime := time.Date(2020, 3, 23, 16, 14, 6, 0, time.UTC)
+	expectedRFC5424 := &RFC5424{
+		Priority:  aws.Uint8(16),
+		Hostname:  aws.String("ip-192-168-0-1"),
+		Ident:     aws.String("fluentd"),
+		ProcID:    (*numerics.Integer)(aws.Int(11111)),
+		MsgID:     aws.String("ID24224"),
+		ExtraData: aws.String("[exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"]"),
+		Message:   aws.String("[error] Syslog test"),
+		Tag:       aws.String("syslog.authpriv.info"),
+		Timestamp: (*timestamp.FluentdTimestamp)(&expectedTime),
+	}
+
+	// panther fields
+	expectedRFC5424.PantherLogType = aws.String("Fluentd.Syslog5424")
+	expectedRFC5424.AppendAnyDomainNamePtrs(expectedRFC5424.Hostname)
 	expectedRFC5424.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
 	checkRFC5424(t, log, expectedRFC5424)
 }


### PR DESCRIPTION
## Background

While testing the new Fluentd parsers with real world data I found some issues. This PR is fixing them. 

## Changes

- Fixing description of RFC5424
- According to the [documentation](https://docs.fluentd.org/parser/syslog#parameters), the only non-required field is `pri` field since it can be tuned on/off using  the parameter `with_priority`. In our tests we noticed that most of the logs were failing to parse because of this issue. Updated validations.
- Added extra unit tests
- Changing PID to be stored as integer instead of string. 

## Testing

- Unit tests
- Deployed in my account processing real data. Verified data was flowing normally. 

<img width="1214" alt="Screen Shot 2020-03-26 at 1 57 53 PM" src="https://user-images.githubusercontent.com/2652630/77649270-ddb38380-6f69-11ea-8002-fbca38cf4380.png">
