### PR TITLE
Build swagger in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,6 @@ jobs:
     steps:
       - setup_backend
       - run:
-          name: Touch Swagger SDKs to prevent regeneration
-          command: touch api/gateway/*/{client,models}
-      - run:
           name: Lint and test the backend infrastructure
           command: mage build:api test:cfn test:go test:python
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - setup_backend
       - run:
           name: Lint and test the backend infrastructure
-          command: mage build:api bulid:cfn test:cfn test:go test:python
+          command: mage build:api build:cfn test:cfn test:go test:python
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - setup_backend
       - run:
           name: Lint and test the backend infrastructure
-          command: mage build:api test:cfn test:go test:python
+          command: mage build:api bulid:cfn test:cfn test:go test:python
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: touch api/gateway/*/{client,models}
       - run:
           name: Lint and test the backend infrastructure
-          command: mage test:cfn test:go test:python
+          command: mage build:api test:cfn test:go test:python
 
 workflows:
   version: 2


### PR DESCRIPTION
## Background

Add `build:api` to CI (trying to reproduce #605 )

## Changes

- Add `build:api` to CI (it used to be part of `test:go`, when we moved it out we didn't update CI)

## Testing

- CI
