### PR TITLE
Add state machine permission to deploy role

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -135,7 +135,7 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/panther-*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/Panther*
-              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:server-certificate/panther/*"
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:server-certificate/panther/*
           - Effect: Allow
             Action: kms:*
             Resource:

--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -18,7 +18,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: IAM role for deploying Panther
 
 Metadata:
-  Version: v1.0.0
+  Version: v1.1.0
 
 Resources:
   DeploymentRole:
@@ -73,16 +73,19 @@ Resources:
               - logs:*
               - sns:List*
               - sqs:List*
+              - states:CreateStateMachine
+              - states:TagResource
+              - states:UntagResource
             Resource: '*'
           - Effect: Allow
             Action: cloudformation:*
             Resource:
-              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/panther-*
-              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stackset/panther-*
-              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
+              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/panther-*
+              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stackset/panther-*
+              - !Sub arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31
           - Effect: Allow
             Action: dynamodb:*
-            Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/panther-*
+            Resource: !Sub arn:${AWS::Partition}:dynamodb:*:${AWS::AccountId}:table/panther-*
           - Effect: Allow
             Action:
               - ec2:AssociateRouteTable
@@ -123,10 +126,10 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Action: ecr:*
-            Resource: !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/panther-*
+            Resource: !Sub arn:${AWS::Partition}:ecr:*:${AWS::AccountId}:repository/panther-*
           - Effect: Allow
             Action: execute-api:Invoke
-            Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:execute-api:*:${AWS::AccountId}:*
           - Effect: Allow
             Action: iam:*
             Resource:
@@ -136,20 +139,26 @@ Resources:
           - Effect: Allow
             Action: kms:*
             Resource:
-              - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/panther-*
-              - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+              - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:alias/panther-*
+              - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:key/*
           - Effect: Allow
             Action: lambda:*
             Resource:
-              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:event-source-mapping:*
-              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-*
-              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:panther-*
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:event-source-mapping:*
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:panther-*
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:layer:panther-*
           - Effect: Allow
             Action: s3:*
             Resource: !Sub arn:${AWS::Partition}:s3:::panther-*
           - Effect: Allow
             Action: sns:*
-            Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:panther-*
+            Resource: !Sub arn:${AWS::Partition}:sns:*:${AWS::AccountId}:panther-*
           - Effect: Allow
             Action: sqs:*
-            Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-*
+            Resource: !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:panther-*
+          - Effect: Allow
+            Action: states:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:states:*:${AWS::AccountId}:activity:panther-*
+              - !Sub arn:${AWS::Partition}:states:*:${AWS::AccountId}:execution:panther-*:*
+              - !Sub arn:${AWS::Partition}:states:*:${AWS::AccountId}:stateMachine:panther-*

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -70,6 +70,9 @@ resource "aws_iam_policy" "deployment" {
           "logs:*",
           "sns:List*",
           "sqs:List*",
+          "states:CreateStateMachine",
+          "states:TagResource",
+          "states:UntagResource",
         ],
         Resource : "*"
       },
@@ -77,15 +80,15 @@ resource "aws_iam_policy" "deployment" {
         Effect : "Allow",
         Action : "cloudformation:*",
         Resource : [
-          "arn:${var.aws_partition}:cloudformation:${var.aws_region}:${var.aws_account_id}:stack/panther-*",
-          "arn:${var.aws_partition}:cloudformation:${var.aws_region}:${var.aws_account_id}:stackset/panther-*",
-          "arn:${var.aws_partition}:cloudformation:${var.aws_region}:aws:transform/Serverless-2016-10-31",
+          "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stack/panther-*",
+          "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stackset/panther-*",
+          "arn:${var.aws_partition}:cloudformation:*:aws:transform/Serverless-2016-10-31",
         ]
       },
       {
         Effect : "Allow",
         Action : "dynamodb:*",
-        Resource : "arn:${var.aws_partition}:dynamodb:${var.aws_region}:${var.aws_account_id}:table/panther-*"
+        Resource : "arn:${var.aws_partition}:dynamodb:*:${var.aws_account_id}:table/panther-*"
       },
       {
         Effect : "Allow",
@@ -131,12 +134,12 @@ resource "aws_iam_policy" "deployment" {
       {
         Effect : "Allow",
         Action : "ecr:*",
-        Resource : "arn:${var.aws_partition}:ecr:${var.aws_region}:${var.aws_account_id}:repository/panther-*"
+        Resource : "arn:${var.aws_partition}:ecr:*:${var.aws_account_id}:repository/panther-*"
       },
       {
         Effect : "Allow",
         Action : "execute-api:Invoke",
-        Resource : "arn:${var.aws_partition}:execute-api:${var.aws_region}:${var.aws_account_id}:*"
+        Resource : "arn:${var.aws_partition}:execute-api:*:${var.aws_account_id}:*"
       },
       {
         Effect : "Allow",
@@ -151,17 +154,17 @@ resource "aws_iam_policy" "deployment" {
         Effect : "Allow",
         Action : "kms:*",
         Resource : [
-          "arn:${var.aws_partition}:kms:${var.aws_region}:${var.aws_account_id}:alias/panther-*",
-          "arn:${var.aws_partition}:kms:${var.aws_region}:${var.aws_account_id}:key/*"
+          "arn:${var.aws_partition}:kms:*:${var.aws_account_id}:alias/panther-*",
+          "arn:${var.aws_partition}:kms:*:${var.aws_account_id}:key/*"
         ]
       },
       {
         Effect : "Allow",
         Action : "lambda:*",
         Resource : [
-          "arn:${var.aws_partition}:lambda:${var.aws_region}:${var.aws_account_id}:event-source-mapping:*",
-          "arn:${var.aws_partition}:lambda:${var.aws_region}:${var.aws_account_id}:function:panther-*",
-          "arn:${var.aws_partition}:lambda:${var.aws_region}:${var.aws_account_id}:layer:panther-*",
+          "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:event-source-mapping:*",
+          "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:panther-*",
+          "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:layer:panther-*",
         ]
       },
       {
@@ -172,12 +175,21 @@ resource "aws_iam_policy" "deployment" {
       {
         Effect : "Allow",
         Action : "sns:*",
-        Resource : "arn:${var.aws_partition}:sns:${var.aws_region}:${var.aws_account_id}:panther-*",
+        Resource : "arn:${var.aws_partition}:sns:*:${var.aws_account_id}:panther-*",
       },
       {
         Effect : "Allow",
         Action : "sqs:*",
-        Resource : "arn:${var.aws_partition}:sqs:${var.aws_region}:${var.aws_account_id}:panther-*",
+        Resource : "arn:${var.aws_partition}:sqs:*:${var.aws_account_id}:panther-*",
+      },
+      {
+        Effect : "Allow",
+        Action : "states:*",
+        Resource : [
+          "arn:${var.aws_partition}:states:*:${var.aws_account_id}:activity:panther-*",
+          "arn:${var.aws_partition}:states:*:${var.aws_account_id}:execution:panther-*:*",
+          "arn:${var.aws_partition}:states:*:${var.aws_account_id}:stateMachine:panther-*",
+        ]
       }
     ]
   })

--- a/deployments/auxiliary/terraform/panther_deployment_role/variables.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/variables.tf
@@ -19,10 +19,6 @@ variable "aws_partition" {
   default = "aws"
 }
 
-variable "aws_region" {
-  type = string
-}
-
 variable "aws_account_id" {
   type = string
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/tidwall/gjson v1.6.0
 	go.uber.org/zap v1.14.1
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	golang.org/x/tools v0.0.0-20200413161937-250b2131eb8b // indirect
+	golang.org/x/tools v0.0.0-20200407144507-5fc56a9a2104 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200413161937-250b2131eb8b h1:FvD0+J5ZtXZrrc2bVxQaUSnJYUhSNlB1P3XHuZohH9I=
-golang.org/x/tools v0.0.0-20200413161937-250b2131eb8b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200407144507-5fc56a9a2104 h1:BgjF1Nn5zNEp8cxfwjYGMLT28bm1GD1Uir2/OnI1Wn4=
+golang.org/x/tools v0.0.0-20200407144507-5fc56a9a2104/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=


### PR DESCRIPTION
## Background

#647 added Panther's first step functions, which means we need to update the deployment role

## Changes

- Add `states:*` IAM permission to deployment role
- Fix a bug with `iam:ListServerCertificates` permission
- Permissions are now region-agnostic
- Update `go.mod` and `go.sum` with whatever was there after `mage clean setup`

## Testing

- Deploy and teardown with the deployment role
