### PR TITLE
Clarify deployment docs

### DIFF
--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -65,7 +65,7 @@ Run the following command to deploy Panther:
 mage setup deploy
 ```
 
-- Optionally, you can run `mage setup test:ci` before deploying to confirm that all tests are passing. If you perform this step, then you can just deploy with `mage deploy` as setup has already been completed.
+- Optionally, you can run `mage setup test:ci` before deploying to confirm that all tests are passing. If you perform this step, then you can deploy with just `mage deploy` as setup has already been completed.
 - The initial deployment will take ~10 minutes with a fast internet connection. If your credentials timeout, you can safely redeploy to pick up where you left off.
 - At the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
 - You'll get an email from `no-reply@verificationemail.com` with your temporary password. If you don't see it, be sure to check your spam folder.

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -65,7 +65,7 @@ Run the following command to deploy Panther:
 mage setup deploy
 ```
 
-- Optionally, you can `mage test:ci` before deploying to confirm that all tests are passing
+- Optionally, you can run `mage setup test:ci` before deploying to confirm that all tests are passing. If you perform this step, then you can just deploy with `mage deploy` as setup has already been completed.
 - The initial deployment will take ~10 minutes with a fast internet connection. If your credentials timeout, you can safely redeploy to pick up where you left off.
 - At the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
 - You'll get an email from `no-reply@verificationemail.com` with your temporary password. If you don't see it, be sure to check your spam folder.

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -65,7 +65,7 @@ Run the following command to deploy Panther:
 mage setup deploy
 ```
 
-- Optionally, you can run `mage setup test:ci` before deploying to confirm that all tests are passing. If you perform this step, then you can deploy with just `mage deploy` as setup has already been completed.
+- Optionally, you can run `mage setup test:ci` before deploying to confirm that all tests are passing (`setup` only needs to be run once in the repo).
 - The initial deployment will take ~10 minutes with a fast internet connection. If your credentials timeout, you can safely redeploy to pick up where you left off.
 - At the end of the deploy command, you'll be prompted for your first/last name and email to setup the first Panther user account.
 - You'll get an email from `no-reply@verificationemail.com` with your temporary password. If you don't see it, be sure to check your spam folder.


### PR DESCRIPTION
## Background

The current deploy docs do not specify that `mage setup` needs to be run before `mage test:ci`, even though they suggest users may run `mage test:ci` before deploying. This small update just clarifies that `mage setup` is a requirement for `mage test:ci`.

## Changes

- Clarified some docs

## Testing

- Viewed in markdown renderer of IDE
