### PR TITLE
Added onboarding docs link

### DIFF
--- a/web/src/components/wizards/LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -76,6 +76,7 @@ const StackDeployment: React.FC = () => {
         `&param_S3Bucket=${values.s3Bucket}` +
         `&param_S3Prefix=${values.s3Prefix}` +
         `&param_KmsKey=${values.kmsKey}`;
+      const onboardingDocsLink = `https://docs.runpanther.io/log-processing#sns-notification-setup`;
 
       return (
         <React.Fragment>
@@ -105,6 +106,13 @@ const StackDeployment: React.FC = () => {
           >
             Download template
           </Link>
+          <Text size="large" color="grey200" as="p" mt={2} mb={2}>
+            After deploying this new infrastructure, follow the steps{' '}
+            <Link external color="blue300" title="SNS Notification Setup" href={onboardingDocsLink}>
+              here
+            </Link>{' '}
+            to complete the log source onboarding.
+          </Text>
         </React.Fragment>
       );
     }

--- a/web/src/components/wizards/LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -81,7 +81,7 @@ const StackDeployment: React.FC = () => {
       return (
         <React.Fragment>
           <Text size="large" color="grey200" as="p" mt={2} mb={2}>
-            The quickest way to do it, is through the AWS console
+            The quickest way to do it is through the AWS console
           </Text>
           <Link
             external
@@ -106,7 +106,7 @@ const StackDeployment: React.FC = () => {
           >
             Download template
           </Link>
-          <Text size="large" color="grey200" as="p" mt={2} mb={2}>
+          <Text size="large" color="grey200" as="p" mt={10} mb={2}>
             After deploying this new infrastructure, follow the steps{' '}
             <Link external color="blue300" title="SNS Notification Setup" href={onboardingDocsLink}>
               here


### PR DESCRIPTION
## Background

Added a link in the onboarding workflow to direct users to the required steps for completing log source onboarding.

## Changes

- Added a link to the docs on log source onboarding page

## Testing

- `npm run start` and checked out the page from a local deployment
