### PR TITLE
Fix error handing in awsathena.WaitForResults

### DIFF
--- a/pkg/awsathena/query.go
+++ b/pkg/awsathena/query.go
@@ -84,7 +84,7 @@ func WaitForResults(client athenaiface.AthenaAPI, queryExecutionID string) (quer
 				return nil, err
 			}
 			if done {
-				return executionOutput, err
+				return executionOutput, nil
 			}
 			time.Sleep(pollDelay)
 		}

--- a/pkg/awsathena/query.go
+++ b/pkg/awsathena/query.go
@@ -81,7 +81,11 @@ func WaitForResults(client athenaiface.AthenaAPI, queryExecutionID string) (quer
 				return nil, err
 			}
 			if done {
-				return executionOutput, nil
+				if *executionOutput.QueryExecution.Status.State == athena.QueryExecutionStateFailed {
+					err = errors.Errorf("query execution failed: %s",
+						*executionOutput.QueryExecution.Status.StateChangeReason)
+				}
+				return executionOutput, err
 			}
 			time.Sleep(pollDelay)
 		}


### PR DESCRIPTION
## Background
We discovered during release testing that athena views were not being deployed. Digging into the problem there were 2 issues:
 1) the new gcp logs have a type declaration that Athena does not like, causing view creation to fail
 2) an error path was not handled in the Athena query code, so deploys succeeded

See issue: https://github.com/panther-labs/panther/issues/834

This PR fixes the second issue.

There was a test for execution failures in this code, however, it was validating the wrong error path (failure in SQL planning). The proper test is to force a failure AFTER the planner. This was achieved by creating a table with a  non-existent bucket. The test was further updated to validate the error message from the check for execution failures to confirm the proper code path.

The Athena API does not use awsathena.WaitForResults() and is not affected by this issue.

## Changes
- Add code to check for execution failures
- Change execution failure test 

## Testing
mage test:ci
ran integration tests for awsathena
ran mage deploy, this now fails due to issue 1 above

