### PR TITLE
Make athenaviews.generateLogViews package public

### DIFF
--- a/tools/athenaviews/athenaviews.go
+++ b/tools/athenaviews/athenaviews.go
@@ -42,7 +42,7 @@ func CreateOrReplaceViews(athenaResultsBucket string) (err error) {
 		return errors.Wrap(err, "CreateOrReplaceViews() failed")
 	}
 	s3Path := "s3://" + athenaResultsBucket + "/athena/"
-	sqlStatements, err := generateLogViews(registry.AvailableTables())
+	sqlStatements, err := GenerateLogViews(registry.AvailableTables())
 	if err != nil {
 		return err
 	}
@@ -55,10 +55,10 @@ func CreateOrReplaceViews(athenaResultsBucket string) (err error) {
 	return err
 }
 
-// generateLogViews creates useful Athena views in the panther views database
-func generateLogViews(tables []*awsglue.GlueTableMetadata) (sqlStatements []string, err error) {
+// GenerateLogViews creates useful Athena views in the panther views database
+func GenerateLogViews(tables []*awsglue.GlueTableMetadata) (sqlStatements []string, err error) {
 	if len(tables) == 0 {
-		return nil, errors.New("no tables specified for generateLogViews()")
+		return nil, errors.New("no tables specified for GenerateLogViews()")
 	}
 	sqlStatement, err := generateViewAllLogs(tables)
 	if err != nil {

--- a/tools/athenaviews/athenaviews_test.go
+++ b/tools/athenaviews/athenaviews_test.go
@@ -66,7 +66,7 @@ func TestGenerateViewAllLogsFail(t *testing.T) {
 
 func TestGenerateLogsViewsFail(t *testing.T) {
 	// no tables
-	_, err := generateLogViews([]*awsglue.GlueTableMetadata{})
+	_, err := GenerateLogViews([]*awsglue.GlueTableMetadata{})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "no tables"))
 }


### PR DESCRIPTION
## Background
athenaviews.generateLogViews() creates SQL views over the Panther tables.
This is the entry point needed for Snowflake integration to generate these views so it needs to be a public function.

## Changes
- athenaviews.generateLogViews() to athenaviews.GenerateLogViews()

## Testing
mage test:ci
