### PR TITLE
Cache dependencies in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,59 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      - restore_cache:
+          name: 'Restore cache: go modules'
+          keys:
+            - gomod2-{{ checksum "go.mod" }}
       - run:
-          name: Install dependencies
-          command: mage setup # TODO: cache these
+          # Start compiling mage in the background while other caches are restoring
+          name: Compile mage (background)
+          command: mage
+          background: true
+      - restore_cache:
+          name: 'Restore cache: npm'
+          keys:
+            - npm-{{ checksum "package-lock.json" }}
+      - restore_cache:
+          name: 'Restore cache: python env'
+          keys:
+            - venv-{{ checksum "requirements.txt" }}
+      - restore_cache:
+          name: 'Restore cache: .setup binaries'
+          keys:
+            - setup-{{ checksum "tools/mage/setup.go" }}
+
       - run:
-          name: Run all tests
+          # By this point, mage is compiled and all dependencies have been restored from the cache.
+          # "mage setup" will be a no-op unless new dependencies have been introduced.
+          name: Install new dependencies
+          command: mage setup
+
+      - save_cache:
+          name: 'Save cache: go modules'
+          key: gomod2-{{ checksum "go.mod" }}
+          paths:
+            - /go/pkg/mod
+      - save_cache:
+          name: 'Save cache: npm'
+          key: npm-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+      - save_cache:
+          name: 'Save cache: python env'
+          key: venv-{{ checksum "requirements.txt" }}
+          paths:
+            - .setup/venv
+      - save_cache:
+          name: 'Save cache: .setup binaries'
+          key: setup-{{ checksum "tools/mage/setup.go" }}
+          paths:
+            - .setup/golangci-lint
+            - .setup/swagger
+            - .setup/terraform
+
+      - run:
+          name: Run test suite
           command: mage test:ci
 
   npm_audit:

--- a/tools/mage/build_namespace.go
+++ b/tools/mage/build_namespace.go
@@ -144,13 +144,10 @@ func (b Build) Tools() {
 func (b Build) tools() error {
 	// cross compile so tools can be copied to other machines easily
 	buildEnvs := []map[string]string{
-		{"GOOS": "darwin", "GOARCH": "386"},
 		// darwin:arm is not compatible
 		{"GOOS": "darwin", "GOARCH": "amd64"},
-		{"GOOS": "linux", "GOARCH": "386"},
 		{"GOOS": "linux", "GOARCH": "amd64"},
 		{"GOOS": "linux", "GOARCH": "arm"},
-		{"GOOS": "windows", "GOARCH": "386"},
 		{"GOOS": "windows", "GOARCH": "amd64"},
 		{"GOOS": "windows", "GOARCH": "arm"},
 	}

--- a/tools/mage/build_namespace.go
+++ b/tools/mage/build_namespace.go
@@ -34,8 +34,6 @@ import (
 
 const swaggerGlob = "api/gateway/*/api.yml"
 
-var buildEnv = map[string]string{"GOARCH": "amd64", "GOOS": "linux"}
-
 // Build contains targets for compiling source code.
 type Build mg.Namespace
 
@@ -123,7 +121,7 @@ func (b Build) lambda() error {
 	errs := make(chan error)
 	for _, pkg := range packages {
 		go func(pkg string, errs chan error) {
-			errs <- buildPackage(pkg)
+			errs <- buildLambdaPackage(pkg)
 		}(pkg, errs)
 	}
 
@@ -144,52 +142,22 @@ func (b Build) Tools() {
 }
 
 func (b Build) tools() error {
-	if err := buildTools("devtools", "out/bin/devtools", "cmd/devtools"); err != nil {
-		return err
-	}
-	return buildTools("opstools", "out/bin/opstools", "cmd/opstools")
-}
-
-func buildTools(tools, binDir, sourceDir string) error {
 	// cross compile so tools can be copied to other machines easily
-	archs := []string{"amd64", "386", "arm"} // yes arm, AWS is now supporting arm processors and they are cheap!
-	oses := []string{"linux", "darwin", "windows"}
-	blacklist := map[string]bool{ // incompatible combinations
-		"darwin:arm": true,
+	buildEnvs := []map[string]string{
+		{"GOOS": "darwin", "GOARCH": "386"},
+		// darwin:arm is not compatible
+		{"GOOS": "darwin", "GOARCH": "amd64"},
+		{"GOOS": "linux", "GOARCH": "386"},
+		{"GOOS": "linux", "GOARCH": "amd64"},
+		{"GOOS": "linux", "GOARCH": "arm"},
+		{"GOOS": "windows", "GOARCH": "386"},
+		{"GOOS": "windows", "GOARCH": "amd64"},
+		{"GOOS": "windows", "GOARCH": "arm"},
 	}
 
-	applyBuildEnv := func(apply func(arch, opsys, binPath string) error) error {
-		for _, arch := range archs {
-			for _, opsys := range oses {
-				if blacklist[opsys+":"+arch] {
-					continue
-				}
-
-				if err := apply(arch, opsys, filepath.Join(binDir, opsys, arch)); err != nil {
-					return err
-				}
-			}
-		}
-
-		return nil
-	}
-
-	// create the dirs
-	err := applyBuildEnv(func(arch, opsys, binPath string) error {
-		if err := os.MkdirAll(binPath, 0755); err != nil {
-			return fmt.Errorf("failed to create %s directory: %v", binPath, err)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	logger.Infof("build:%s using %s for %s on %s",
-		tools, runtime.Version(), strings.Join(oses, ","), strings.Join(archs, ","))
-
-	// compile each app
-	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+	count := 0
+	results := make(chan error)
+	err := filepath.Walk("cmd", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -198,26 +166,39 @@ func buildTools(tools, binDir, sourceDir string) error {
 			return nil
 		}
 
-		return applyBuildEnv(func(arch, opsys, binPath string) error {
-			app := filepath.Dir(path)
-			logger.Debugf("build:%s compiling %s for %s on %s to %s",
-				tools, filepath.Base(app), opsys, arch, binPath)
+		// Build each os/arch combination in parallel
+		logger.Infof("build:tools: compiling %s for %d os/arch combinations", path, len(buildEnvs))
+		for _, env := range buildEnvs {
+			count++
+			go func(env map[string]string, path string, results chan error) {
+				outDir := filepath.Join("out", "bin", filepath.Dir(path),
+					env["GOOS"], env["GOARCH"], filepath.Base(filepath.Dir(path)))
+				results <- sh.RunWith(env, "go", "build", "-ldflags", "-s -w", "-o", outDir, "./"+path)
+			}(env, path, results)
+		}
 
-			if err = sh.RunWith(map[string]string{"GOARCH": arch, "GOOS": opsys},
-				"go", "build", "-ldflags", "-s -w", "-o", binPath, "./"+app); err != nil {
-				return fmt.Errorf("go build %s failed: %v", path, err)
-			}
-
-			return nil
-		})
+		return nil
 	})
+
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < count; i++ {
+		if err = <-results; err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func buildPackage(pkg string) error {
+func buildLambdaPackage(pkg string) error {
 	targetDir := filepath.Join("out", "bin", pkg)
 	binary := filepath.Join(targetDir, "main")
 	oldInfo, statErr := os.Stat(binary)
 	oldHash, hashErr := fileMD5(binary)
+	var buildEnv = map[string]string{"GOARCH": "amd64", "GOOS": "linux"}
 
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return fmt.Errorf("failed to create %s directory: %v", targetDir, err)

--- a/tools/mage/setup.go
+++ b/tools/mage/setup.go
@@ -92,7 +92,8 @@ func Setup() {
 // Fetch all Go modules needed for tests and compilation.
 //
 // "go test" and "go build" will do this automatically, but putting it in the setup flow allows it
-// to happen in parallel with the rest of the downloads.
+// to happen in parallel with the rest of the downloads. Pre-installing modules also allows
+// us to build Lambda functions in parallel.
 func installGoModules() error {
 	logger.Info("setup: download go modules...")
 
@@ -194,7 +195,11 @@ func installTerraform(uname string) error {
 func installPythonEnv() error {
 	// Create .setup/venv if it doesn't already exist
 	if info, err := os.Stat(pythonVirtualEnvPath); err == nil && info.IsDir() {
-		logger.Debugf("setup: %s already exists", pythonVirtualEnvPath)
+		if runningInCI() {
+			// If .setup/venv already exists in CI, it must have been restored from the cache.
+			logger.Info("setup: skipping pip install")
+			return nil
+		}
 	} else {
 		if err := sh.Run("python3", "-m", "venv", pythonVirtualEnvPath); err != nil {
 			return fmt.Errorf("failed to create venv %s: %v", pythonVirtualEnvPath, err)
@@ -216,6 +221,17 @@ func installPythonEnv() error {
 
 // Install npm modules
 func installNodeModules() error {
+	if _, err := os.Stat("node_modules"); err == nil && runningInCI() {
+		// In CI, if node_modules already exist, they must have been restored from the cache.
+		// Stop early (otherwise, npm install takes ~10 seconds to figure out it has nothing to do).
+		logger.Info("setup: skipping npm install")
+		return nil
+	}
+
 	logger.Info("setup: npm install...")
-	return sh.Run("npm", "i", "--no-progress", "--silent")
+	args := []string{"install", "--no-progress", "--no-audit"}
+	if !mg.Verbose() {
+		args = append(args, "--silent")
+	}
+	return sh.Run("npm", args...)
 }

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -69,8 +69,6 @@ func (t Test) CI() {
 		c <- goroutineResult{"build:cfn", build.cfn()}
 	}(results)
 
-	// We build tools and lambda source in parallel, but if you run into problems with Go modules,
-	// we may have to do all go compilation sequentially.
 	count++
 	go func(c chan goroutineResult) {
 		c <- goroutineResult{"build:lambda", build.lambda()}


### PR DESCRIPTION
## Background

CircleCI currently spends 40 seconds installing python/go/npm/other dependencies on every build. But most of the time these dependencies don't change, so this is a waste of time and compute. Thankfully, CircleCI has native support for [dependency caching](https://circleci.com/docs/2.0/caching/) for exactly this reason!

## Changes

- Cache each language's dependencies in CircleCI. Any changes to dependencies will rebuild just the dependencies for that language
- Simplify `build:tools` and build in parallel (saves 10-30 seconds in CI)
- Added `--no-audit` to npm install (saves a few seconds, we have a separate test for auditing)

## Testing

- Dozens of CI builds
- Restoring from the cache usually saves ~20 seconds during the setup phase, though CircleCI cache performance seems to vary. We can always revert this if it proves to be slower on average

CircleCI steps now look like this:
<img width="1378" alt="Screen Shot 2020-04-13 at 4 58 07 PM" src="https://user-images.githubusercontent.com/3608925/79174548-e43a5b80-7daf-11ea-92b7-841faf6a8ce7.png">

You can see in this case that setup only took ~20 seconds total (twice as fast as before)