### PR TITLE
Clarify license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ We welcome all contributions! Please read the [contributing guidelines](https://
 
 ## License
 
-Panther source code is licensed under AGPLv3, except the common utility `pkg/` folder, which uses the more permissive Apache v2 license.
+Panther source code is licensed under AGPLv3, except the common utility `pkg/` folder, which uses the Apache 2.0 license.
 See the [LICENSE file](https://github.com/panther-labs/panther/blob/master/LICENSE) for more information.
 
 ### FOSSA Status

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ We welcome all contributions! Please read the [contributing guidelines](https://
 
 ## License
 
-Panther is dual-licensed under the AGPLv3 and Apache-2.0 [licenses](https://github.com/panther-labs/panther/blob/master/LICENSE).
+Panther source code is licensed under AGPLv3, except the common utility `pkg/` folder, which uses the more permissive Apache v2 license.
+See the [LICENSE file](https://github.com/panther-labs/panther/blob/master/LICENSE) for more information.
 
 ### FOSSA Status
 


### PR DESCRIPTION
## Background

Panther is not "dual-licensed" so much as it is "selectively licensed"

Closes: #583 

## Changes

- Update README license blurb
