### PR TITLE
Change onboarding check

### DIFF
--- a/tools/mage/deploy_onboard.go
+++ b/tools/mage/deploy_onboard.go
@@ -101,8 +101,7 @@ func registerPantherAccount(awsSession *session.Session, settings *config.Panthe
 	registerCloudSec, registerLogProcessing := true, true
 	for _, integration := range listOutput {
 		if *integration.AWSAccountID == accountID &&
-			*integration.IntegrationType == models.IntegrationTypeAWSScan &&
-			*integration.IntegrationLabel == cloudSecLabel {
+			*integration.IntegrationType == models.IntegrationTypeAWSScan {
 
 			logger.Infof("deploy: account %s is already registered for cloud security", accountID)
 			registerCloudSec = false


### PR DESCRIPTION
## Background

When upgrading Panther, the self onboarding step assumes that users have not changed the label for the self onboarded cloud security source. In at least one of our internal deployments, this is not the case. This assumption doesn't break anything, but it causes an error to be logged in the backend which sets off alarms and pages people. Updating this check to be more accurate to how the backend performs the same check.

## Changes

- Update the checks performed to determine whether self onboarding is necessary

## Testing

- Deployed in dev account, upgraded, observed error. Made changes, deployed, no error observed.