### PR TITLE
 Remove AdditionalAuthenticationProviders from GraphQLApi in boostrap.yml

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -702,8 +702,6 @@ Resources:
       # * The Panther user interface will show errors.
       # </cfndoc>
       AuthenticationType: AMAZON_COGNITO_USER_POOLS
-      AdditionalAuthenticationProviders:
-        - AuthenticationType: AWS_IAM # this is used for lambda callbacks to AppSync (e.g., to signal Athena query completion)
       UserPoolConfig:
         AwsRegion: !Ref AWS::Region
         UserPoolId: !Ref UserPool

--- a/internal/core/database_api/athena/driver/api/integration_test.go
+++ b/internal/core/database_api/athena/driver/api/integration_test.go
@@ -135,11 +135,16 @@ var (
 	             ResponseMappingTemplate: |
 	               $util.toJson($context.result)
 
-	  3. Run: mage deploy
+	  3. Edit deployments/bootstrap.yml, add to GraphQLApi:
 
-	  4. Set variable 'subscriptionTest' to true below
+	     AdditionalAuthenticationProviders:
+	        - AuthenticationType: AWS_IAM # this is used for lambda callbacks to AppSync (e.g., to signal Athena query completion)
 
-	  5. Follow instructions in the integration test below on verifying working subscriptions.
+	  4. Run: mage deploy
+
+	  5. Set variable 'subscriptionTest' to true below
+
+	  6. Follow instructions in the integration test below on verifying working subscriptions.
 
 	  We hope to implement the use of subscriptions in the UI in the near future which has many benefits.
 


### PR DESCRIPTION

## Background
Remove AdditionalAuthenticationProviders from GraphQLApi in boostrap.yml, this was an oversight in previous PR taking out the config for AppSync subscriptions.


## Testing
mage test:ci
mage deploy