### PR TITLE
Updated EditProfile to use 'users-api' instead of Cognito

### DIFF
--- a/web/src/components/forms/EditProfileForm/EditProfileForm.tsx
+++ b/web/src/components/forms/EditProfileForm/EditProfileForm.tsx
@@ -22,8 +22,8 @@ import { Field, Formik } from 'formik';
 import FormikTextInput from 'Components/fields/TextInput';
 import SubmitButton from 'Components/buttons/SubmitButton';
 import useAuth from 'Hooks/useAuth';
-import { useState } from 'react';
 import { useEditUser } from 'Components/sidesheets/EditUserSidesheet/graphql/editUser.generated';
+import { extractErrorMessage } from 'Helpers/utils';
 
 interface EditProfileFormProps {
   onSuccess: () => void;
@@ -37,17 +37,17 @@ interface EditProfileFormValues {
 
 const EditProfileForm: React.FC<EditProfileFormProps> = ({ onSuccess }) => {
   const { userInfo, refetchUserInfo } = useAuth();
-  const [status, setStatus] = useState(null);
+  const [status, setStatus] = React.useState(null);
 
   const [editUser] = useEditUser({
     onCompleted: () => {
       onSuccess();
       return refetchUserInfo();
     },
-    onError: ({ message }) =>
+    onError: updateUserError =>
       setStatus({
         title: 'Unable to update profile',
-        message,
+        message: extractErrorMessage(updateUserError) || 'An unknown error occurred',
       }),
   });
 

--- a/web/src/components/forms/EditProfileForm/EditProfileForm.tsx
+++ b/web/src/components/forms/EditProfileForm/EditProfileForm.tsx
@@ -17,7 +17,7 @@
  */
 
 import * as React from 'react';
-import { Alert, Box, Flex } from 'pouncejs';
+import { Alert, Box, Flex, useSnackbar } from 'pouncejs';
 import { Field, Formik } from 'formik';
 import FormikTextInput from 'Components/fields/TextInput';
 import SubmitButton from 'Components/buttons/SubmitButton';
@@ -37,11 +37,16 @@ interface EditProfileFormValues {
 
 const EditProfileForm: React.FC<EditProfileFormProps> = ({ onSuccess }) => {
   const { userInfo, refetchUserInfo } = useAuth();
+  const { pushSnackbar } = useSnackbar();
   const [status, setStatus] = React.useState(null);
 
   const [editUser] = useEditUser({
     onCompleted: () => {
       onSuccess();
+      pushSnackbar({
+        variant: 'success',
+        title: 'User profile updated successfully',
+      });
       return refetchUserInfo();
     },
     onError: updateUserError =>

--- a/web/src/components/utils/AuthContext/AuthContext.tsx
+++ b/web/src/components/utils/AuthContext/AuthContext.tsx
@@ -98,12 +98,6 @@ interface SetNewPasswordParams {
   onError?: (err: AuthError) => void;
 }
 
-interface UpdateUserInfoParams {
-  newAttributes: Partial<EnhancedCognitoUser['attributes']>;
-  onSuccess?: () => void;
-  onError?: (err: AuthError) => void;
-}
-
 interface ChangePasswordParams {
   oldPassword: string;
   newPassword: string;
@@ -144,7 +138,6 @@ export interface AuthContextValue {
   verifyTotpSetup: (params: VerifyTotpSetupParams) => Promise<void>;
   requestTotpSecretCode: () => Promise<string>;
   signOut: (params?: SignOutParams) => Promise<void>;
-  updateUserInfo: (params: UpdateUserInfoParams) => Promise<void>;
   changePassword: (params: ChangePasswordParams) => Promise<void>;
   resetPassword: (params: ResetPasswordParams) => Promise<void>;
   forgotPassword: (params: ForgotPasswordParams) => Promise<void>;
@@ -285,27 +278,6 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
         const confirmedUser = await Auth.currentAuthenticatedUser();
         setAuthUser(confirmedUser);
         setAuthenticated(true);
-        onSuccess();
-      } catch (err) {
-        onError(err as AuthError);
-      }
-    },
-    [authUser]
-  );
-
-  /**
-   *
-   * @public
-   * Updates the user's personal information
-   *
-   */
-  const updateUserInfo = React.useCallback(
-    async ({ newAttributes, onSuccess = () => {}, onError = () => {} }: UpdateUserInfoParams) => {
-      try {
-        await Auth.updateUserAttributes(authUser, newAttributes);
-        const updatedUser = await Auth.currentAuthenticatedUser({ bypassCache: true });
-        setAuthUser(updatedUser);
-
         onSuccess();
       } catch (err) {
         onError(err as AuthError);
@@ -456,7 +428,6 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
       isAuthenticated,
       currentAuthChallengeName: authUser?.challengeName || null,
       userInfo,
-      updateUserInfo,
       refetchUserInfo,
 
       signIn,


### PR DESCRIPTION
## Background

For security reasons, we need to block updates on user's first and last name that include HTML fragments. This check is supported from `users-api` but from cognito which we are currently usign for user updates.

This PR addresses this issue by update the `EditProfileForm` to use `users-api`

Closes #817 

## Changes

- Updated `EditProfileForm` to use `useEditUser` instead of cognito's `updateUserInfo`

## Testing

- Locally