### PR TITLE
Proper handling of layer related events

### DIFF
--- a/internal/compliance/aws_event_processor/processor/lambda.go
+++ b/internal/compliance/aws_event_processor/processor/lambda.go
@@ -52,7 +52,6 @@ func classifyLambda(detail gjson.Result, metadata *CloudTrailMetadata) []*resour
 		"DeleteFunction",
 		"DeleteFunctionConcurrency",
 		"PublishVersion",
-		"PublishLayerVersion",
 		"PutFunctionConcurrency",
 		"RemovePermission",
 		"UpdateAlias",
@@ -70,6 +69,13 @@ func classifyLambda(detail gjson.Result, metadata *CloudTrailMetadata) []*resour
 	case "DeleteEventSourceMapping":
 		functionName := detail.Get("responseElements.functionArn").Str
 		lambdaARN.Resource += lambdaNameRegex.FindStringSubmatch(functionName)[7]
+	case "AddLayerVersionPermission",
+		"DeleteLayerVersion",
+		"PublishLayerVersion",
+		"RemoveLayerVersionPermission":
+		// Normally we would add these as ignored events in process.go to save time, but then we would not have the
+		// special lambda event version suffix stripping logic applied which we need
+		return nil
 	case "TagResource",
 		"UntagResource":
 		var err error


### PR DESCRIPTION
## Background

When processing the `PublishLayerVersion` event, the `aws-event-processor` would panic. This is because we erroneously assumed that a `functionName` field would be present in those events.

## Changes

- Updated the `aws-event-processor` to explicitly handle all layer events appropriately

## Testing

- Deployed to a dev account and observed before/after behavior
