### PR TITLE
Add alb latency and 5XX alarms

### DIFF
--- a/tools/cfngen/cloudwatchcf/alarms.go
+++ b/tools/cfngen/cloudwatchcf/alarms.go
@@ -55,7 +55,8 @@ type AlarmProperties struct {
 	Period             int
 	Threshold          float32
 	Unit               string
-	Statistic          string
+	Statistic          string `json:",omitempty"`
+	ExtendedStatistic  string `json:",omitempty"`
 }
 
 type MetricDimension struct {
@@ -181,6 +182,17 @@ func (alarm *Alarm) MaxNoUnitsThreshold(threshold float32, period int) *Alarm {
 	alarm.Properties.Unit = cloudwatch.StandardUnitNone
 	alarm.Properties.Period = period
 	alarm.Properties.Statistic = cloudwatch.StatisticMaximum
+	alarm.Properties.TreatMissingData = "notBreaching"
+	return alarm
+}
+
+// P95SecondsThreshold configures alarm for p90 threshold with Seconds units
+func (alarm *Alarm) P95SecondsThreshold(threshold float32, period int) *Alarm {
+	alarm.Properties.ComparisonOperator = cloudwatch.ComparisonOperatorGreaterThanThreshold
+	alarm.Properties.Threshold = threshold
+	alarm.Properties.Unit = cloudwatch.StandardUnitSeconds
+	alarm.Properties.Period = period
+	alarm.Properties.ExtendedStatistic = "p95"
 	alarm.Properties.TreatMissingData = "notBreaching"
 	return alarm
 }

--- a/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
+++ b/tools/cfngen/cloudwatchcf/testdata/generated_test_alarms.json
@@ -470,10 +470,10 @@
         "Statistic": "Sum"
       }
     },
-    "PantherAlarmELBErrorWeb": {
+    "PantherAlarmELB4XXErrorWeb": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
-        "AlarmName": "PantherAlarm-ELBError-Web",
+        "AlarmName": "PantherAlarm-ELB4XXError-Web",
         "AlarmDescription": "ALB has elevated ELB 4XX errors. See: https://docs.runpanther.io/operations/runbooks#web",
         "AlarmActions": [
           {
@@ -492,10 +492,32 @@
         "Statistic": "Sum"
       }
     },
-    "PantherAlarmELBTargetErrorWeb": {
+    "PantherAlarmELB5XXErrorWeb": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
-        "AlarmName": "PantherAlarm-ELBTargetError-Web",
+        "AlarmName": "PantherAlarm-ELB5XXError-Web",
+        "AlarmDescription": "ALB has elevated ELB 5XX errors. See: https://docs.runpanther.io/operations/runbooks#web",
+        "AlarmActions": [
+          {
+            "Ref": "AlarmTopicArn"
+          }
+        ],
+        "TreatMissingData": "notBreaching",
+        "Namespace": "AWS/ApplicationELB",
+        "MetricName": "HTTPCode_ELB_5XX_Count",
+        "Dimensions": [{ "Name": "LoadBalancer", "Value": { "Ref": "LoadBalancerFullName" } }],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Period": 300,
+        "Threshold": 0,
+        "Unit": "None",
+        "Statistic": "Sum"
+      }
+    },
+    "PantherAlarmELBTarget4XXErrorWeb": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": "PantherAlarm-ELBTarget4XXError-Web",
         "AlarmDescription": "ALB has elevated Target 4XX errors. See: https://docs.runpanther.io/operations/runbooks#web",
         "AlarmActions": [
           {
@@ -512,6 +534,50 @@
         "Threshold": 5,
         "Unit": "None",
         "Statistic": "Sum"
+      }
+    },
+    "PantherAlarmELBTarget5XXErrorWeb": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": "PantherAlarm-ELBTarget5XXError-Web",
+        "AlarmDescription": "ALB has elevated Target 5XX errors. See: https://docs.runpanther.io/operations/runbooks#web",
+        "AlarmActions": [
+          {
+            "Ref": "AlarmTopicArn"
+          }
+        ],
+        "TreatMissingData": "notBreaching",
+        "Namespace": "AWS/ApplicationELB",
+        "MetricName": "HTTPCode_Target_5XX_Count",
+        "Dimensions": [{ "Name": "LoadBalancer", "Value": { "Ref": "LoadBalancerFullName" } }],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Period": 300,
+        "Threshold": 0,
+        "Unit": "None",
+        "Statistic": "Sum"
+      }
+    },
+    "PantherAlarmELBTargetLatencyWeb": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": "PantherAlarm-ELBTargetLatency-Web",
+        "AlarmDescription": "ALB has elevated latency. See: https://docs.runpanther.io/operations/runbooks#web",
+        "AlarmActions": [
+          {
+            "Ref": "AlarmTopicArn"
+          }
+        ],
+        "TreatMissingData": "notBreaching",
+        "Namespace": "AWS/ApplicationELB",
+        "MetricName": "TargetResponseTime",
+        "Dimensions": [{ "Name": "LoadBalancer", "Value": { "Ref": "LoadBalancerFullName" } }],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 5,
+        "Period": 300,
+        "Threshold": 0.5,
+        "Unit": "Seconds",
+        "ExtendedStatistic": "p95"
       }
     },
     "PantherAlarmELBUnhealthyWeb": {


### PR DESCRIPTION
## Background
For SOC compliance we are required to have latency and 5XX alarms on the alb.

## Changes
- Add support for p95 stats
- Add 5XX and latency alarms

## Testing
mage test:ci
mage deploy

