### PR TITLE
Enforce Cognito advanced security

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -388,8 +388,11 @@ Resources:
                 !If [UseCustomDomain, !Ref CustomDomain, !GetAtt PublicLoadBalancer.DNSName]
       AutoVerifiedAttributes:
         - email
+      EnabledMfas:
+        - SOFTWARE_TOKEN_MFA
       LambdaConfig:
         CustomMessage: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-users-api
+      MfaConfiguration: 'ON' # quotes required here, otherwise CFN interprets it as true because ???
       Policies:
         PasswordPolicy:
           MinimumLength: 12
@@ -410,6 +413,8 @@ Resources:
           Name: family_name
       UsernameAttributes:
         - email
+      UserPoolAddOns:
+        AdvancedSecurityMode: ENFORCED
       UserPoolName: panther-users
 
   AppClient:

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/fatih/color"
@@ -213,21 +212,6 @@ func bootstrap(awsSession *session.Session, settings *config.PantherConfig) map[
 		}
 
 		outputs = deployTemplate(awsSession, bootstrapTemplate, "", bootstrapStack, params)
-
-		// Enable software 2FA for the Cognito user pool - this is not yet supported in CloudFormation.
-		userPoolID := outputs["UserPoolId"]
-		logger.Debugf("deploy: enabling TOTP for user pool %s", userPoolID)
-		_, err := cognitoidentityprovider.New(awsSession).SetUserPoolMfaConfig(&cognitoidentityprovider.SetUserPoolMfaConfigInput{
-			MfaConfiguration: aws.String("ON"),
-			SoftwareTokenMfaConfiguration: &cognitoidentityprovider.SoftwareTokenMfaConfigType{
-				Enabled: aws.Bool(true),
-			},
-			UserPoolId: &userPoolID,
-		})
-		if err != nil {
-			logger.Fatalf("failed to enable TOTP for user pool %s: %v", userPoolID, err)
-		}
-
 		wg.Done()
 	}()
 

--- a/tools/mage/util_cfn.go
+++ b/tools/mage/util_cfn.go
@@ -191,16 +191,13 @@ func stackSetInstanceExists(cfClient *cfn.CloudFormation, stackSetName, account,
 	return true, nil
 }
 
-func describeStack(cfClient *cfn.CloudFormation, stackName string) (status string, output map[string]string, err error) {
+// Returns stack status, outputs, and any error
+func describeStack(cfClient *cfn.CloudFormation, stackName string) (string, map[string]string, error) {
 	input := &cfn.DescribeStacksInput{StackName: &stackName}
 	response, err := cfClient.DescribeStacks(input)
 	if err != nil {
-		return status, output, err
+		return "", nil, err
 	}
 
-	status = *response.Stacks[0].StackStatus
-	if status == cfn.StackStatusCreateComplete || status == cfn.StackStatusUpdateComplete {
-		output = flattenStackOutputs(response)
-	}
-	return status, output, err
+	return aws.StringValue(response.Stacks[0].StackStatus), flattenStackOutputs(response), nil
 }


### PR DESCRIPTION
## Background
Cognito has an [advanced security mode](https://aws.amazon.com/blogs/security/how-to-use-new-advanced-security-features-for-amazon-cognito-user-pools/) which checks for compromised credentials. Advanced security also allows for adaptive authentication (require MFA only for high-risk logins), but we always require MFA for now, so we won't use that feature yet.

However, high-risk logins are at least logged to CloudWatch (which Panther should monitor!)

Related to https://github.com/panther-labs/panther/issues/606

## Changes

- The Cognito user pool MFA is now configured in CloudFormation instead of manually via an API call. There's a weird string bug in CFN itself (which is presumably why we couldn't get CFN to work for this before), but I was able to work around it
- Enforce advanced cognito security - users will not be able to use known compromised credentials
- Fix a bug when deploying over an UPDATE_ROLLBACK_COMPLETE stack - `mage deploy` was prematurely checking for a successful status and would fail

## Testing

- `mage deploy` over an existing deployment (to ensure the user pool could be updated in place). I was still able to sign in

Here's the cognito advanced security settings page after the change:

<img width="1020" alt="Screen Shot 2020-04-01 at 2 24 57 PM" src="https://user-images.githubusercontent.com/3608925/78189036-2f568500-7426-11ea-922d-1a3b5270ef6c.png">
