### PR TITLE
Resource Timeouts

### DIFF
--- a/internal/compliance/aws_event_processor/processor/ec2.go
+++ b/internal/compliance/aws_event_processor/processor/ec2.go
@@ -97,6 +97,10 @@ func classifyEC2(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 		deleteResource = true
 		ec2Type = aws.Ec2SecurityGroupSchema
 		ec2ARN.Resource = "security-group/" + detail.Get("requestParameters.groupId").Str
+	case "DeleteVpc":
+		deleteResource = true
+		ec2Type = aws.Ec2VpcSchema
+		ec2ARN.Resource = "vpc/" + detail.Get("requestParameters.vpcId").Str
 	case "DeleteNetworkAcl":
 		deleteResource = true
 		ec2Type = aws.Ec2NetworkAclSchema


### PR DESCRIPTION
## Background

Updated the resources API to set a default timeout for resources of three days. This means that existing resources would have to get missed in 2-3 consecutive daily scans to accidentally be forgotten, but we won't have forgotten resources sitting around forever without any compliance status never being updated.

Additionally, corrected handling for the `DeleteVpc` event in the `aws-event-processor`.

## Changes

- Updated the `resources-api` to set a three day expiration window for all resources by default
- Updated the `aws-event-processor` to appropriately handle `DeleteVpc` events (it was previously treating them as a regular resource update, not a resource deletion)

## Testing

- `mage test:ci`
- Deployed to dev account, manually verified both changes
