### PR TITLE
Include CFN stack name as billing tag

### DIFF
--- a/tools/mage/deploy_template.go
+++ b/tools/mage/deploy_template.go
@@ -180,6 +180,10 @@ func createChangeSet(
 				Key:   aws.String("Application"),
 				Value: aws.String("Panther"),
 			},
+			{
+				Key:   aws.String("Stack"),
+				Value: &stack,
+			},
 		},
 	}
 


### PR DESCRIPTION
## Background

We need some sense of billing breakdown by component for Panther deployments, but manually tagging resources is fairly time consuming and not all resources support tagging.

It's much simpler to let CloudFormation automatically propagate tags to all supported resources, so for now we can just tag resources in each stack with that stack's name. That will identify Panther components as one of the following:

* `panther-bootstrap` - Critical common functionality like S3 buckets, networking, GraphQL API, KMS keys, etc. Most of the costs here will presumably be with the S3 buckets (all of which are defined in this stack)
* `panther-bootstrap-gateway` - API gateway
* `panther-cw-alarms`, `panther-cw-metric-filters`, `panther-cw-dashboards` - CloudWatch monitoring
* `panther-core` - shared services like `analysis-api` and `users-api`
* `panther-cloud-security` - snapshot polling, policy engine
* `panther-log-analysis` - log processor / classifier, rules engine
* `panther-web` - the running web task (not the load balancer itself)
* `panther-glue` - Athena and Glue catalog
* `panther-appsync` and `panther-onboard` will probably not have associated costs

Closes #443 

## Changes

- Add stack name as a tag when creating a change set

## Testing

- `mage test:ci`
