### PR TITLE
White list CreateResolver for aws event processor

### DIFF
--- a/internal/compliance/aws_event_processor/processor/process.go
+++ b/internal/compliance/aws_event_processor/processor/process.go
@@ -71,6 +71,7 @@ var (
 		"ResendValidationEmail": {},
 
 		// appsync
+		"CreateResolver":      {}, // unable to get AWS region from CloudTrail event
 		"StartSchemaCreation": {},
 
 		// cloudformation


### PR DESCRIPTION
## Background
See errors like "unable to get AWS region from CloudTrail event" for CreateResolver in aws event processor

## Changes
- Whitelist CreateResolver  in aws event processor

## Testing
- mage test:ci
- mage deploy
