### PR TITLE
Update deployment role

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -57,37 +57,11 @@ Resources:
               - athena:*
               - cloudformation:Describe*
               - cloudformation:List*
+              - cloudtrail:DescribeTrails
+              - cloudtrail:CreateTrail
               - cloudwatch:*
               - cognito-idp:*
               - dynamodb:List*
-              - ecr:GetAuthorizationToken
-              - ecs:*
-              - events:*
-              - glue:*
-              - guardduty:CreatePublishingDestination
-              - guardduty:ListDetectors
-              - kms:CreateKey
-              - kms:List*
-              - lambda:*EventSourceMapping
-              - lambda:List*
-              - logs:*
-              - sns:List*
-              - sqs:List*
-              - states:CreateStateMachine
-              - states:TagResource
-              - states:UntagResource
-            Resource: '*'
-          - Effect: Allow
-            Action: cloudformation:*
-            Resource:
-              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/panther-*
-              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stackset/panther-*
-              - !Sub arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31
-          - Effect: Allow
-            Action: dynamodb:*
-            Resource: !Sub arn:${AWS::Partition}:dynamodb:*:${AWS::AccountId}:table/panther-*
-          - Effect: Allow
-            Action:
               - ec2:AssociateRouteTable
               - ec2:AssociateSubnetCidrBlock
               - ec2:AssociateVpcCidrBlock
@@ -123,7 +97,40 @@ Resources:
               - ec2:UpdateSecurityGroupRuleDescriptionsEgress
               - ec2:UpdateSecurityGroupRuleDescriptionsIngress
               - elasticloadbalancing:*
+              - ecr:GetAuthorizationToken
+              - ecs:*
+              - events:*
+              - glue:*
+              - guardduty:CreatePublishingDestination
+              - guardduty:ListDetectors
+              - kms:CreateKey
+              - kms:List*
+              - lambda:*EventSourceMapping
+              - lambda:List*
+              - logs:*
+              - sns:List*
+              - sqs:List*
+              - states:CreateStateMachine
+              - states:TagResource
+              - states:UntagResource
             Resource: '*'
+          - Effect: Allow
+            Action: # permissions for handling self-onboarding CloudTrail
+              - cloudtrail:DeleteTrail
+              - cloudtrail:StartLogging
+              - cloudtrail:StopLogging
+              - cloudtrail:AddTags
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/panther-cloudtrail-${AWS::Region}
+          - Effect: Allow
+            Action: cloudformation:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/panther-*
+              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stackset/panther-*
+              - !Sub arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31
+          - Effect: Allow
+            Action: dynamodb:*
+            Resource: !Sub arn:${AWS::Partition}:dynamodb:*:${AWS::AccountId}:table/panther-*
           - Effect: Allow
             Action: ecr:*
             Resource: !Sub arn:${AWS::Partition}:ecr:*:${AWS::AccountId}:repository/panther-*

--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -18,7 +18,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: IAM role for deploying Panther
 
 Metadata:
-  Version: v1.1.1
+  Version: v1.1.2
 
 Resources:
   DeploymentRole:
@@ -116,12 +116,13 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Action: # permissions for handling self-onboarding CloudTrail
+              - cloudtrail:AddTags
               - cloudtrail:DeleteTrail
+              - cloudtrail:PutEventSelectors
               - cloudtrail:StartLogging
               - cloudtrail:StopLogging
-              - cloudtrail:AddTags
-            Resource:
-              - !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/panther-cloudtrail-${AWS::Region}
+              - cloudtrail:UpdateTrail
+            Resource: !Sub arn:${AWS::Partition}:cloudtrail:*:${AWS::AccountId}:trail/panther-cloudtrail-*
           - Effect: Allow
             Action: cloudformation:*
             Resource:

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -57,42 +57,6 @@ resource "aws_iam_policy" "deployment" {
           "cloudwatch:*",
           "cognito-idp:*",
           "dynamodb:List*",
-          "ecr:GetAuthorizationToken",
-          "ecs:*",
-          "events:*",
-          "glue:*",
-          "guardduty:CreatePublishingDestination",
-          "guardduty:ListDetectors",
-          "kms:CreateKey",
-          "kms:List*",
-          "lambda:*EventSourceMapping",
-          "lambda:List*",
-          "logs:*",
-          "sns:List*",
-          "sqs:List*",
-          "states:CreateStateMachine",
-          "states:TagResource",
-          "states:UntagResource",
-        ],
-        Resource : "*"
-      },
-      {
-        Effect : "Allow",
-        Action : "cloudformation:*",
-        Resource : [
-          "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stack/panther-*",
-          "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stackset/panther-*",
-          "arn:${var.aws_partition}:cloudformation:*:aws:transform/Serverless-2016-10-31",
-        ]
-      },
-      {
-        Effect : "Allow",
-        Action : "dynamodb:*",
-        Resource : "arn:${var.aws_partition}:dynamodb:*:${var.aws_account_id}:table/panther-*"
-      },
-      {
-        Effect : "Allow",
-        Action : [
           "ec2:AssociateRouteTable",
           "ec2:AssociateSubnetCidrBlock",
           "ec2:AssociateVpcCidrBlock",
@@ -128,8 +92,50 @@ resource "aws_iam_policy" "deployment" {
           "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
           "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
           "elasticloadbalancing:*"
+          "ecr:GetAuthorizationToken",
+          "ecs:*",
+          "events:*",
+          "glue:*",
+          "guardduty:CreatePublishingDestination",
+          "guardduty:ListDetectors",
+          "kms:CreateKey",
+          "kms:List*",
+          "lambda:*EventSourceMapping",
+          "lambda:List*",
+          "logs:*",
+          "sns:List*",
+          "sqs:List*",
+          "states:CreateStateMachine",
+          "states:TagResource",
+          "states:UntagResource",
         ],
         Resource : "*"
+      },
+      {
+        Effect : "Allow",
+        Action : [
+          "cloudtrail:AddTags",
+          "cloudtrail:DeleteTrail",
+          "cloudtrail:PutEventSelectors",
+          "cloudtrail:StartLogging",
+          "cloudtrail:StopLogging",
+          "cloudtrail:UpdateTrail",
+        ],
+        Resource : "arn:${var.aws_partition}:cloudtrail:*:${var.aws_account_id}:trail/panther-cloudtrail-*"
+      },
+      {
+        Effect : "Allow",
+        Action : "cloudformation:*",
+        Resource : [
+          "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stack/panther-*",
+          "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stackset/panther-*",
+          "arn:${var.aws_partition}:cloudformation:*:aws:transform/Serverless-2016-10-31",
+        ]
+      },
+      {
+        Effect : "Allow",
+        Action : "dynamodb:*",
+        Resource : "arn:${var.aws_partition}:dynamodb:*:${var.aws_account_id}:table/panther-*"
       },
       {
         Effect : "Allow",

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -91,7 +91,7 @@ resource "aws_iam_policy" "deployment" {
           "ec2:RevokeSecurityGroupIngress",
           "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
           "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
-          "elasticloadbalancing:*"
+          "elasticloadbalancing:*",
           "ecr:GetAuthorizationToken",
           "ecs:*",
           "events:*",


### PR DESCRIPTION
## Background

The main functional change is adding some CloudTrail permissions so that the deployment role can succesfully deploy an account where `SelfOnboard` and `EnableCloudTrail` are both set equal to `true` in the `deployments/panther_config.yml` file. I also merged two permission blocks that I didn't actually understand why they were separate, but I can revert that change if need be.

## Changes

- Added `cloudtrail:CreateTrail` and `cloudtrail:DescribeTrails` actions to the `Resource: *` permission
- Created a new permission that grants `cloudtrail:DeleteTrail`, `cloudtrail:StartLogging`, `cloudtrail:StopLogging`, and `cloudtrail:AddTags` on the CloudTrail that is created by Panther for self-onboarding
- Condensed two separate permissions that allowed various actions on `Resource: *` into one permission

## Testing

- Did a fresh deployment with this role where CloudTrailEnabled and SelfOnboard were both equal to `true`
