### PR TITLE
Use worker model to limit max number of parallel go builds

### DIFF
--- a/tools/mage/util.go
+++ b/tools/mage/util.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -41,6 +42,9 @@ import (
 const (
 	maxRetries = 20 // try very hard, avoid throttles
 )
+
+// For CPU-intensive operations, limit the max number of worker goroutines.
+var maxWorkers = runtime.NumCPU() - 1
 
 // Track results when executing similar tasks in parallel
 type goroutineResult struct {


### PR DESCRIPTION
## Background

#696 started compiling Go binaries in parallel. While faster, this will completely consume all available compute resources, and @kostaspap started noticing his laptop struggling to do other things while building/testing.

This PR introduces a compromise - instead of launching a new goroutine for every unit of work, we launch a goroutine for each logical CPU (-1) and feed a stream of work units. In this model, you have to introduce a "poison pill" into the stream so the workers know when to stop.

## Changes

- `mage build:lambda` and `mage build:tools` will only use `runtime.numCPU() - 1` concurrent goroutines

Since these commands themselves run in parallel in `mage test:ci`, it's still possible to be consuming all cores, but hopefully by reducing the parallelism of both commands the system can keep up now. If not, it's easy to tune the "maxWorkers" parameter as needed.

## Testing

- Temporarily added log messages to see worker start + stop
- Tested with 1 - 30 workers (below, at, and above my system CPU)
