### PR TITLE
Remove API latency alarms

### DIFF
--- a/tools/cfngen/cloudwatchcf/alarms_apigw.go
+++ b/tools/cfngen/cloudwatchcf/alarms_apigw.go
@@ -50,13 +50,9 @@ func generateAPIGatewayAlarms(resource map[interface{}]interface{}) (alarms []*A
 
 	// client errors are used for signalling internally so we do not alarm on them
 
-	// latency
-	alarms = append(alarms, NewAPIGatewayAlarm("ApiGatewayHighLatency", "Latency",
-		"is experience high latency", resource).MaxMillisecondsThreshold(1000, 60).EvaluationPeriods(5))
-
 	// integration latency
 	alarms = append(alarms, NewAPIGatewayAlarm("ApiGatewayHighIntegationLatency", "IntegrationLatency",
-		"is experience high integration latency", resource).MaxMillisecondsThreshold(1000, 60).EvaluationPeriods(5))
+		"is experiencing high integration latency", resource).MaxMillisecondsThreshold(1000, 60).EvaluationPeriods(5))
 
 	return alarms
 }

--- a/tools/cfngen/cloudwatchcf/alarms_appsync.go
+++ b/tools/cfngen/cloudwatchcf/alarms_appsync.go
@@ -56,9 +56,5 @@ func generateAppSyncAlarms(resource map[interface{}]interface{}) (alarms []*Alar
 	alarms = append(alarms, NewAppSyncAlarm("AppSyncClientError", "4XXError",
 		"has has elevated 4XX errors", resource).SumNoUnitsThreshold(20, 60*5) /* tolerate a few client errors */)
 
-	// latency
-	alarms = append(alarms, NewAppSyncAlarm("AppSyncHighLatency", "Latency",
-		"is experience high latency", resource).MaxNoUnitsThreshold(1000, 60).EvaluationPeriods(5))
-
 	return alarms
 }

--- a/tools/cfngen/cloudwatchcf/alarms_elb.go
+++ b/tools/cfngen/cloudwatchcf/alarms_elb.go
@@ -57,10 +57,6 @@ func generateApplicationELBAlarms(resource map[interface{}]interface{}) (alarms 
 	alarms = append(alarms, NewApplicationELBAlarm("ELBError", "HTTPCode_ELB_4XX_Count",
 		"has elevated ELB 4XX errors", resource).SumNoUnitsThreshold(20, 60*5) /* tolerate a few  errors */)
 
-	// latency
-	alarms = append(alarms, NewApplicationELBAlarm("ELBHighLatency", "TargetResponseLatency",
-		"is experience high latency", resource).MaxSecondsThreshold(1, 60).EvaluationPeriods(5))
-
 	// unhealthy
 	alarms = append(alarms, NewApplicationELBAlarm("ELBUnhealthy", "UnHealthyHostCount",
 		"has unhealthy hosts", resource).SumNoUnitsThreshold(0, 60*5))

--- a/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
+++ b/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
@@ -11,7 +11,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": "PantherAlarm-ApiGatewayHighIntegationLatency-panther-resources-api",
-        "AlarmDescription": "ApiGateway panther-resources-api is experience high integration latency. See: https://docs.runpanther.io/operations/runbooks#panther-resources-api",
+        "AlarmDescription": "ApiGateway panther-resources-api is experiencing high integration latency. See: https://docs.runpanther.io/operations/runbooks#panther-resources-api",
         "AlarmActions": [
           {
             "Ref": "AlarmTopicArn"
@@ -20,28 +20,6 @@
         "TreatMissingData": "notBreaching",
         "Namespace": "AWS/ApiGateway",
         "MetricName": "IntegrationLatency",
-        "Dimensions": [{ "Name": "Name", "Value": "panther-resources-api" }],
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 5,
-        "Period": 60,
-        "Threshold": 1000,
-        "Unit": "Milliseconds",
-        "Statistic": "Maximum"
-      }
-    },
-    "PantherAlarmApiGatewayHighLatencypantherresourcesapi": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmName": "PantherAlarm-ApiGatewayHighLatency-panther-resources-api",
-        "AlarmDescription": "ApiGateway panther-resources-api is experience high latency. See: https://docs.runpanther.io/operations/runbooks#panther-resources-api",
-        "AlarmActions": [
-          {
-            "Ref": "AlarmTopicArn"
-          }
-        ],
-        "TreatMissingData": "notBreaching",
-        "Namespace": "AWS/ApiGateway",
-        "MetricName": "Latency",
         "Dimensions": [{ "Name": "Name", "Value": "panther-resources-api" }],
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 5,
@@ -93,28 +71,6 @@
         "Threshold": 20,
         "Unit": "None",
         "Statistic": "Sum"
-      }
-    },
-    "PantherAlarmAppSyncHighLatencypanthergraphqlapi": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmName": "PantherAlarm-AppSyncHighLatency-panther-graphql-api",
-        "AlarmDescription": "AppSync panther-graphql-api is experience high latency. See: https://docs.runpanther.io/operations/runbooks#panther-graphql-api",
-        "AlarmActions": [
-          {
-            "Ref": "AlarmTopicArn"
-          }
-        ],
-        "TreatMissingData": "notBreaching",
-        "Namespace": "AWS/AppSync",
-        "MetricName": "Latency",
-        "Dimensions": [{ "Name": "GraphQLAPIId", "Value": { "Ref": "AppsyncId" } }],
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 5,
-        "Period": 60,
-        "Threshold": 1000,
-        "Unit": "None",
-        "Statistic": "Maximum"
       }
     },
     "PantherAlarmAppSyncServerErrorpanthergraphqlapi": {
@@ -534,28 +490,6 @@
         "Threshold": 20,
         "Unit": "None",
         "Statistic": "Sum"
-      }
-    },
-    "PantherAlarmELBHighLatencyWeb": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmName": "PantherAlarm-ELBHighLatency-Web",
-        "AlarmDescription": "ALB is experience high latency. See: https://docs.runpanther.io/operations/runbooks#web",
-        "AlarmActions": [
-          {
-            "Ref": "AlarmTopicArn"
-          }
-        ],
-        "TreatMissingData": "notBreaching",
-        "Namespace": "AWS/ApplicationELB",
-        "MetricName": "TargetResponseLatency",
-        "Dimensions": [{ "Name": "LoadBalancer", "Value": { "Ref": "LoadBalancerFullName" } }],
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 5,
-        "Period": 60,
-        "Threshold": 1,
-        "Unit": "Seconds",
-        "Statistic": "Maximum"
       }
     },
     "PantherAlarmELBTargetErrorWeb": {


### PR DESCRIPTION
## Background

After some discussion as a team, we decided to remove the appsync latency alarm completely - API calls can take a few seconds on occasion for any number of reasons (cold starts, AWS service outages, etc). Users will notice exceptionally slow pages anyway

We should still graph the latency to understand opportunities for performance improvements, but there's no actionable response to a high latency alarm

By the same argument, API gateway and ELB do not need latency alarms. API gateway is used for internal services as well, but latency issues aren't generally actionable and don't really cause issues unless it causes other lambda functions to timeout, which we will see on those alarms instead

## Changes

- Remove appsync, API gateway, and ELB latency alarms

## Testing

- `mage build:cfn test:go`
