### PR TITLE
URL-decoding for list users filter

### DIFF
--- a/internal/core/users_api/api/list_users.go
+++ b/internal/core/users_api/api/list_users.go
@@ -18,10 +18,28 @@ package api
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import "github.com/panther-labs/panther/api/lambda/users/models"
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/panther-labs/panther/api/lambda/users/models"
+	"github.com/panther-labs/panther/pkg/genericapi"
+)
 
 // ListUsers lists details for each user in Panther.
 func (API) ListUsers(input *models.ListUsersInput) (*models.ListUsersOutput, error) {
+	if input.Contains != nil {
+		decoded, err := url.QueryUnescape(*input.Contains)
+		if err != nil {
+			return nil, &genericapi.InvalidInputError{
+				Message: fmt.Sprintf("\"%s\" url decoding failed: %v", *input.Contains, err)}
+		}
+		input.Contains = aws.String(strings.ToLower(strings.TrimSpace(decoded)))
+	}
+
 	users, err := userGateway.ListUsers(input)
 	if err != nil {
 		return nil, err

--- a/internal/core/users_api/cognito/list_users.go
+++ b/internal/core/users_api/cognito/list_users.go
@@ -43,8 +43,7 @@ func (g *UsersGateway) ListUsers(input *models.ListUsersInput) ([]*models.User, 
 			if input.Status != nil && *input.Status != aws.StringValue(user.Status) {
 				continue // filter by status
 			}
-			if input.Contains != nil {
-				search := strings.TrimSpace(strings.ToLower(*input.Contains))
+			if search := aws.StringValue(input.Contains); search != "" {
 				if !strings.Contains(strings.ToLower(aws.StringValue(user.GivenName)), search) &&
 					!strings.Contains(strings.ToLower(aws.StringValue(user.FamilyName)), search) &&
 					!strings.Contains(strings.ToLower(aws.StringValue(user.Email)), search) {


### PR DESCRIPTION
## Background
The `users-api` supports filtering users by name or email, though this functionality isn't yet exposed in the web app.

Adding URL-decoding to the search field in the backend (see: #576)

## Changes

- URL-decode the "contains" filter in `users-api`
    - Tiny optimization - trim and lowercase the search string once at the beginning instead of for each scanned user

## Testing

- `mage fmt test:go deploy`
- `PKG=./internal/core/users_api/main mage test:integration`