### PR TITLE
Fix MFA for cognito user pools on fresh deployments

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -362,6 +362,8 @@ Resources:
         Status: Enabled
 
   ########## Cognito ##########
+  # MFA is configured for the user pool via the Go SDK rather than CloudFormation.
+  # Using CFN for MFA forces SMS, but we only want software tokens (SMS is not as secure)
   UserPool:
     Type: AWS::Cognito::UserPool
     Properties:
@@ -388,11 +390,8 @@ Resources:
                 !If [UseCustomDomain, !Ref CustomDomain, !GetAtt PublicLoadBalancer.DNSName]
       AutoVerifiedAttributes:
         - email
-      EnabledMfas:
-        - SOFTWARE_TOKEN_MFA
       LambdaConfig:
         CustomMessage: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-users-api
-      MfaConfiguration: 'ON' # quotes required here, otherwise CFN interprets it as true because ???
       Policies:
         PasswordPolicy:
           MinimumLength: 12


### PR DESCRIPTION
## Background

#633 tried to configure MFA for Cognito user pools in CloudFormation. It turns out that worked only on an *existing* deployment, fresh deployments from master fail with:

> SMS configuration and Auto verification for phone_number are required when MFA is required/optional

We *only* allow software token MFA, because SMS is not as secure. But CloudFormation literally cannot configure a user pool without SMS MFA (unless it already exists, apparently). I tried a couple workarounds (e.g. specifying dummy values for the SMS config block), but no luck - CFN forces real SMS MFA.

So we're forced to revert to what we were doing before - enable MFA on the user pool manually via the SDK

## Changes

- Revert part of #633, adding more comments explaining why we have to do it that way

## Testing

- Fresh deploy from master