### PR TITLE
Fix output path for mage build:tools

### DIFF
--- a/docs/gitbook/enterprise/rbac.md
+++ b/docs/gitbook/enterprise/rbac.md
@@ -27,3 +27,7 @@ When you create or edit a role, you are shown the following screen:
 ![Role Edit 1](../.gitbook/assets/rbac-role-edit1.png)
 ![Role Edit 2](../.gitbook/assets/rbac-role-edit2.png)
 ![Role Edit 3](../.gitbook/assets/rbac-role-edit3.png)
+
+{% hint style="info" %}
+Permission changes do not take effect until the next login or until the user's session expires.
+{% endhint %}

--- a/tools/mage/build_namespace.go
+++ b/tools/mage/build_namespace.go
@@ -168,7 +168,7 @@ func (b Build) tools() error {
 		for _, env := range buildEnvs {
 			count++
 			go func(env map[string]string, path string, results chan error) {
-				outDir := filepath.Join("out", "bin", filepath.Dir(path),
+				outDir := filepath.Join("out", "bin", filepath.Base(filepath.Dir(path)),
 					env["GOOS"], env["GOARCH"], filepath.Base(filepath.Dir(path)))
 				results <- sh.RunWith(env, "go", "build", "-ldflags", "-s -w", "-o", outDir, "./"+path)
 			}(env, path, results)


### PR DESCRIPTION
## Before
Output path for tools executable was deeply nested and confusing:
```
./out/bin/cmd/opstools/s3queue/s3queue/darwin/amd64/s3queue 
```
## After
Now path starts with tool name: 
```
./out/bin/s3queue/darwin/amd64/s3queue
```

## Testing
mage test:ci
mage build:tools
