### PR TITLE
v1.1.0 release - fix doc link

### DIFF
--- a/docs/gitbook/development.md
+++ b/docs/gitbook/development.md
@@ -86,7 +86,7 @@ To update your deployment of Panther, follow the steps below:
 
 1. Checkout the latest release:
    1. `git fetch origin master`
-   2. `git checkout tags/v1.0.1`
+   2. `git checkout tags/v1.1.0`
 2. Clean the existing build artifacts: `mage clean`
 3. Deploy the latest application changes: `mage deploy`
 

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -29,7 +29,7 @@ Get started with 3 quick steps!
 Clone the latest release of [Panther](https://github.com/panther-labs/panther):
 
 ```bash
-git clone https://github.com/panther-labs/panther --depth 1 --branch v1.0.1
+git clone https://github.com/panther-labs/panther --depth 1 --branch v1.1.0
 cd panther
 ```
 

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -249,13 +249,13 @@ export const copyTextToClipboard = (text: string) => {
   }
 };
 
-// Function that given an version always return the stable version i.e "v1.0.1-abc" return "v1.0.1"
+// Extracts stable version from git tag, i.e "v1.0.1-abc" returns "v1.0.1"
 export const getStableVersion = (version: string) =>
   version.indexOf('-') > 0 ? version.substring(0, version.indexOf('-')) : version;
 
 export const generateDocUrl = (baseUrl: string, version: string) => {
   if (version) {
-    return `${baseUrl}/v/${getStableVersion(version)}`;
+    return `${baseUrl}/v/${getStableVersion(version)}-docs`;
   }
   return baseUrl;
 };


### PR DESCRIPTION
## Background

This is the candidate commit for the 1.1.0 release! 

### v*-docs branches
The link to documentation versions has been changed with a `-docs` suffix (e.g. https://docs.runpanther.io/v/v1.0.1-docs/). The reason is that gitbook automatically saves branches with the same name as the variant. When we had a `v1.0.1` variant, gitbook created a branch with that same name, which was confusing and actually broke deploys. Our documentation says to

```
git clone https://github.com/panther-labs/panther --depth 1 --branch v1.0.1
```

The `--branch` flag clones branches or tags with that name. Before, we just had a tag with that name, but now there was a branch as well! In that branch, `git describe --tags` does not work (there are no tags), which fails the deploy.

Removing the `v1.0.1` branch fixed the problem - we will now always have `v1.x.y-docs` branches, even though the name is redundant when looking in gitbooks

### stable tag?
To avoid having to update the version in the documentation for every release, I tried to make a "stable" tag, which we could bump on each release to the next version. The problem is that we use `git describe --tags` to parse the actual version number. What was once `v1.0.1-25-abcde` became `stable-25-abcde` which meant we would show the panther version as "stable" in the UI; not very helpful.

So for now we'll have to continue updating the version in the documentation with each new release.

## Changes

- Change `v1.0.1` references in docs to `v1.1.0`
- Add `-docs` suffix to generated docs link

## Testing

- `git clone https://github.com/panther-labs/panther --depth 1 --branch v1.0.1; cd panther; git describe --tags`
- Deployed to dev account, docs link worked
- Full release testing ongoing
