### PR TITLE
Shorten default CloudWatch log retention to be frugal

### DIFF
--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -52,7 +52,7 @@ Monitoring:
   AlarmSnsTopicArn: ''
 
   # Retention period for all Panther CloudWatch log groups.
-  CloudWatchLogRetentionDays: 365
+  CloudWatchLogRetentionDays: 30
 
   # Enable DEBUG logging for all Lambda functions.
   Debug: false


### PR DESCRIPTION
## Background
The previous default retention for CW logs was 365 days. This is expensive and likely unneeded for most users.

## Changes
- Change default CW retention to 30 days
