### PR TITLE
Add ConfirmDevice to ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/internal/compliance/aws_event_processor/processor/process.go
+++ b/internal/compliance/aws_event_processor/processor/process.go
@@ -100,6 +100,7 @@ var (
 
 		// cognito
 		"ConfirmForgotPassword": {},
+		"ConfirmDevice":         {}, // This API call does not log a userIdentity with an accountID
 
 		// config
 		"BatchGetResourceConfig":          {},


### PR DESCRIPTION
## Background

The aws-event-processor cannot process events of the type `ConfirmDevice` from the cognito service because these events do not specify a userIdentity field with an account ID set, and we rely on this account ID for processing. Since this event type will never require a scan, I'm adding it to the ignore list.

## Changes

- Add `ConfirmDevice` to the aws-event-processor ignore list

## Testing

- None