### PR TITLE
Move log processor sqs mocks to pkg/testutils

### DIFF
--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -82,6 +82,26 @@ func (m *SqsMock) SendMessage(input *sqs.SendMessageInput) (*sqs.SendMessageOutp
 	return args.Get(0).(*sqs.SendMessageOutput), args.Error(1)
 }
 
+func (m *SqsMock) SendMessageBatch(input *sqs.SendMessageBatchInput) (*sqs.SendMessageBatchOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.SendMessageBatchOutput), args.Error(1)
+}
+
+func (m *SqsMock) DeleteMessageBatch(input *sqs.DeleteMessageBatchInput) (*sqs.DeleteMessageBatchOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.DeleteMessageBatchOutput), args.Error(1)
+}
+
+func (m *SqsMock) ReceiveMessage(input *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.ReceiveMessageOutput), args.Error(1)
+}
+
+func (m *SqsMock) GetQueueAttributes(input *sqs.GetQueueAttributesInput) (*sqs.GetQueueAttributesOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.GetQueueAttributesOutput), args.Error(1)
+}
+
 type GlueMock struct {
 	glueiface.GlueAPI
 	mock.Mock


### PR DESCRIPTION
## Background
Move log processor sqs mocks to pkg/testutils to allow sharing.

## Changes

- Move log processor sqs mocks to pkg/testutils


## Testing

- mage test:ci
