### PR TITLE
Add note about rbac permission changes

### DIFF
--- a/docs/gitbook/enterprise/rbac.md
+++ b/docs/gitbook/enterprise/rbac.md
@@ -27,3 +27,7 @@ When you create or edit a role, you are shown the following screen:
 ![Role Edit 1](../.gitbook/assets/rbac-role-edit1.png)
 ![Role Edit 2](../.gitbook/assets/rbac-role-edit2.png)
 ![Role Edit 3](../.gitbook/assets/rbac-role-edit3.png)
+
+{% hint style="info" %}
+Permission changes do not take effect until the next time each user logs in.
+{% endhint %}

--- a/docs/gitbook/enterprise/rbac.md
+++ b/docs/gitbook/enterprise/rbac.md
@@ -29,5 +29,5 @@ When you create or edit a role, you are shown the following screen:
 ![Role Edit 3](../.gitbook/assets/rbac-role-edit3.png)
 
 {% hint style="info" %}
-Permission changes do not take effect until the next time each user logs in.
+Permission changes do not take effect until the next login or until the user's session expires.
 {% endhint %}


### PR DESCRIPTION
## Background

In Panther enterprise, changing a user's role / role permissions will not take effect until the next time the user logs in. This is because their [Cognito groups are encoded in a token sent to AppSync](https://docs.aws.amazon.com/appsync/latest/devguide/security.html#amazon-cognito-user-pools-authorization) and so persist for the duration of their session.

> When using Amazon Cognito User Pools, you can create groups that users belong to. This information is encoded in a JWT token that your application sends to AWS AppSync in an authorization header when sending GraphQL operations.

## Changes

Add a note so enterprise users understand when permission changes will take effect
