### PR TITLE
Safeguard Doc Url for missing version

### DIFF
--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -18,7 +18,7 @@
 
 import { SeverityEnum } from 'Generated/schema';
 import { BadgeProps } from 'pouncejs';
-import { getStableVersion } from 'Helpers/utils';
+import { generateDocUrl } from 'Helpers/utils';
 
 export const AWS_ACCOUNT_ID_REGEX = new RegExp('^\\d{12}$');
 
@@ -115,9 +115,10 @@ export const SEVERITY_COLOR_MAP: { [key in SeverityEnum]: BadgeProps['color'] } 
 
 export const PANTHER_SCHEMA_DOCS_MASTER_LINK = 'https://docs.runpanther.io';
 
-export const PANTHER_SCHEMA_DOCS_LINK = `${PANTHER_SCHEMA_DOCS_MASTER_LINK}/v/${getStableVersion(
+export const PANTHER_SCHEMA_DOCS_LINK = generateDocUrl(
+  PANTHER_SCHEMA_DOCS_MASTER_LINK,
   process.env.PANTHER_VERSION
-)}`;
+);
 
 export const DEFAULT_SMALL_PAGE_SIZE = 10;
 export const DEFAULT_LARGE_PAGE_SIZE = 25;

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -246,6 +246,13 @@ export const copyTextToClipboard = (text: string) => {
 export const getStableVersion = (version: string) =>
   version.indexOf('-') > 0 ? version.substring(0, version.indexOf('-')) : version;
 
+export const generateDocUrl = (baseUrl: string, version: string) => {
+  if (version) {
+    return `${baseUrl}/v/${getStableVersion(version)}`;
+  }
+  return baseUrl;
+};
+
 export const isNumber = (value: string) => /^-{0,1}\d+$/.test(value);
 
 export const toStackNameFormat = (val: string) => val.replace(/ /g, '-').toLowerCase();


### PR DESCRIPTION
## Background

When running UI locally, it's missing the necessary version environment variable.

## Changes

- Added a function to generate doc url with a safeguard

## Testing

- Locally
- Deployed env
