### PR TITLE
Fix Audit bucket permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -104,9 +104,9 @@ Mappings:
     ap-northeast-2:
       ARN: arn:aws:iam::600734575887:root
     ap-southeast-1:
-      ARN: arn:aws:iam::383597477331:root
-    ap-southeast-2:
       ARN: arn:aws:iam::114774131450:root
+    ap-southeast-2:
+      ARN: arn:aws:iam::783225319266:root
     ap-south-1:
       ARN: arn:aws:iam::718504428378:root
     me-south-1:

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -103,6 +103,8 @@ Mappings:
       ARN: arn:aws:iam::582318560864:root
     ap-northeast-2:
       ARN: arn:aws:iam::600734575887:root
+    ap-northeast-3:
+      ARN: arn:aws:iam::383597477331:root
     ap-southeast-1:
       ARN: arn:aws:iam::114774131450:root
     ap-southeast-2:

--- a/docs/gitbook/log-analysis/log-processing/supported-logs/GitLab.md
+++ b/docs/gitbook/log-analysis/log-processing/supported-logs/GitLab.md
@@ -233,7 +233,6 @@ Reference: https://docs.gitlab.com/ee/administration/logs.html#git_jsonlog
 ##GitLab.Integrations
 GitLab log with information about integrations activities such as Jira, Asana, and Irker services.
 Reference: https://docs.gitlab.com/ee/administration/logs.html#integrations_jsonlog
-
 <table>
 <tr><th align=center>Column</th><th align=center>Type</th><th align=center>Description</th></tr>
 <tr><td valign=top><code><b>severity</b></code></td><td><code>string</code></td><td valign=top>The log level</td></tr>


### PR DESCRIPTION
## Background

Fixes deployments in ap-southeast-1 as reported in https://github.com/panther-labs/panther/issues/747

## Changes

- Fixed deployments in ap-southeast-1. 
- Updated audit bucket permissions to allow deployments in ap-northeast-3

## Testing

- Deployed successfully to ap-southeast-1
