### PR TITLE
Verifying IP addresses

### DIFF
--- a/internal/log_analysis/log_processor/parsers/awslogs/alb.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/alb.go
@@ -177,7 +177,8 @@ func (p *ALBParser) LogType() string {
 
 func (event *ALB) updatePantherFields(p *ALBParser) {
 	event.SetCoreFields(p.LogType(), event.Timestamp, event)
-	event.AppendAnyIPAddressPtrs(event.ClientIP, event.TargetIP)
+	event.AppendAnyIPAddressPtr(event.ClientIP)
+	event.AppendAnyIPAddressPtr(event.TargetIP)
 	event.AppendAnyDomainNamePtrs(event.DomainName)
 	event.AppendAnyAWSARNPtrs(event.ChosenCertARN, event.TargetGroupARN)
 }

--- a/internal/log_analysis/log_processor/parsers/awslogs/alb_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/alb_test.go
@@ -72,7 +72,8 @@ func TestHTTPLog(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.ALB")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("192.168.131.39", "10.0.0.1")
+	expectedEvent.AppendAnyIPAddress("192.168.131.39")
+	expectedEvent.AppendAnyIPAddress("10.0.0.1")
 	expectedEvent.AppendAnyAWSARNs("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067")
 
 	checkALBLog(t, log, expectedEvent)
@@ -123,7 +124,8 @@ func TestHTTPSLog(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.ALB")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("192.168.131.39", "10.0.0.1")
+	expectedEvent.AppendAnyIPAddress("192.168.131.39")
+	expectedEvent.AppendAnyIPAddress("10.0.0.1")
 	expectedEvent.AppendAnyDomainNames("www.example.com")
 	expectedEvent.AppendAnyAWSARNs("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067",
 		"arn:aws:acm:us-east-2:123456789012:certificate/12345678-1234-1234-1234-123456789012")
@@ -176,7 +178,8 @@ func TestHTTP2Log(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.ALB")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("10.0.1.252", "10.0.0.66")
+	expectedEvent.AppendAnyIPAddress("10.0.1.252")
+	expectedEvent.AppendAnyIPAddress("10.0.0.66")
 	expectedEvent.AppendAnyAWSARNs("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067")
 
 	checkALBLog(t, log, expectedEvent)
@@ -226,7 +229,7 @@ func TestHTTPSNoTarget(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.ALB")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("138.246.253.5")
+	expectedEvent.AppendAnyIPAddress("138.246.253.5")
 	expectedEvent.AppendAnyAWSARNs("arn:aws:acm:us-east-1:050603629990:certificate/bedab50c-9007-4ee9-89a5-d1929edb364c")
 
 	checkALBLog(t, log, expectedEvent)

--- a/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit.go
@@ -119,6 +119,6 @@ func (p *AuroraMySQLAuditParser) LogType() string {
 
 func (event *AuroraMySQLAudit) updatePantherFields(p *AuroraMySQLAuditParser) {
 	event.SetCoreFields(p.LogType(), event.Timestamp, event)
-	event.AppendAnyIPAddressPtrs(event.Host)
+	event.AppendAnyIPAddressPtr(event.Host)
 	event.AppendAnyDomainNamePtrs(event.ServerHost)
 }

--- a/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit_test.go
@@ -53,7 +53,7 @@ func TestAuroraMySQLAuditLog(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.AuroraMySQLAudit")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("10.0.143.147")
+	expectedEvent.AppendAnyIPAddress("10.0.143.147")
 	expectedEvent.AppendAnyDomainNames("db-instance-name")
 
 	checkAuroraMysqlAuditLogLog(t, log, expectedEvent)

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail.go
@@ -19,8 +19,6 @@ package awslogs
  */
 
 import (
-	"strings"
-
 	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 
@@ -156,9 +154,7 @@ func (event *CloudTrail) updatePantherFields(p *CloudTrailParser) {
 	event.SetCoreFields(p.LogType(), event.EventTime, event)
 
 	// structured (parsed) fields
-	if event.SourceIPAddress != nil && !strings.HasSuffix(*event.SourceIPAddress, "amazonaws.com") {
-		event.AppendAnyIPAddresses(*event.SourceIPAddress)
-	}
+	event.AppendAnyIPAddressPtr(event.SourceIPAddress)
 
 	for _, resource := range event.Resources {
 		event.AppendAnyAWSARNPtrs(resource.ARN)

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_test.go
@@ -133,7 +133,7 @@ func TestCloudTrailLogDecrypt(t *testing.T) {
 		"arn:aws:sts::888888888888:assumed-role/panther-app-LogProcessor-XXXXXXXXXXXX-FunctionRole-XXXXXXXXXX/panther-log-processor",
 		"arn:aws:lambda:us-east-1:888888888888:function:panther-log-processor")
 	expectedEvent.AppendAnyAWSAccountIds("888888888888")
-	expectedEvent.AppendAnyIPAddresses("1.2.3.4")
+	expectedEvent.AppendAnyIPAddress("1.2.3.4")
 
 	checkCloudTrailLog(t, log, []*CloudTrail{expectedEvent})
 }

--- a/internal/log_analysis/log_processor/parsers/awslogs/extractor.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/extractor.go
@@ -99,7 +99,7 @@ func (e *AWSExtractor) Extract(key, value gjson.Result) {
 	case "ipv6Addresses": // found in instanceDetails in CloudTrail and GuardDuty (perhaps others)
 		if value.IsArray() {
 			value.ForEach(func(v6ListKey, v6ListValue gjson.Result) bool {
-				e.pl.AppendAnyIPAddresses(v6ListValue.Str)
+				e.pl.AppendAnyIPAddress(v6ListValue.Str)
 				return true
 			})
 		}
@@ -108,7 +108,7 @@ func (e *AWSExtractor) Extract(key, value gjson.Result) {
 		"publicIp",         // found in instanceDetails in CloudTrail and GuardDuty (perhaps others)
 		"privateIpAddress", // found in instanceDetails in CloudTrail and GuardDuty (perhaps others)
 		"ipAddressV4":      // found in GuardDuty findings
-		e.pl.AppendAnyIPAddresses(value.Str)
+		e.pl.AppendAnyIPAddress(value.Str)
 
 	case
 		"publicDnsName",  // found in instanceDetails in CloudTrail and GuardDuty (perhaps others)

--- a/internal/log_analysis/log_processor/parsers/awslogs/extractor_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/extractor_test.go
@@ -131,8 +131,10 @@ func TestAWSExtractor(t *testing.T) {
 		"arn:aws:ec2:region:111122223333:instance/")
 	expectedEvent.AppendAnyAWSInstanceIds("i-081de1d7604b11e4a", "i-0072230f74b3a798e" /* from ARN */)
 	expectedEvent.AppendAnyAWSAccountIds("123456789012", "888888888888" /* from ARN */, "111122223333" /* from ARN */)
-	expectedEvent.AppendAnyIPAddresses("54.152.215.140", "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		"172.31.81.237", "151.80.19.228")
+	expectedEvent.AppendAnyIPAddress("54.152.215.140")
+	expectedEvent.AppendAnyIPAddress("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+	expectedEvent.AppendAnyIPAddress("172.31.81.237")
+	expectedEvent.AppendAnyIPAddress("151.80.19.228")
 	expectedEvent.AppendAnyAWSTags("tag1:val1")
 	expectedEvent.AppendAnyDomainNames("ec2-54-152-215-140.compute-1.amazonaws.com", "GeneratedFindingDomainName",
 		"ip-172-31-81-237.ec2.internal")

--- a/internal/log_analysis/log_processor/parsers/awslogs/guardduty_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/guardduty_test.go
@@ -66,7 +66,7 @@ func TestGuardDutyLogIAMUserLoggingConfigurationModified(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.GuardDuty")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedDate)
-	expectedEvent.AppendAnyIPAddresses("198.51.100.0")
+	expectedEvent.AppendAnyIPAddress("198.51.100.0")
 	expectedEvent.AppendAnyAWSAccountIds("123456789012")
 	// nolint(lll)
 	expectedEvent.AppendAnyAWSARNs("arn:aws:guardduty:eu-west-1:123456789012:detector/b2b7c4e8df224d1b74bece34cc2cf1d5/finding/44b7c4e9781822beb75d3fbd518abf5b")
@@ -159,8 +159,10 @@ func TestGuardDutyLogSSHBruteForce(t *testing.T) {
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedDate)
 	expectedEvent.AppendAnyAWSInstanceIds("i-081de1d7604b11e4a")
 	expectedEvent.AppendAnyAWSAccountIds("123456789012")
-	expectedEvent.AppendAnyIPAddresses("54.152.215.140",
-		"151.80.19.228", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "172.31.81.237")
+	expectedEvent.AppendAnyIPAddress("54.152.215.140")
+	expectedEvent.AppendAnyIPAddress("151.80.19.228")
+	expectedEvent.AppendAnyIPAddress("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+	expectedEvent.AppendAnyIPAddress("172.31.81.237")
 	expectedEvent.AppendAnyAWSTags("tag1:val1")
 	expectedEvent.AppendAnyDomainNames("ec2-54-152-215-140.compute-1.amazonaws.com", "ip-172-31-81-237.ec2.internal")
 	expectedEvent.AppendAnyAWSARNs("arn:aws:iam::123456789012:instance-profile/EC2Dev",

--- a/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access.go
@@ -154,7 +154,7 @@ func (p *S3ServerAccessParser) LogType() string {
 
 func (event *S3ServerAccess) updatePantherFields(p *S3ServerAccessParser) {
 	event.SetCoreFields(p.LogType(), event.Time, event)
-	event.AppendAnyIPAddressPtrs(event.RemoteIP)
+	event.AppendAnyIPAddressPtr(event.RemoteIP)
 	if event.Requester != nil && strings.HasPrefix(*event.Requester, "arn:") {
 		event.AppendAnyAWSARNs(*event.Requester)
 	}

--- a/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access_test.go
@@ -58,7 +58,7 @@ func TestS3AccessLogGetHttpOk(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.S3ServerAccess")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&date)
-	expectedEvent.AppendAnyIPAddresses("192.0.2.3")
+	expectedEvent.AppendAnyIPAddress("192.0.2.3")
 
 	checkS3AccessLog(t, log, expectedEvent)
 }
@@ -93,7 +93,7 @@ func TestS3AccessLogGetHttpNotFound(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.S3ServerAccess")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&date)
-	expectedEvent.AppendAnyIPAddresses("192.0.2.3")
+	expectedEvent.AppendAnyIPAddress("192.0.2.3")
 
 	checkS3AccessLog(t, log, expectedEvent)
 }
@@ -129,7 +129,7 @@ func TestS3AccessLogPutHttpOK(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.S3ServerAccess")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&date)
-	expectedEvent.AppendAnyIPAddresses("192.0.2.3")
+	expectedEvent.AppendAnyIPAddress("192.0.2.3")
 	expectedEvent.AppendAnyAWSARNs("arn:aws:sts::123456789012:assumed-role/PantherLogProcessingRole/1579693334126446707")
 
 	checkS3AccessLog(t, log, expectedEvent)
@@ -167,7 +167,7 @@ func TestS3AccessLogPutHttpOKExtraFields(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.S3ServerAccess")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&date)
-	expectedEvent.AppendAnyIPAddresses("192.0.2.3")
+	expectedEvent.AppendAnyIPAddress("192.0.2.3")
 
 	checkS3AccessLog(t, log, expectedEvent)
 }

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow.go
@@ -266,5 +266,8 @@ func (event *VPCFlow) updatePantherFields(p *VPCFlowParser) {
 	event.SetCoreFields(p.LogType(), event.Start, event)
 	event.AppendAnyAWSAccountIdPtrs(event.AccountID)
 	event.AppendAnyAWSInstanceIdPtrs(event.InstanceID)
-	event.AppendAnyIPAddressPtrs(event.SrcAddr, event.DstAddr, event.PacketSrcAddr, event.PacketDstAddr)
+	event.AppendAnyIPAddressPtr(event.SrcAddr)
+	event.AppendAnyIPAddressPtr(event.DstAddr)
+	event.AppendAnyIPAddressPtr(event.PacketSrcAddr)
+	event.AppendAnyIPAddressPtr(event.PacketDstAddr)
 }

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow_test.go
@@ -60,7 +60,8 @@ func TestStandardVpcFlowLog(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.VPCFlow")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedStartTime)
-	expectedEvent.AppendAnyIPAddresses("172.31.20.31", "52.119.169.95")
+	expectedEvent.AppendAnyIPAddress("172.31.20.31")
+	expectedEvent.AppendAnyIPAddress("52.119.169.95")
 	expectedEvent.AppendAnyAWSAccountIds("348372346321")
 
 	checkVPCFlowLog(t, vpcFlowDefaultHeader, log, expectedEvent)
@@ -99,7 +100,10 @@ func TestExtendedVpcFlowLog(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("AWS.VPCFlow")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedStartTime)
-	expectedEvent.AppendAnyIPAddresses("172.31.20.31", "52.119.169.95", "76.198.154.105", "172.31.88.3")
+	expectedEvent.AppendAnyIPAddress("172.31.20.31")
+	expectedEvent.AppendAnyIPAddress("52.119.169.95")
+	expectedEvent.AppendAnyIPAddress("76.198.154.105")
+	expectedEvent.AppendAnyIPAddress("172.31.88.3")
 	expectedEvent.AppendAnyAWSAccountIds("348372346321")
 	expectedEvent.AppendAnyAWSInstanceIds("i-038407d32b0f38c60")
 

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
@@ -19,8 +19,6 @@ package fluentdsyslogs
  */
 
 import (
-	"net"
-
 	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 
@@ -79,14 +77,10 @@ func (p *RFC3164Parser) LogType() string {
 
 func (event *RFC3164) updatePantherFields(p *RFC3164Parser) {
 	event.SetCoreFields(p.LogType(), (*timestamp.RFC3339)(event.Timestamp), event)
-	if event.Hostname != nil {
-		// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
-		// add as a domain name. https://tools.ietf.org/html/rfc3164#section-6.2.4
-		hostname := *event.Hostname
-		if net.ParseIP(hostname) != nil {
-			event.AppendAnyIPAddresses(hostname)
-		} else {
-			event.AppendAnyDomainNames(hostname)
-		}
+
+	// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
+	// add as a domain name. https://tools.ietf.org/html/rfc3164#section-6.2.4
+	if !event.AppendAnyIPAddressPtr(event.Hostname) {
+		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
 }

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
@@ -19,8 +19,6 @@ package fluentdsyslogs
  */
 
 import (
-	"net"
-
 	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 
@@ -81,14 +79,10 @@ func (p *RFC5424Parser) LogType() string {
 
 func (event *RFC5424) updatePantherFields(p *RFC5424Parser) {
 	event.SetCoreFields(p.LogType(), (*timestamp.RFC3339)(event.Timestamp), event)
-	if event.Hostname != nil {
-		// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
-		// add as a domain name. https://tools.ietf.org/html/rfc3164#section-6.2.4
-		hostname := *event.Hostname
-		if net.ParseIP(hostname) != nil {
-			event.AppendAnyIPAddresses(hostname)
-		} else {
-			event.AppendAnyDomainNames(hostname)
-		}
+
+	// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
+	// add as a domain name. https://tools.ietf.org/html/rfc5424#section-6.2.4
+	if !event.AppendAnyIPAddressPtr(event.Hostname) {
+		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
 }

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424_test.go
@@ -49,7 +49,7 @@ func TestRFC5424(t *testing.T) {
 
 	// panther fields
 	expectedRFC5424.PantherLogType = aws.String("Fluentd.Syslog5424")
-	expectedRFC5424.AppendAnyIPAddressPtrs(expectedRFC5424.Hostname)
+	expectedRFC5424.AppendAnyIPAddressPtr(expectedRFC5424.Hostname)
 	expectedRFC5424.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
 	checkRFC5424(t, log, expectedRFC5424)
 }

--- a/internal/log_analysis/log_processor/parsers/nginxlogs/access.go
+++ b/internal/log_analysis/log_processor/parsers/nginxlogs/access.go
@@ -126,5 +126,5 @@ func (p *AccessParser) LogType() string {
 
 func (event *Access) updatePantherFields(p *AccessParser) {
 	event.SetCoreFields(p.LogType(), event.Time, event)
-	event.AppendAnyIPAddressPtrs(event.RemoteAddress)
+	event.AppendAnyIPAddressPtr(event.RemoteAddress)
 }

--- a/internal/log_analysis/log_processor/parsers/nginxlogs/access_test.go
+++ b/internal/log_analysis/log_processor/parsers/nginxlogs/access_test.go
@@ -48,7 +48,7 @@ func TestAccessLog(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("Nginx.Access")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("180.76.15.143")
+	expectedEvent.AppendAnyIPAddress("180.76.15.143")
 
 	checkAccessLog(t, log, expectedEvent)
 }
@@ -71,7 +71,7 @@ func TestAccessLogWithoutReferer(t *testing.T) {
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("Nginx.Access")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
-	expectedEvent.AppendAnyIPAddresses("180.76.15.143")
+	expectedEvent.AppendAnyIPAddress("180.76.15.143")
 
 	checkAccessLog(t, log, expectedEvent)
 }

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/differential.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/differential.go
@@ -19,8 +19,6 @@ package osquerylogs
  */
 
 import (
-	"net"
-
 	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 
@@ -92,11 +90,6 @@ func (event *Differential) updatePantherFields(p *DifferentialParser) {
 	event.SetCoreFields(p.LogType(), (*timestamp.RFC3339)(event.CalendarTime), event)
 	event.AppendAnyDomainNamePtrs(event.HostIdentifier)
 
-	if net.ParseIP(event.Columns["local_address"]) != nil {
-		event.AppendAnyIPAddresses(event.Columns["local_address"])
-	}
-
-	if net.ParseIP(event.Columns["remote_address"]) != nil {
-		event.AppendAnyIPAddresses(event.Columns["remote_address"])
-	}
+	event.AppendAnyIPAddress(event.Columns["local_address"])
+	event.AppendAnyIPAddress(event.Columns["remote_address"])
 }

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/differential_test.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/differential_test.go
@@ -90,7 +90,8 @@ func TestDifferentialLogWithExtraIps(t *testing.T) {
 	expectedEvent.PantherLogType = aws.String("Osquery.Differential")
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
 	expectedEvent.AppendAnyDomainNames("Quans-MacBook-Pro-2.local")
-	expectedEvent.AppendAnyIPAddresses("192.168.1.1", "192.168.1.2")
+	expectedEvent.AppendAnyIPAddress("192.168.1.1")
+	expectedEvent.AppendAnyIPAddress("192.168.1.2")
 
 	checkOsQueryDifferentialLog(t, log, expectedEvent)
 }

--- a/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo.go
+++ b/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo.go
@@ -148,7 +148,8 @@ func (p *EventInfoParser) LogType() string {
 
 func (event *EventInfo) updatePantherFields(p *EventInfoParser) {
 	event.SetCoreFields(p.LogType(), (*timestamp.RFC3339)(event.Timestamp), event)
-	event.AppendAnyIPAddressPtrs(event.SrcIP, event.DstIP)
+	event.AppendAnyIPAddressPtr(event.SrcIP)
+	event.AppendAnyIPAddressPtr(event.DstIP)
 	if event.SyscheckFile != nil {
 		event.AppendAnyMD5HashPtrs(event.SyscheckFile.MD5Before, event.SyscheckFile.MD5After)
 		event.AppendAnySHA1HashPtrs(event.SyscheckFile.SHA1Before, event.SyscheckFile.SHA1After)

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -19,6 +19,7 @@ package parsers
  */
 
 import (
+	"net"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -125,19 +126,23 @@ func (pl *PantherLog) SetCoreFields(logType string, eventTime *timestamp.RFC3339
 	pl.PantherParseTime = &parseTime
 }
 
-func (pl *PantherLog) AppendAnyIPAddressPtrs(values ...*string) {
-	for _, value := range values {
-		if value != nil {
-			pl.AppendAnyIPAddresses(*value)
-		}
+// Will return true if the IP address was successfully appended, false if the value was not an IP
+func (pl *PantherLog) AppendAnyIPAddressPtr(value *string) bool {
+	if value == nil {
+		return false
 	}
+	return pl.AppendAnyIPAddress(*value)
 }
 
-func (pl *PantherLog) AppendAnyIPAddresses(values ...string) {
-	if pl.PantherAnyIPAddresses == nil { // lazy create
-		pl.PantherAnyIPAddresses = NewPantherAnyString()
+func (pl *PantherLog) AppendAnyIPAddress(value string) bool {
+	if net.ParseIP(value) != nil {
+		if pl.PantherAnyIPAddresses == nil { // lazy create
+			pl.PantherAnyIPAddresses = NewPantherAnyString()
+		}
+		AppendAnyString(pl.PantherAnyIPAddresses, value)
+		return true
 	}
-	AppendAnyString(pl.PantherAnyIPAddresses, values...)
+	return false
 }
 
 func (pl *PantherLog) AppendAnyDomainNamePtrs(values ...*string) {

--- a/internal/log_analysis/log_processor/parsers/pantherlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 
@@ -139,19 +140,33 @@ func TestSetCoreFieldsNilEventTime(t *testing.T) {
 	require.Equal(t, expectedEvent, event)
 }
 
-func TestAppendAnyIPAddresses(t *testing.T) {
+func TestAppendAnyIPV4(t *testing.T) {
 	event := PantherLog{}
-	value := "a"
+	require.True(t, event.AppendAnyIPAddressPtr(aws.String("192.168.1.1")))
+	require.True(t, event.AppendAnyIPAddress("192.168.1.2"))
+	require.False(t, event.AppendAnyIPAddress("not-an-ip"))
+
 	expectedAny := &PantherAnyString{
 		set: map[string]struct{}{
-			value: {},
+			"192.168.1.1": {},
+			"192.168.1.2": {},
 		},
 	}
-	event.AppendAnyIPAddresses(value)
 	require.Equal(t, expectedAny, event.PantherAnyIPAddresses)
+}
 
-	event = PantherLog{}
-	event.AppendAnyIPAddressPtrs(&value)
+func TestAppendAnyIPV6(t *testing.T) {
+	event := PantherLog{}
+	require.True(t, event.AppendAnyIPAddressPtr(aws.String("2001:db8:85a3:0:0:8a2e:370:7334")))
+	require.True(t, event.AppendAnyIPAddress("::ffff:192.0.2.128"))
+	require.False(t, event.AppendAnyIPAddress("not-an-ip"))
+
+	expectedAny := &PantherAnyString{
+		set: map[string]struct{}{
+			"2001:db8:85a3:0:0:8a2e:370:7334": {},
+			"::ffff:192.0.2.128":              {},
+		},
+	}
 	require.Equal(t, expectedAny, event.PantherAnyIPAddresses)
 }
 

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
@@ -20,7 +20,6 @@ package sysloglogs
 
 import (
 	"errors"
-	"net"
 	"time"
 
 	"github.com/influxdata/go-syslog/v3"
@@ -110,14 +109,9 @@ func (p *RFC3164Parser) LogType() string {
 func (event *RFC3164) updatePantherFields(p *RFC3164Parser) {
 	event.SetCoreFields(p.LogType(), event.Timestamp, event)
 
-	if event.Hostname != nil {
-		// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
-		// add as a domain name. https://tools.ietf.org/html/rfc3164#section-6.2.4
-		hostname := *event.Hostname
-		if net.ParseIP(hostname) != nil {
-			event.AppendAnyIPAddresses(hostname)
-		} else {
-			event.AppendAnyDomainNames(hostname)
-		}
+	// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
+	// add as a domain name. https://tools.ietf.org/html/rfc3164#section-6.2.4
+	if !event.AppendAnyIPAddressPtr(event.Hostname) {
+		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
 }

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
@@ -147,7 +147,7 @@ func testRFC3164Example2(t *testing.T) {
 		Message:   aws.String("Use the BFG!"),
 	}
 
-	expectedEvent.AppendAnyIPAddressPtrs(expectedEvent.Hostname)
+	expectedEvent.AppendAnyIPAddressPtr(expectedEvent.Hostname)
 
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("Syslog.RFC3164")

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424.go
@@ -20,7 +20,6 @@ package sysloglogs
 
 import (
 	"errors"
-	"net"
 
 	"github.com/influxdata/go-syslog/v3"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
@@ -108,14 +107,9 @@ func (p *RFC5424Parser) LogType() string {
 func (event *RFC5424) updatePantherFields(p *RFC5424Parser) {
 	event.SetCoreFields(p.LogType(), event.Timestamp, event)
 
-	if event.Hostname != nil {
-		// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
-		// add as a domain name. https://tools.ietf.org/html/rfc5424#section-6.2.4
-		hostname := *event.Hostname
-		if net.ParseIP(hostname) != nil {
-			event.AppendAnyIPAddresses(hostname)
-		} else {
-			event.AppendAnyDomainNames(hostname)
-		}
+	// The hostname should be a FQDN, but may also be an IP address. Check for IP, otherwise
+	// add as a domain name. https://tools.ietf.org/html/rfc5424#section-6.2.4
+	if !event.AppendAnyIPAddressPtr(event.Hostname) {
+		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
 }

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424_test.go
@@ -160,7 +160,7 @@ func testRFC5424NoStructuredDataNoMsgID(t *testing.T) {
 		StructuredData: nil,
 	}
 
-	expectedEvent.AppendAnyIPAddressPtrs(expectedEvent.Hostname)
+	expectedEvent.AppendAnyIPAddressPtr(expectedEvent.Hostname)
 
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("Syslog.RFC5424")

--- a/internal/log_analysis/log_processor/parsers/zeeklogs/dns_test.go
+++ b/internal/log_analysis/log_processor/parsers/zeeklogs/dns_test.go
@@ -59,8 +59,8 @@ func TestZeekDNS(t *testing.T) {
 
 	// panther fields
 	expectedEvent.PantherLogType = aws.String("Zeek.DNS")
-	expectedEvent.AppendAnyIPAddressPtrs(expectedEvent.IDOrigH)
-	expectedEvent.AppendAnyIPAddressPtrs(expectedEvent.IDRespH)
+	expectedEvent.AppendAnyIPAddressPtr(expectedEvent.IDOrigH)
+	expectedEvent.AppendAnyIPAddressPtr(expectedEvent.IDRespH)
 	expectedEvent.AppendAnyDomainNamePtrs(expectedEvent.Query)
 	expectedEvent.AppendAnyDomainNames(expectedEvent.Answers[0])
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)


### PR DESCRIPTION
## Background

Verifying that a field is a valid IP address before adding it to the "any" field. This helps avoid issues like adding a "domain" as an IP domain (seems to appear very often in our fields) and protect us from mistakes in the parser code in the future.
Using the `net.ParseIP` library from golang which seems to be pretty efficient (Olog(N))

## Changes

- Added `AppendAnyIPAddressPtr` and `AppendAnyIPAddress` methods. These methods will attempt to add an IP address to the `any IP address` field. The method returns true if the value was an IP address, false otherwise. This feedback seems to be useful for some parts of the code. 
- Removed `AppendAnyIPAddresses` and `AppendAnyIPAddressesPtr`. I felt that having 4 methods for adding IP addresses might be an overkill.  This lead to some extra verbosity in some parts of the code, mostly tests, but I though that might be better approach than have 2 more methods in a lower-level package. It's my personal preference but don't feel strongly about this, if someone feel more strongly about this i can keep the old methods (with the IP verification) and add the new ones. 
- Fixed typo in file name. `patherlog.go` -> `pantherlog.go`

## Testing

- Unit testing. 
