### PR TITLE
Fix error handling for 404 in compliance alert processor

### DIFF
--- a/internal/compliance/alert_processor/processor/processor.go
+++ b/internal/compliance/alert_processor/processor/processor.go
@@ -119,8 +119,10 @@ func shouldTriggerActions(event *models.ComplianceNotification) (bool, error) {
 			ResourceID: *event.ResourceID,
 			HTTPClient: httpClient,
 		})
-
 	if err != nil {
+		if _, ok := err.(*complianceoperations.GetStatusNotFound); ok {
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
## Changes
Do not error when getStatus returns a 404, just skip.

## Testing
mage test:ci
