### PR TITLE
Updated latency threshold

### DIFF
--- a/tools/cfngen/cloudwatchcf/alarms_appsync.go
+++ b/tools/cfngen/cloudwatchcf/alarms_appsync.go
@@ -58,7 +58,7 @@ func generateAppSyncAlarms(resource map[interface{}]interface{}) (alarms []*Alar
 
 	// latency
 	alarms = append(alarms, NewAppSyncAlarm("AppSyncHighLatency", "Latency",
-		"is experience high latency", resource).MaxNoUnitsThreshold(2000, 60).EvaluationPeriods(5))
+		"is experiencing high latency", resource).MaxNoUnitsThreshold(2000, 60).EvaluationPeriods(5))
 
 	return alarms
 }

--- a/tools/cfngen/cloudwatchcf/alarms_appsync.go
+++ b/tools/cfngen/cloudwatchcf/alarms_appsync.go
@@ -58,7 +58,7 @@ func generateAppSyncAlarms(resource map[interface{}]interface{}) (alarms []*Alar
 
 	// latency
 	alarms = append(alarms, NewAppSyncAlarm("AppSyncHighLatency", "Latency",
-		"is experience high latency", resource).MaxNoUnitsThreshold(1000, 60).EvaluationPeriods(5))
+		"is experience high latency", resource).MaxNoUnitsThreshold(2000, 60).EvaluationPeriods(5))
 
 	return alarms
 }

--- a/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
+++ b/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
@@ -99,7 +99,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": "PantherAlarm-AppSyncHighLatency-panther-graphql-api",
-        "AlarmDescription": "AppSync panther-graphql-api is experience high latency. See: https://docs.runpanther.io/operations/runbooks#panther-graphql-api",
+        "AlarmDescription": "AppSync panther-graphql-api is experiencing high latency. See: https://docs.runpanther.io/operations/runbooks#panther-graphql-api",
         "AlarmActions": [
           {
             "Ref": "AlarmTopicArn"

--- a/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
+++ b/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
@@ -112,7 +112,7 @@
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 5,
         "Period": 60,
-        "Threshold": 1000,
+        "Threshold": 2000,
         "Unit": "None",
         "Statistic": "Maximum"
       }


### PR DESCRIPTION
## Background

Observed that some app sync queries (especially on a cold start) were taking longer than 1 second to respond under normal circumstances, but our alarms trigger when more than 5 queries hit 1 second latency in a short period. Increasing the latency required to trigger an alarm to 2 seconds.

## Changes

- Bumped latency threshold for app sync alarms from 1 second to 2 seconds

## Testing

- None
