### PR TITLE
Added Security headers for server responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack-manifest-plugin": "^2.2.0"
   },
   "dependencies": {
-    "@apollo/client": "^3.0.0-beta.31",
+    "@apollo/client": "3.0.0-beta.41",
     "@sentry/browser": "^5.12.1",
     "apollo-link-error": "^1.1.12",
     "aws-amplify": "^2.2.2",

--- a/web/scripts/serve.js
+++ b/web/scripts/serve.js
@@ -36,6 +36,30 @@ const getCacheControlForFile = filepath => {
   return 'no-cache';
 };
 
+const addHeaders = (req, res, next) => {
+  res.header('X-Powered-by', 'N/A');
+  res.header('X-XSS-Protection', '1; mode=block');
+  res.header('X-Frame-Options', 'SAMEORIGIN');
+  res.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  res.header('X-Content-Type-Options', 'nosniff');
+  /*
+    Unsafe-inline is not recommended for neither css or scripts and we should convert tem
+    https://stackoverflow.com/questions/17766817/refused-to-apply-inline-style-because-it-violates-the-following-content-security
+   */
+  res.header(
+    'Content-Security-Policy',
+    "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self' *.amazonaws.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; base-uri 'self';form-action 'self'"
+  );
+  res.header('Referrer-Policy', 'no-referrer');
+  res.header(
+    'Feature-Policy',
+    "accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; battery 'none'; camera 'none'; geolocation 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'; midi 'none"
+  );
+  next();
+};
+
+app.use('*', addHeaders);
+
 // allow static assets to be served from the /dist folder
 app.use(
   expressStaticGzip(path.resolve(__dirname, '../dist'), {

--- a/web/scripts/serve.js
+++ b/web/scripts/serve.js
@@ -42,10 +42,6 @@ const addHeaders = (req, res, next) => {
   res.header('X-Frame-Options', 'SAMEORIGIN');
   res.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   res.header('X-Content-Type-Options', 'nosniff');
-  /*
-    Unsafe-inline is not recommended for neither css or scripts and we should convert tem
-    https://stackoverflow.com/questions/17766817/refused-to-apply-inline-style-because-it-violates-the-following-content-security
-   */
   res.header(
     'Content-Security-Policy',
     "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self' *.amazonaws.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; base-uri 'self';form-action 'self'"


### PR DESCRIPTION
## Background

We are missing security headers for the server serving the webapp. This is not a exploitable risk but it is consider a good practise to add them to prevent escalation of low severity issues.

Below you can find links that explain what some of them prevent or do: 

[X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
[Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
[Feature-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)
[X-Content-Type-Options](https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff)
[Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
[Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) - We have small issue here, we may need to address in the future

You can also test the headers of any site here [securityheaders.com](https://securityheaders.com/)

Closes #643 
## Changes

- Added a middleware that attaches headers on every response from the server

## Testing

- Locally
- Deployed env
