### PR TITLE
Fixed parameter

### DIFF
--- a/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -28,7 +28,7 @@ const StackDeployment: React.FC = () => {
   const { data, loading, error } = useGetComplianceCfnTemplate({
     variables: {
       input: {
-        awsAccountId: values.awsAccountId,
+        awsAccountId: process.env.AWS_ACCOUNT_ID,
         integrationLabel: values.integrationLabel,
         remediationEnabled: values.remediationEnabled,
         cweEnabled: values.cweEnabled,

--- a/web/src/components/wizards/LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -28,7 +28,7 @@ const StackDeployment: React.FC = () => {
   const { data, loading, error } = useGetLogCfnTemplate({
     variables: {
       input: {
-        awsAccountId: values.awsAccountId,
+        awsAccountId: process.env.AWS_ACCOUNT_ID,
         integrationLabel: values.integrationLabel,
         s3Bucket: values.s3Bucket,
         logTypes: values.logTypes,


### PR DESCRIPTION
## Background

The source onboarding wizards were sending the wrong account ID when requesting a template. This fixes so they send the correct account ID.

## Changes

- Updated cloud security & log analysis source wizards to send the master account ID and not the satellite account ID when requesting a template

## Testing

- Started the web server locally and verified it created the template correctly
- Going to test a full end to end source onboarding before merging