### PR TITLE
Tune Syslog, Pull IPs from Syslog Messages

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -28,6 +28,7 @@
 * [Supported Logs]()
   * [AWS](log-analysis/log-processing/supported-logs/AWS.md)
   * [Fluentd](log-analysis/log-processing/supported-logs/Fluentd.md)
+  * [GitLab](log-analysis/log-processing/supported-logs/GitLab.md)
   * [Nginx](log-analysis/log-processing/supported-logs/Nginx.md)
   * [Osquery](log-analysis/log-processing/supported-logs/Osquery.md)
   * [OSSEC](log-analysis/log-processing/supported-logs/OSSEC.md)

--- a/docs/gitbook/log-analysis/log-processing/supported-logs/Fluentd.md
+++ b/docs/gitbook/log-analysis/log-processing/supported-logs/Fluentd.md
@@ -10,7 +10,7 @@ Reference: https://docs.fluentd.org/parser/syslog#rfc3164-log
 <tr><td valign=top><code>pri</code></td><td><code>smallint</code></td><td valign=top>Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message.</td></tr>
 <tr><td valign=top><code><b>host</b></code></td><td><code>string</code></td><td valign=top>Hostname identifies the machine that originally sent the syslog message.</td></tr>
 <tr><td valign=top><code><b>ident</b></code></td><td><code>string</code></td><td valign=top>Appname identifies the device or application that originated the syslog message.</td></tr>
-<tr><td valign=top><code><b>pid</b></code></td><td><code>bigint</code></td><td valign=top>ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting.</td></tr>
+<tr><td valign=top><code>pid</code></td><td><code>bigint</code></td><td valign=top>ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting.</td></tr>
 <tr><td valign=top><code><b>message</b></code></td><td><code>string</code></td><td valign=top>Message contains free-form text that provides information about the event.</td></tr>
 <tr><td valign=top><code><b>time</b></code></td><td><code>timestamp</code></td><td valign=top>Timestamp of the syslog message in UTC.</td></tr>
 <tr><td valign=top><code><b>tag</b></code></td><td><code>string</code></td><td valign=top>Tag of the syslog message</td></tr>

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
@@ -35,7 +35,7 @@ type RFC3164 struct {
 	Priority  *uint8                      `json:"pri" description:"Priority is calculated by (Facility * 8 + Severity). The lower this value, the higher importance of the log message."`
 	Hostname  *string                     `json:"host,omitempty" validate:"required" description:"Hostname identifies the machine that originally sent the syslog message."`
 	Ident     *string                     `json:"ident,omitempty" validate:"required" description:"Appname identifies the device or application that originated the syslog message."`
-	ProcID    *numerics.Integer           `json:"pid,omitempty" validate:"required" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
+	ProcID    *numerics.Integer           `json:"pid,omitempty" description:"ProcID is often the process ID, but can be any value used to enable log analyzers to detect discontinuities in syslog reporting."`
 	Message   *string                     `json:"message,omitempty" validate:"required" description:"Message contains free-form text that provides information about the event."`
 	Timestamp *timestamp.FluentdTimestamp `json:"time,omitempty" validate:"required" description:"Timestamp of the syslog message in UTC."`
 	Tag       *string                     `json:"tag,omitempty" validate:"required" description:"Tag of the syslog message"`

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
@@ -83,4 +83,6 @@ func (event *RFC3164) updatePantherFields(p *RFC3164Parser) {
 	if !event.AppendAnyIPAddressPtr(event.Hostname) {
 		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
+
+	event.AppendAnyIPAddressInFieldPtr(event.Message)
 }

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
@@ -54,13 +54,12 @@ func TestRFC3164(t *testing.T) {
 
 func TestRFC3164WithoutPriority(t *testing.T) {
 	// nolint:lll
-	log := `{"host":"ip-172-31-91-66","ident":"systemd-timesyncd","pid":"565","message":"Network configuration changed, trying to establish connection.","tag":"syslog.cron.info","time":"2020-03-23 16:14:06 +0000"}`
+	log := `{"host":"ip-172-31-91-66","ident":"systemd-timesyncd","message":"Network configuration changed, trying to establish connection.","tag":"syslog.cron.info","time":"2020-03-23 16:14:06 +0000"}`
 
 	expectedTime := time.Date(2020, 3, 23, 16, 14, 6, 0, time.UTC)
 	expectedEvent := &RFC3164{
 		Hostname:  aws.String("ip-172-31-91-66"),
 		Ident:     aws.String("systemd-timesyncd"),
-		ProcID:    (*numerics.Integer)(aws.Int(565)),
 		Message:   aws.String("Network configuration changed, trying to establish connection."),
 		Tag:       aws.String("syslog.cron.info"),
 		Timestamp: (*timestamp.FluentdTimestamp)(&expectedTime),

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
@@ -49,6 +49,7 @@ func TestRFC3164(t *testing.T) {
 	expectedRFC3164.PantherLogType = aws.String("Fluentd.Syslog3164")
 	expectedRFC3164.AppendAnyDomainNamePtrs(expectedRFC3164.Hostname)
 	expectedRFC3164.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+
 	checkRFC3164(t, log, expectedRFC3164)
 }
 
@@ -69,6 +70,30 @@ func TestRFC3164WithoutPriority(t *testing.T) {
 	expectedEvent.PantherLogType = aws.String("Fluentd.Syslog3164")
 	expectedEvent.AppendAnyDomainNamePtrs(expectedEvent.Hostname)
 	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+
+	checkRFC3164(t, log, expectedEvent)
+}
+
+func TestRFC3164SSHMessage(t *testing.T) {
+	// nolint:lll
+	log := `{"host":"ip-172-31-33-197","ident":"sshd","pid":"5433","message":"Accepted publickey for ubuntu from 150.18.226.10 port 54717 ssh2: RSA SHA256:u...","tag":"syslog.auth.info","time":"2020-04-19 20:20:05 +0000"}`
+
+	expectedTime := time.Date(2020, 4, 19, 20, 20, 5, 0, time.UTC)
+	expectedEvent := &RFC3164{
+		Hostname:  aws.String("ip-172-31-33-197"),
+		Ident:     aws.String("sshd"),
+		ProcID:    (*numerics.Integer)(aws.Int(5433)),
+		Message:   aws.String("Accepted publickey for ubuntu from 150.18.226.10 port 54717 ssh2: RSA SHA256:u..."),
+		Tag:       aws.String("syslog.auth.info"),
+		Timestamp: (*timestamp.FluentdTimestamp)(&expectedTime),
+	}
+
+	// panther fields
+	expectedEvent.PantherLogType = aws.String("Fluentd.Syslog3164")
+	expectedEvent.AppendAnyDomainNamePtrs(expectedEvent.Hostname)
+	expectedEvent.AppendAnyIPAddressInFieldPtr(expectedEvent.Message)
+	expectedEvent.PantherEventTime = (*timestamp.RFC3339)(&expectedTime)
+
 	checkRFC3164(t, log, expectedEvent)
 }
 

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
@@ -85,4 +85,6 @@ func (event *RFC5424) updatePantherFields(p *RFC5424Parser) {
 	if !event.AppendAnyIPAddressPtr(event.Hostname) {
 		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
+
+	event.AppendAnyIPAddressInFieldPtr(event.Message)
 }

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -147,17 +147,12 @@ func (pl *PantherLog) AppendAnyIPAddressInFieldPtr(value *string) bool {
 
 // AppendAnyIPAddressInField extracts all IPs from the value using a regexp
 func (pl *PantherLog) AppendAnyIPAddressInField(value string) bool {
-	matchedIPs := ipRegex.FindAll([]byte(value), -1)
-	if len(matchedIPs) > 0 {
-		if pl.PantherAnyIPAddresses == nil { // lazy create
-			pl.PantherAnyIPAddresses = NewPantherAnyString()
-		}
-		for _, match := range matchedIPs {
-			AppendAnyString(pl.PantherAnyIPAddresses, string(match))
-		}
-		return true
+	result := false
+	matchedIPs := ipRegex.FindAllString(value, -1)
+	for _, match := range matchedIPs{
+		result = result || pl.AppendAnyIPAddress(match)
 	}
-	return false
+	return result
 }
 
 func (pl *PantherLog) AppendAnyIPAddress(value string) bool {

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	ipRegex, _ = regexp.Compile(`(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])`)
+	ipv4Regex  = regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])`)
 	rowCounter RowID // number of rows generated in this lambda execution (used to generate p_row_id)
 )
 
@@ -148,8 +148,8 @@ func (pl *PantherLog) AppendAnyIPAddressInFieldPtr(value *string) bool {
 // AppendAnyIPAddressInField extracts all IPs from the value using a regexp
 func (pl *PantherLog) AppendAnyIPAddressInField(value string) bool {
 	result := false
-	matchedIPs := ipRegex.FindAllString(value, -1)
-	for _, match := range matchedIPs{
+	matchedIPs := ipv4Regex.FindAllString(value, -1)
+	for _, match := range matchedIPs {
 		result = result || pl.AppendAnyIPAddress(match)
 	}
 	return result

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -153,7 +153,7 @@ func (pl *PantherLog) AppendAnyIPAddressInField(value string) bool {
 		return false
 	}
 	for _, match := range matchedIPs {
-		if pl.AppendAnyIPAddress(match) == false {
+		if !pl.AppendAnyIPAddress(match) {
 			return false
 		}
 	}

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -20,6 +20,7 @@ package parsers
 
 import (
 	"net"
+	"regexp"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -32,6 +33,7 @@ const (
 )
 
 var (
+	ipRegex, _ = regexp.Compile(`(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])`)
 	rowCounter RowID // number of rows generated in this lambda execution (used to generate p_row_id)
 )
 
@@ -126,12 +128,36 @@ func (pl *PantherLog) SetCoreFields(logType string, eventTime *timestamp.RFC3339
 	pl.PantherParseTime = &parseTime
 }
 
-// Will return true if the IP address was successfully appended, false if the value was not an IP
+// AppendAnyIPAddressPtr returns true if the IP address was successfully appended,
+// otherwise false if the value was not an IP
 func (pl *PantherLog) AppendAnyIPAddressPtr(value *string) bool {
 	if value == nil {
 		return false
 	}
 	return pl.AppendAnyIPAddress(*value)
+}
+
+// AppendAnyIPAddressInFieldPtr makes sure the value passed is not nil
+func (pl *PantherLog) AppendAnyIPAddressInFieldPtr(value *string) bool {
+	if value == nil {
+		return false
+	}
+	return pl.AppendAnyIPAddressInField(*value)
+}
+
+// AppendAnyIPAddressInField extracts all IPs from the value using a regexp
+func (pl *PantherLog) AppendAnyIPAddressInField(value string) bool {
+	matchedIPs := ipRegex.FindAll([]byte(value), -1)
+	if len(matchedIPs) > 0 {
+		if pl.PantherAnyIPAddresses == nil { // lazy create
+			pl.PantherAnyIPAddresses = NewPantherAnyString()
+		}
+		for _, match := range matchedIPs {
+			AppendAnyString(pl.PantherAnyIPAddresses, string(match))
+		}
+		return true
+	}
+	return false
 }
 
 func (pl *PantherLog) AppendAnyIPAddress(value string) bool {

--- a/internal/log_analysis/log_processor/parsers/pantherlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog_test.go
@@ -140,6 +140,21 @@ func TestSetCoreFieldsNilEventTime(t *testing.T) {
 	require.Equal(t, expectedEvent, event)
 }
 
+func TestAppendAnyIPsInField(t *testing.T) {
+	event := PantherLog{}
+	require.True(t, event.AppendAnyIPAddressInFieldPtr(aws.String("connection established from 192.168.1.1")))
+	require.True(t, event.AppendAnyIPAddressInField("Accepted publickey for ubuntu from 192.168.1.2 port 54717 ssh2"))
+	require.False(t, event.AppendAnyIPAddressInField("connection established"))
+
+	expectedAny := &PantherAnyString{
+		set: map[string]struct{}{
+			"192.168.1.1": {},
+			"192.168.1.2": {},
+		},
+	}
+	require.Equal(t, expectedAny, event.PantherAnyIPAddresses)
+}
+
 func TestAppendAnyIPV4(t *testing.T) {
 	event := PantherLog{}
 	require.True(t, event.AppendAnyIPAddressPtr(aws.String("192.168.1.1")))

--- a/internal/log_analysis/log_processor/parsers/pantherlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog_test.go
@@ -155,6 +155,23 @@ func TestAppendAnyIPsInField(t *testing.T) {
 	require.Equal(t, expectedAny, event.PantherAnyIPAddresses)
 }
 
+func TestAppendAnyIPsInFieldMultiple(t *testing.T) {
+	event := PantherLog{}
+	require.True(t, event.AppendAnyIPAddressInFieldPtr(aws.String("connection established from 206.206.199.127 to 186.28.188.20")))
+	require.True(t, event.AppendAnyIPAddressInField("Accepted publickey from 221.19.216.201 to 229.12.27.176 port 54717"))
+	require.False(t, event.AppendAnyIPAddressInField("connection established"))
+
+	expectedAny := &PantherAnyString{
+		set: map[string]struct{}{
+			"206.206.199.127": {},
+			"186.28.188.20":   {},
+			"221.19.216.201":  {},
+			"229.12.27.176":   {},
+		},
+	}
+	require.Equal(t, expectedAny, event.PantherAnyIPAddresses)
+}
+
 func TestAppendAnyIPV4(t *testing.T) {
 	event := PantherLog{}
 	require.True(t, event.AppendAnyIPAddressPtr(aws.String("192.168.1.1")))

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
@@ -114,4 +114,6 @@ func (event *RFC3164) updatePantherFields(p *RFC3164Parser) {
 	if !event.AppendAnyIPAddressPtr(event.Hostname) {
 		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
+
+	event.AppendAnyIPAddressInFieldPtr(event.Message)
 }

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424.go
@@ -112,4 +112,6 @@ func (event *RFC5424) updatePantherFields(p *RFC5424Parser) {
 	if !event.AppendAnyIPAddressPtr(event.Hostname) {
 		event.AppendAnyDomainNamePtrs(event.Hostname)
 	}
+
+	event.AppendAnyIPAddressInFieldPtr(event.Message)
 }


### PR DESCRIPTION
## Background

It's common for IPs to land in the authentication information generated from the SSH daemon and collected with syslog. We want to search this easily with the standardized data fields, so this change extracts them out.

```
Accepted publickey for ubuntu from 8.103.222.11 port 51454 ssh2: RSA SHA256:...
```

## Changes

- Remove the validate:"required" tag on the FluentdSyslog.RFC3164 struct
- Pull out IPs from log messages using a regexp
- Enable IP extraction on all syslog log messages
- Update tests

## Testing

- Unit testing
