### PR TITLE
Fix scheduler bug

### DIFF
--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -25,6 +25,7 @@ type LambdaInput struct {
 	CheckIntegration *CheckIntegrationInput `json:"integrationHealthCheck"`
 
 	PutIntegration *PutIntegrationInput `json:"putIntegration"`
+	FullScan       *FullScanInput       `json:"fullScan"`
 
 	ListIntegrations *ListIntegrationsInput `json:"listIntegrations"`
 
@@ -83,12 +84,21 @@ type PutIntegrationSettings struct {
 }
 
 //
-// ListIntegrations: Used by the Scheduler
+// ListIntegrations: Used by the Scheduler to find integrations to scan
 //
 
 // ListIntegrationsInput allows filtering by the IntegrationType or Enabled fields
 type ListIntegrationsInput struct {
 	IntegrationType *string `json:"integrationType" validate:"omitempty,oneof=aws-scan aws-s3"`
+}
+
+//
+// FullScan: Used by the Scheduler to scan integrations
+//
+
+// FullScanInput is used to do a full scan of one or more integrations.
+type FullScanInput struct {
+	Integrations []*SourceIntegrationMetadata
 }
 
 //

--- a/internal/compliance/snapshot_scheduler/scheduler/schedule.go
+++ b/internal/compliance/snapshot_scheduler/scheduler/schedule.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
-	snapshotapi "github.com/panther-labs/panther/internal/core/source_api/api"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
@@ -62,7 +61,14 @@ func PollAndIssueNewScans() error {
 		}
 	}
 
-	return snapshotapi.ScanAllResources(integrationsToScan)
+	return genericapi.Invoke(
+		lambdaClient,
+		sourceAPIFunctionName,
+		&models.LambdaInput{FullScan: &models.FullScanInput{
+			Integrations: integrationsToScan,
+		}},
+		nil,
+	)
 }
 
 // getEnabledIntegrations lists enabled integrations from the snapshot-api.
@@ -75,9 +81,6 @@ func getEnabledIntegrations() (integrations []*models.SourceIntegration, err err
 		}},
 		&integrations,
 	)
-	if err != nil {
-		return
-	}
 
 	return
 }

--- a/internal/compliance/snapshot_scheduler/scheduler/schedule_test.go
+++ b/internal/compliance/snapshot_scheduler/scheduler/schedule_test.go
@@ -169,6 +169,10 @@ func TestPollAndIssueNewScansNoneToRun(t *testing.T) {
 	mockLambda := &mockLambdaClient{}
 
 	mockLambda.
+		On("Invoke", mock.Anything).
+		// Pass in the first integration, which won't need a new scan.
+		Return(getTestInvokeOutput(exampleIntegrations[:1], 200), nil)
+	mockLambda.
 		On("Invoke", getTestInvokeInput()).
 		// Pass in the first integration, which won't need a new scan.
 		Return(getTestInvokeOutput(exampleIntegrations[:1], 200), nil)

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -193,6 +193,11 @@ func ScanAllResources(integrations []*models.SourceIntegrationMetadata) error {
 		zap.Int("count", len(sqsEntries)),
 	)
 
+	// Setup may have been skipped if this code was called directly from another lambda
+	if sqsClient == nil {
+		Setup()
+	}
+
 	// Batch send all the messages to SQS
 	_, err := sqsbatch.SendMessageBatch(sqsClient, maxElapsedTime, &sqs.SendMessageBatchInput{
 		Entries:  sqsEntries,

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -112,7 +112,7 @@ func (api API) PutIntegration(input *models.PutIntegrationInput) (*models.Source
 	}
 
 	if *input.IntegrationType == models.IntegrationTypeAWSScan {
-		err = ScanAllResources([]*models.SourceIntegrationMetadata{newIntegration})
+		err = api.FullScan(&models.FullScanInput{Integrations: []*models.SourceIntegrationMetadata{newIntegration}})
 		if err != nil {
 			err = errors.Wrap(err, "failed to trigger scanning of resources")
 			return nil, putIntegrationInternalError
@@ -153,14 +153,14 @@ func (api API) integrationAlreadyExists(input *models.PutIntegrationInput) error
 	return nil
 }
 
-// ScanAllResources schedules scans for each Resource type for each integration.
+// FullScan schedules scans for each Resource type for each integration.
 //
 // Each Resource type is sent within its own SQS message.
-func ScanAllResources(integrations []*models.SourceIntegrationMetadata) error {
+func (api API) FullScan(input *models.FullScanInput) error {
 	var sqsEntries []*sqs.SendMessageBatchRequestEntry
 
 	// For each integration, add a ScanMsg to the queue per service
-	for _, integration := range integrations {
+	for _, integration := range input.Integrations {
 		for resourceType := range awspoller.ServicePollers {
 			scanMsg := &pollermodels.ScanMsg{
 				Entries: []*pollermodels.ScanEntry{
@@ -192,11 +192,6 @@ func ScanAllResources(integrations []*models.SourceIntegrationMetadata) error {
 		zap.String("queueUrl", env.SnapshotPollersQueueURL),
 		zap.Int("count", len(sqsEntries)),
 	)
-
-	// Setup may have been skipped if this code was called directly from another lambda
-	if sqsClient == nil {
-		Setup()
-	}
 
 	// Batch send all the messages to SQS
 	_, err := sqsbatch.SendMessageBatch(sqsClient, maxElapsedTime, &sqs.SendMessageBatchInput{

--- a/internal/core/source_api/api/put_integration_test.go
+++ b/internal/core/source_api/api/put_integration_test.go
@@ -134,7 +134,7 @@ func TestAddToSnapshotQueue(t *testing.T) {
 	mockSQS.On("SendMessageBatch", mock.Anything).Return(sqsOut, nil)
 	sqsClient = mockSQS
 
-	err = ScanAllResources([]*models.SourceIntegrationMetadata{testIntegration})
+	err = apiTest.FullScan(&models.FullScanInput{Integrations: []*models.SourceIntegrationMetadata{testIntegration}})
 
 	require.NoError(t, err)
 	// Check that there is one message per service


### PR DESCRIPTION
## Background

Some recent refactoring of the `source-api` prevented the `snapshot-scheduler` from initiating the daily scans, as the `snapshot-scheduler` had previously been directly invoking a function defined in the `source-api` (a function that had previously existed in the now defunct `snapshot-api`). The recent updates to the `source-api` to instantiate all the clients in a `Setup` function broke this because the SQS client would no longer be defined.

## Changes

- The `snapshot-scheduler` now communicates to the `source-api` via API call instead of just by importing it and running the code

## Testing

- Deployed into my dev account
