### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-#
-# Default Owners
-#
-* @3nvi @austinbyers @nhakmiller @kostaspap @jacknagz @rleighton @alexmylonas
-
-#
-# Documentation
-#
-docs/ @3nvi @austinbyers @nhakmiller @kostaspap @jacknagz @rleighton @kartikeypan


### PR DESCRIPTION
## Background

We have a CODEOWNERS file primarily to satisfy an internal compliance tool. However, it then forces the entire team to be tagged on every PR, which makes it hard for authors to tag who they want for review and for reviewers to filter out requests that apply only to them.

As long as the repo requires approval from someone on the team with merge permissions, we don't need the codeowners file. We're not using any of its actual features (separating concerns by reviewer/team) because we're not that large of an engineering team.


## Changes

- ❌ codeowners

## Testing

💥 
