### PR TITLE
Separated Delete Rule Query in schema & AppSync

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -173,7 +173,7 @@ input GetRuleInput {
 }
 
 input DeleteRuleInput {
-  policies: [DeleteRuleInputItem]
+  rules: [DeleteRuleInputItem!]!
 }
 
 input DeleteRuleInputItem {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -18,6 +18,7 @@ type Mutation {
   deleteComplianceIntegration(id: ID!): Boolean
   deleteLogIntegration(id: ID!): Boolean
   deletePolicy(input: DeletePolicyInput!): Boolean
+  deleteRule(input: DeleteRuleInput!): Boolean
   deleteUser(id: ID!): Boolean
   inviteUser(input: InviteUserInput): User!
   remediateResource(input: RemediateResourceInput!): Boolean
@@ -169,6 +170,14 @@ input CreateOrModifyRuleInput {
 input GetRuleInput {
   ruleId: ID!
   versionId: ID
+}
+
+input DeleteRuleInput {
+  policies: [DeleteRuleInputItem]
+}
+
+input DeleteRuleInputItem {
+  id: ID!
 }
 
 type RuleSummary {

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -1391,6 +1391,44 @@ Resources:
             $util.error($ctx.result.body, "$statusCode", $input)
         #end
 
+  DeleteRuleResolver:
+    Type: AWS::AppSync::Resolver
+    DependsOn: GraphQLSchema
+    Properties:
+      ApiId: !Ref ApiId
+      TypeName: Mutation
+      FieldName: deleteRule
+      DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
+      RequestMappingTemplate: |
+        #set ($policiesInput = [])
+        #foreach($item in $ctx.args.input.policies)
+            #set ($inputItem = {})
+            $util.qr($inputItem.put("id", $item.id))
+            $util.qr($policiesInput.add($inputItem))
+        #end
+        {
+          "version": "2018-05-29",
+          "method": "POST",
+          "resourcePath": "/v1/delete",
+          "params": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": $util.toJson({
+              "policies": $policiesInput
+            })
+          }
+        }
+      ResponseMappingTemplate: |
+        #set ($statusCode = $ctx.result.statusCode)
+        #if($statusCode == 200)
+            true
+        #elseif($statusCode >= 400 && $statusCode < 500)
+            $util.error($util.parseJson($ctx.result.body).message, $statusCode, $ctx.args)
+        #else
+            $util.error($ctx.result.body, $statusCode, $ctx.args)
+        #end
+
   ListAlertsResolver:
     Type: AWS::AppSync::Resolver
     DependsOn: GraphQLSchema

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -1400,12 +1400,6 @@ Resources:
       FieldName: deleteRule
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
-        #set ($policiesInput = [])
-        #foreach($item in $ctx.args.input.policies)
-            #set ($inputItem = {})
-            $util.qr($inputItem.put("id", $item.id))
-            $util.qr($policiesInput.add($inputItem))
-        #end
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1415,7 +1409,7 @@ Resources:
               "Content-Type": "application/json"
             },
             "body": $util.toJson({
-              "policies": $policiesInput
+              "policies": $ctx.args.input.rules
             })
           }
         }

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -962,12 +962,6 @@ Resources:
       FieldName: deletePolicy
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
-        #set ($policiesInput = [])
-        #foreach($item in $ctx.args.input.policies)
-            #set ($inputItem = {})
-            $util.qr($inputItem.put("id", $item.id))
-            $util.qr($policiesInput.add($inputItem))
-        #end
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -977,7 +971,7 @@ Resources:
               "Content-Type": "application/json"
             },
             "body": $util.toJson({
-              "policies": $policiesInput
+              "policies": $ctx.args.input.policies
             })
           }
         }

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -168,6 +168,14 @@ export type DeletePolicyInputItem = {
   id: Scalars['ID'];
 };
 
+export type DeleteRuleInput = {
+  policies?: Maybe<Array<Maybe<DeleteRuleInputItem>>>;
+};
+
+export type DeleteRuleInputItem = {
+  id: Scalars['ID'];
+};
+
 export type Destination = {
   __typename?: 'Destination';
   createdBy: Scalars['String'];
@@ -472,6 +480,7 @@ export type Mutation = {
   deleteComplianceIntegration?: Maybe<Scalars['Boolean']>;
   deleteLogIntegration?: Maybe<Scalars['Boolean']>;
   deletePolicy?: Maybe<Scalars['Boolean']>;
+  deleteRule?: Maybe<Scalars['Boolean']>;
   deleteUser?: Maybe<Scalars['Boolean']>;
   inviteUser: User;
   remediateResource?: Maybe<Scalars['Boolean']>;
@@ -522,6 +531,10 @@ export type MutationDeleteLogIntegrationArgs = {
 
 export type MutationDeletePolicyArgs = {
   input: DeletePolicyInput;
+};
+
+export type MutationDeleteRuleArgs = {
+  input: DeleteRuleInput;
 };
 
 export type MutationDeleteUserArgs = {
@@ -1155,6 +1168,8 @@ export type ResolversTypes = {
   CreateOrModifyRuleInput: CreateOrModifyRuleInput;
   DeletePolicyInput: DeletePolicyInput;
   DeletePolicyInputItem: DeletePolicyInputItem;
+  DeleteRuleInput: DeleteRuleInput;
+  DeleteRuleInputItem: DeleteRuleInputItem;
   InviteUserInput: InviteUserInput;
   RemediateResourceInput: RemediateResourceInput;
   SuppressPoliciesInput: SuppressPoliciesInput;
@@ -1263,6 +1278,8 @@ export type ResolversParentTypes = {
   CreateOrModifyRuleInput: CreateOrModifyRuleInput;
   DeletePolicyInput: DeletePolicyInput;
   DeletePolicyInputItem: DeletePolicyInputItem;
+  DeleteRuleInput: DeleteRuleInput;
+  DeleteRuleInputItem: DeleteRuleInputItem;
   InviteUserInput: InviteUserInput;
   RemediateResourceInput: RemediateResourceInput;
   SuppressPoliciesInput: SuppressPoliciesInput;
@@ -1645,6 +1662,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeletePolicyArgs, 'input'>
+  >;
+  deleteRule?: Resolver<
+    Maybe<ResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRuleArgs, 'input'>
   >;
   deleteUser?: Resolver<
     Maybe<ResolversTypes['Boolean']>,

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -169,7 +169,7 @@ export type DeletePolicyInputItem = {
 };
 
 export type DeleteRuleInput = {
-  policies?: Maybe<Array<Maybe<DeleteRuleInputItem>>>;
+  rules: Array<DeleteRuleInputItem>;
 };
 
 export type DeleteRuleInputItem = {

--- a/web/src/components/modals/DeletePolicyModal/graphql/deletePolicy.graphql
+++ b/web/src/components/modals/DeletePolicyModal/graphql/deletePolicy.graphql
@@ -1,3 +1,3 @@
 mutation DeletePolicy($input: DeletePolicyInput!) {
-    deletePolicy(input: $input)
+  deletePolicy(input: $input)
 }

--- a/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
+++ b/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
@@ -22,7 +22,8 @@ import useRouter from 'Hooks/useRouter';
 import urls from 'Source/urls';
 import BaseConfirmModal from 'Components/modals/BaseConfirmModal';
 // Delete Rule and Delete Policy uses the same endpoint
-import { useDeletePolicy } from '../DeletePolicyModal/graphql/deletePolicy.generated';
+// import { useDeletePolicy } from '../DeletePolicyModal/graphql/deletePolicy.generated';
+import { useDeleteRule } from './graphql/deleteRule.generated';
 
 export interface DeleteRuleModalProps {
   rule: RuleDetails | RuleSummary;
@@ -31,7 +32,7 @@ export interface DeleteRuleModalProps {
 const DeleteRuleModal: React.FC<DeleteRuleModalProps> = ({ rule }) => {
   const { location, history } = useRouter<{ id?: string }>();
   const ruleDisplayName = rule.displayName || rule.id;
-  const mutation = useDeletePolicy({
+  const mutation = useDeleteRule({
     variables: {
       input: {
         policies: [
@@ -42,7 +43,7 @@ const DeleteRuleModal: React.FC<DeleteRuleModalProps> = ({ rule }) => {
       },
     },
     optimisticResponse: {
-      deletePolicy: true,
+      deleteRule: true,
     },
     update: async cache => {
       cache.modify('ROOT_QUERY', {

--- a/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
+++ b/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
@@ -35,7 +35,7 @@ const DeleteRuleModal: React.FC<DeleteRuleModalProps> = ({ rule }) => {
   const mutation = useDeleteRule({
     variables: {
       input: {
-        policies: [
+        rules: [
           {
             id: rule.id,
           },

--- a/web/src/components/modals/DeleteRuleModal/graphql/deleteRule.generated.ts
+++ b/web/src/components/modals/DeleteRuleModal/graphql/deleteRule.generated.ts
@@ -1,0 +1,73 @@
+/**
+ * Panther is a scalable, powerful, cloud-native SIEM written in Golang/React.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable import/order, import/no-duplicates, @typescript-eslint/no-unused-vars */
+
+import * as Types from '../../../../../__generated__/schema';
+
+import gql from 'graphql-tag';
+import * as ApolloReactCommon from '@apollo/client';
+import * as ApolloReactHooks from '@apollo/client';
+
+export type DeleteRuleVariables = {
+  input: Types.DeleteRuleInput;
+};
+
+export type DeleteRule = Pick<Types.Mutation, 'deleteRule'>;
+
+export const DeleteRuleDocument = gql`
+  mutation DeleteRule($input: DeleteRuleInput!) {
+    deleteRule(input: $input)
+  }
+`;
+export type DeleteRuleMutationFn = ApolloReactCommon.MutationFunction<
+  DeleteRule,
+  DeleteRuleVariables
+>;
+
+/**
+ * __useDeleteRule__
+ *
+ * To run a mutation, you first call `useDeleteRule` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteRule` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteRule, { data, loading, error }] = useDeleteRule({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDeleteRule(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteRule, DeleteRuleVariables>
+) {
+  return ApolloReactHooks.useMutation<DeleteRule, DeleteRuleVariables>(
+    DeleteRuleDocument,
+    baseOptions
+  );
+}
+export type DeleteRuleHookResult = ReturnType<typeof useDeleteRule>;
+export type DeleteRuleMutationResult = ApolloReactCommon.MutationResult<DeleteRule>;
+export type DeleteRuleMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  DeleteRule,
+  DeleteRuleVariables
+>;

--- a/web/src/components/modals/DeleteRuleModal/graphql/deleteRule.graphql
+++ b/web/src/components/modals/DeleteRuleModal/graphql/deleteRule.graphql
@@ -1,0 +1,3 @@
+mutation DeleteRule($input: DeleteRuleInput!) {
+  deleteRule(input: $input)
+}


### PR DESCRIPTION
## Background

Deleting a Rule in Log Analysis is using a deletePolicy query that is defined from DeletePolicyResolver in appsync right now. We need to split this to a separate resolver DeleteRuleResolver and a separate query for clarity and consistency.

Closes #464 

## Changes

- Added `DeleteRuleResolver` in Appsync
- Added new graphql queries in web and schema
- Update `DeleteRuleModal` to use new query
## Testing

- Locally
- Dev enviroment

