### PR TITLE
Add PantherEdition tag so it easy to tell apart Enterprise vs OpenSource

### DIFF
--- a/tools/mage/deploy_template.go
+++ b/tools/mage/deploy_template.go
@@ -304,6 +304,7 @@ func createChangeSet(
 		StackName:     &stack,
 		Tags: []*cfn.Tag{ // Tags are propagated to every supported resource in the stack
 			{Key: aws.String("Application"), Value: aws.String("Panther")},
+			{Key: aws.String("PantherEdition"), Value: aws.String("OpenSource")},
 			{Key: aws.String("PantherVersion"), Value: &pantherVersion},
 			{Key: aws.String("Stack"), Value: &stack},
 		},

--- a/tools/mage/deploy_template.go
+++ b/tools/mage/deploy_template.go
@@ -304,7 +304,7 @@ func createChangeSet(
 		StackName:     &stack,
 		Tags: []*cfn.Tag{ // Tags are propagated to every supported resource in the stack
 			{Key: aws.String("Application"), Value: aws.String("Panther")},
-			{Key: aws.String("PantherEdition"), Value: aws.String("OpenSource")},
+			{Key: aws.String("PantherEdition"), Value: aws.String("Community")},
 			{Key: aws.String("PantherVersion"), Value: &pantherVersion},
 			{Key: aws.String("Stack"), Value: &stack},
 		},


### PR DESCRIPTION
## Background
When having more than one deployment, it easy to forget which is Enterprise and which is OpenSource.

This can also be useful for troubleshooting customer issues to definitively know the edition deployed.

## Changes
* Add a "PantherEdition" tag.

## Testing
* mage test:ci
* mage deploy
