### PR TITLE
Filtering based on "free" text field passed encode data to API 

### DIFF
--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -109,7 +109,7 @@ export const minutesToString = (minutes: number) =>
 export const convertObjArrayValuesToCsv = (obj: { [key: string]: any }) =>
   mapValues(obj, v => (Array.isArray(v) ? v.join(',') : v));
 
-/** URI encoding for specified fields from object */
+/** URI encoding for specified fields in object */
 export const encodeParams = (obj: { [key: string]: any }, fields: [string]) => {
   const encodedObj = { ...obj };
   fields.forEach(field => {

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -109,6 +109,7 @@ export const minutesToString = (minutes: number) =>
 export const convertObjArrayValuesToCsv = (obj: { [key: string]: any }) =>
   mapValues(obj, v => (Array.isArray(v) ? v.join(',') : v));
 
+/** URI encoding for specified fields from object */
 export const encodeParams = (obj: { [key: string]: any }, fields: [string]) => {
   const encodedObj = { ...obj };
   fields.forEach(field => {

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -109,6 +109,14 @@ export const minutesToString = (minutes: number) =>
 export const convertObjArrayValuesToCsv = (obj: { [key: string]: any }) =>
   mapValues(obj, v => (Array.isArray(v) ? v.join(',') : v));
 
+export const encodeParams = (obj: { [key: string]: any }, fields: [string]) => {
+  const encodedObj = { ...obj };
+  fields.forEach(field => {
+    if (obj[field]) encodedObj[field] = encodeURIComponent(obj[field]);
+  });
+  return encodedObj;
+};
+
 /**
  * makes sure that it properly formats a JSON struct in order to be properly displayed within the
  * editor

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -110,14 +110,8 @@ export const convertObjArrayValuesToCsv = (obj: { [key: string]: any }) =>
   mapValues(obj, v => (Array.isArray(v) ? v.join(',') : v));
 
 /** URI encoding for specified fields in object */
-export const encodeParams = (obj: { [key: string]: any }, fields: [string]) => {
-  const encodedObj = { ...obj };
-  fields.forEach(field => {
-    if (obj[field]) encodedObj[field] = encodeURIComponent(obj[field]);
-  });
-  return encodedObj;
-};
-
+export const encodeParams = (obj: { [key: string]: any }, fields: [string]) =>
+  mapValues(obj, (v, key) => (fields.includes(key) ? encodeURIComponent(v) : v));
 /**
  * makes sure that it properly formats a JSON struct in order to be properly displayed within the
  * editor

--- a/web/src/pages/ListPolicies/ListPolicies.tsx
+++ b/web/src/pages/ListPolicies/ListPolicies.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { Alert, Box, Card } from 'pouncejs';
 import { DEFAULT_LARGE_PAGE_SIZE } from 'Source/constants';
-import { convertObjArrayValuesToCsv, extractErrorMessage } from 'Helpers/utils';
+import { convertObjArrayValuesToCsv, encodeParams, extractErrorMessage } from 'Helpers/utils';
 import { ListPoliciesInput, SortDirEnum, ListPoliciesSortFieldsEnum } from 'Generated/schema';
 import { TableControlsPagination } from 'Components/utils/TableControls';
 import useRequestParamsWithPagination from 'Hooks/useRequestParamsWithPagination';
@@ -41,7 +41,7 @@ const ListPolicies = () => {
   const { loading, error, data } = useListPolicies({
     fetchPolicy: 'cache-and-network',
     variables: {
-      input: convertObjArrayValuesToCsv(requestParams),
+      input: encodeParams(convertObjArrayValuesToCsv(requestParams), ['nameContains']),
     },
   });
 

--- a/web/src/pages/ListResources/ListResources.tsx
+++ b/web/src/pages/ListResources/ListResources.tsx
@@ -23,6 +23,7 @@ import { ListResourcesInput, ListResourcesSortFieldsEnum, SortDirEnum } from 'Ge
 import { TableControlsPagination } from 'Components/utils/TableControls';
 import {
   convertObjArrayValuesToCsv,
+  encodeParams,
   extendResourceWithIntegrationLabel,
   extractErrorMessage,
 } from 'Helpers/utils';
@@ -45,7 +46,7 @@ const ListResources = () => {
   const { loading, data, error } = useListResources({
     fetchPolicy: 'cache-and-network',
     variables: {
-      input: convertObjArrayValuesToCsv(requestParams),
+      input: encodeParams(convertObjArrayValuesToCsv(requestParams), ['idContains']),
     },
   });
   if (loading && !data) {

--- a/web/src/pages/ListRules/ListRules.tsx
+++ b/web/src/pages/ListRules/ListRules.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { Alert, Box, Card } from 'pouncejs';
 import { DEFAULT_LARGE_PAGE_SIZE } from 'Source/constants';
-import { convertObjArrayValuesToCsv, extractErrorMessage } from 'Helpers/utils';
+import { convertObjArrayValuesToCsv, extractErrorMessage, encodeParams } from 'Helpers/utils';
 import { ListRulesInput, SortDirEnum, ListRulesSortFieldsEnum } from 'Generated/schema';
 import { TableControlsPagination } from 'Components/utils/TableControls';
 import useRequestParamsWithPagination from 'Hooks/useRequestParamsWithPagination';
@@ -41,7 +41,7 @@ const ListRules = () => {
   const { loading, error, data } = useListRules({
     fetchPolicy: 'cache-and-network',
     variables: {
-      input: convertObjArrayValuesToCsv(requestParams),
+      input: encodeParams(convertObjArrayValuesToCsv(requestParams), ['nameContains']),
     },
   });
 


### PR DESCRIPTION
## Background

Initial problem from issue #576 : 

> Filtering Resources with quotes in the name returns all result

This PR addresses this issue by url encoding all free text fields for `names` and `ids`
Specifically: 
 - Cloud Security -> Policies, Resources
 - Log Analysis -> Rules

Related to #642
Closes #576

## Changes

- Added new util functions for encoding parameters
- Encode parameters in `ListPolicies`, `ListRules` and `ListResources`

## Testing

- Locally
