### PR TITLE
Remove GrapQL and CF for athena query subscriptions (not yet used by UI)

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -6,7 +6,6 @@ scalar AWSJSON
 schema {
   query: Query
   mutation: Mutation
-  subscription: Subscription
 }
 
 type Mutation {
@@ -22,7 +21,6 @@ type Mutation {
   deleteRule(input: DeleteRuleInput!): Boolean
   deleteUser(id: ID!): Boolean
   inviteUser(input: InviteUserInput): User!
-  queryDone(input: QueryDoneInput!): QueryDone! @aws_iam
   remediateResource(input: RemediateResourceInput!): Boolean
   resetUserPassword(id: ID!): User!
   suppressPolicies(input: SuppressPoliciesInput!): Boolean
@@ -62,10 +60,6 @@ type Query {
   rule(input: GetRuleInput!): RuleDetails
   rules(input: ListRulesInput): ListRulesResponse
   users: [User!]!
-}
-
-type Subscription {
-  queryDone(userData: String!): QueryDone @aws_subscribe(mutations: ["queryDone"]) @aws_iam
 }
 
 input GetComplianceIntegrationTemplateInput {
@@ -717,18 +711,6 @@ input InviteUserInput {
   givenName: String
   familyName: String
   email: AWSEmail
-}
-
-input QueryDoneInput {
-  userData: String!
-  queryId: String!
-  workflowId: String!
-}
-
-type QueryDone @aws_iam {
-  userData: String!
-  queryId: String!
-  workflowId: String!
 }
 
 enum ComplianceStatusEnum {

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -159,14 +159,6 @@ Resources:
             SigningServiceName: execute-api
         Endpoint: !Ref RemediationApi
 
-  QueryDoneDataSource:
-    Type: AWS::AppSync::DataSource
-    Properties:
-      ApiId: !Ref ApiId
-      Name: PantherQueryDone
-      Type: NONE
-      ServiceRoleArn: !Ref ServiceRole
-
   ########## Resolvers ##########
 
   ResetUserPasswordResolver:
@@ -1500,19 +1492,3 @@ Resources:
         #else
             $util.error($ctx.result.body, "$statusCode", $input)
         #end
-
-  QueryDoneResolver:
-    Type: AWS::AppSync::Resolver
-    DependsOn: GraphQLSchema
-    Properties:
-      ApiId: !Ref ApiId
-      TypeName: Mutation
-      FieldName: queryDone # noop that returns {userData,queryId,workflowId} (used for subscriptions to trigger async query completion)
-      DataSourceName: !GetAtt QueryDoneDataSource.Name
-      RequestMappingTemplate: |
-        {
-          "version" : "2017-02-28",
-          "payload": $utils.toJson($context.arguments.input)
-        }
-      ResponseMappingTemplate: |
-        $util.toJson($context.result)

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -502,7 +502,6 @@ export type Mutation = {
   deleteRule?: Maybe<Scalars['Boolean']>;
   deleteUser?: Maybe<Scalars['Boolean']>;
   inviteUser: User;
-  queryDone: QueryDone;
   remediateResource?: Maybe<Scalars['Boolean']>;
   resetUserPassword: User;
   suppressPolicies?: Maybe<Scalars['Boolean']>;
@@ -563,10 +562,6 @@ export type MutationDeleteUserArgs = {
 
 export type MutationInviteUserArgs = {
   input?: Maybe<InviteUserInput>;
-};
-
-export type MutationQueryDoneArgs = {
-  input: QueryDoneInput;
 };
 
 export type MutationRemediateResourceArgs = {
@@ -825,19 +820,6 @@ export type QueryRulesArgs = {
   input?: Maybe<ListRulesInput>;
 };
 
-export type QueryDone = {
-  __typename?: 'QueryDone';
-  userData: Scalars['String'];
-  queryId: Scalars['String'];
-  workflowId: Scalars['String'];
-};
-
-export type QueryDoneInput = {
-  userData: Scalars['String'];
-  queryId: Scalars['String'];
-  workflowId: Scalars['String'];
-};
-
 export type RemediateResourceInput = {
   policyId: Scalars['ID'];
   resourceId: Scalars['ID'];
@@ -955,15 +937,6 @@ export type SqsConfig = {
 
 export type SqsConfigInput = {
   queueUrl: Scalars['String'];
-};
-
-export type Subscription = {
-  __typename?: 'Subscription';
-  queryDone?: Maybe<QueryDone>;
-};
-
-export type SubscriptionQueryDoneArgs = {
-  userData: Scalars['String'];
 };
 
 export type SuppressPoliciesInput = {
@@ -1217,8 +1190,6 @@ export type ResolversTypes = {
   DeleteRuleInput: DeleteRuleInput;
   DeleteRuleInputItem: DeleteRuleInputItem;
   InviteUserInput: InviteUserInput;
-  QueryDoneInput: QueryDoneInput;
-  QueryDone: ResolverTypeWrapper<QueryDone>;
   RemediateResourceInput: RemediateResourceInput;
   SuppressPoliciesInput: SuppressPoliciesInput;
   TestPolicyInput: TestPolicyInput;
@@ -1231,7 +1202,6 @@ export type ResolversTypes = {
   UpdateUserInput: UpdateUserInput;
   UploadPoliciesInput: UploadPoliciesInput;
   UploadPoliciesResponse: ResolverTypeWrapper<UploadPoliciesResponse>;
-  Subscription: ResolverTypeWrapper<{}>;
   AccountTypeEnum: AccountTypeEnum;
 };
 
@@ -1330,8 +1300,6 @@ export type ResolversParentTypes = {
   DeleteRuleInput: DeleteRuleInput;
   DeleteRuleInputItem: DeleteRuleInputItem;
   InviteUserInput: InviteUserInput;
-  QueryDoneInput: QueryDoneInput;
-  QueryDone: QueryDone;
   RemediateResourceInput: RemediateResourceInput;
   SuppressPoliciesInput: SuppressPoliciesInput;
   TestPolicyInput: TestPolicyInput;
@@ -1344,7 +1312,6 @@ export type ResolversParentTypes = {
   UpdateUserInput: UpdateUserInput;
   UploadPoliciesInput: UploadPoliciesInput;
   UploadPoliciesResponse: UploadPoliciesResponse;
-  Subscription: {};
   AccountTypeEnum: AccountTypeEnum;
 };
 
@@ -1734,12 +1701,6 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationInviteUserArgs, never>
   >;
-  queryDone?: Resolver<
-    ResolversTypes['QueryDone'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationQueryDoneArgs, 'input'>
-  >;
   remediateResource?: Resolver<
     Maybe<ResolversTypes['Boolean']>,
     ParentType,
@@ -2066,16 +2027,6 @@ export type QueryResolvers<
   users?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType>;
 };
 
-export type QueryDoneResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['QueryDone'] = ResolversParentTypes['QueryDone']
-> = {
-  userData?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  queryId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  workflowId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
-};
-
 export type ResourceDetailsResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['ResourceDetails'] = ResolversParentTypes['ResourceDetails']
@@ -2195,19 +2146,6 @@ export type SqsConfigResolvers<
   __isTypeOf?: isTypeOfResolverFn<ParentType>;
 };
 
-export type SubscriptionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']
-> = {
-  queryDone?: SubscriptionResolver<
-    Maybe<ResolversTypes['QueryDone']>,
-    'queryDone',
-    ParentType,
-    ContextType,
-    RequireFields<SubscriptionQueryDoneArgs, 'userData'>
-  >;
-};
-
 export type TestPolicyResponseResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['TestPolicyResponse'] = ResolversParentTypes['TestPolicyResponse']
@@ -2288,7 +2226,6 @@ export type Resolvers<ContextType = any> = {
   PolicyUnitTest?: PolicyUnitTestResolvers<ContextType>;
   PolicyUnitTestError?: PolicyUnitTestErrorResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
-  QueryDone?: QueryDoneResolvers<ContextType>;
   ResourceDetails?: ResourceDetailsResolvers<ContextType>;
   ResourceSummary?: ResourceSummaryResolvers<ContextType>;
   RuleDetails?: RuleDetailsResolvers<ContextType>;
@@ -2298,7 +2235,6 @@ export type Resolvers<ContextType = any> = {
   SlackConfig?: SlackConfigResolvers<ContextType>;
   SnsConfig?: SnsConfigResolvers<ContextType>;
   SqsConfig?: SqsConfigResolvers<ContextType>;
-  Subscription?: SubscriptionResolvers<ContextType>;
   TestPolicyResponse?: TestPolicyResponseResolvers<ContextType>;
   UploadPoliciesResponse?: UploadPoliciesResponseResolvers<ContextType>;
   User?: UserResolvers<ContextType>;


### PR DESCRIPTION
## Background
The UI is not ready ready to use subscriptions to be notified on Athena query completion (but the backend has this implemented). 

This PR removes the GraphQL and CF configuration for the subscriptions but adds instructions in the athena_api integration tests for restoring this configuration. This will be used when we start adding support in the UI in the future.

## Changes
- Removed queryDone subscription support in both the graph ql schema and appsync cloudformation
- Added a comment to the athena_api integration test explaining how to re-enable this capability.

## Testing
mage test:ci
ran integration tests

