### PR TITLE
Filtering based on "free" text field passed encode data to API

### DIFF
--- a/web/src/hooks/useRequestParamsWithPagination.tsx
+++ b/web/src/hooks/useRequestParamsWithPagination.tsx
@@ -30,8 +30,8 @@ function useRequestParamsWithPagination<
   const updateRequestParamsAndResetPaging = React.useCallback(
     (newParams: Partial<AvailableParams>) => {
       const params = { ...urlParams, ...newParams, page: 1 };
-      if (params.idContains) params.idContains = encodeURI(newParams.idContains);
-      if (params.nameContains) params.nameContains = encodeURI(newParams.nameContains);
+      if (params.idContains) params.idContains = encodeURIComponent(newParams.idContains);
+      if (params.nameContains) params.nameContains = encodeURIComponent(newParams.nameContains);
       updateUrlParams(params);
     },
     [urlParams]

--- a/web/src/hooks/useRequestParamsWithPagination.tsx
+++ b/web/src/hooks/useRequestParamsWithPagination.tsx
@@ -19,7 +19,9 @@
 import React from 'react';
 import useUrlParams from 'Hooks/useUrlParams';
 
-function useRequestParamsWithPagination<AvailableParams extends { page?: number }>() {
+function useRequestParamsWithPagination<
+  AvailableParams extends { page?: number; idContains?: string; nameContains?: string }
+>() {
   const { urlParams, updateUrlParams } = useUrlParams<Partial<AvailableParams>>();
 
   // This is our typical function that updates the parameters with the addition of resetting the
@@ -27,7 +29,10 @@ function useRequestParamsWithPagination<AvailableParams extends { page?: number 
   // scenario, we want to change the params but not reset the page.
   const updateRequestParamsAndResetPaging = React.useCallback(
     (newParams: Partial<AvailableParams>) => {
-      updateUrlParams({ ...urlParams, ...newParams, page: 1 });
+      const params = { ...urlParams, ...newParams, page: 1 };
+      if (params.idContains) params.idContains = encodeURI(newParams.idContains);
+      if (params.nameContains) params.nameContains = encodeURI(newParams.nameContains);
+      updateUrlParams(params);
     },
     [urlParams]
   );


### PR DESCRIPTION
## Background

Initial problem from issue #576 : 

> Filtering Resources with quotes in the name returns all result

This PR addresses this issue by url encoding all free text fields for `names` and `ids`
Specifically: 
 - Cloud Security -> Policies, Resources
 - Log Analysis -> Rules

Closes #576
## Changes

- Encode params `idContains` & `nameContains` on `updateRequestParams`

## Testing

- Locally
