### PR TITLE
Simplify metric filters

### DIFF
--- a/internal/core/custom_resources/resources/map.go
+++ b/internal/core/custom_resources/resources/map.go
@@ -35,7 +35,7 @@ var CustomResources = map[string]cfn.CustomResourceFunction{
 	// Enforces MFA with TOTP as the only option.
 	//
 	// Parameters:
-	//     UserPoolId: String (required)
+	//     UserPoolId: string (required)
 	// Outputs: None
 	// PhysicalId: custom:cognito-user-pool:$USER_POOL_ID:mfa
 	//
@@ -45,9 +45,9 @@ var CustomResources = map[string]cfn.CustomResourceFunction{
 	// Creates error/warn/memory metric filters on a Lambda function's CloudWatch log group.
 	//
 	// Parameters:
-	//     LambdaRuntime: String ("Go" or "Python", defaults to "Go")
-	//     LogGroupName:  String (required)
+	//     LambdaRuntime: string ("Go" or "Python", default: "Go")
+	//     LogGroupName:  string (required)
 	// Outputs: None
-	// PhysicalId: custom:metric-filters:$LOG_GROUP_NAME:$FILTER1/$FILTER2/...
+	// PhysicalId: custom:metric-filters:$LOG_GROUP_NAME
 	"Custom::LambdaMetricFilters": customLambdaMetricFilters,
 }


### PR DESCRIPTION
## Background

As I was getting ready to work on the next custom resource (alarms), I realized there's a slight problem with the way #872 implemented the custom resource ID.

I was putting the names of each metric filter in the resourceID, so we could extract them later for deletion/updates. However, that makes it hard to add new filters in the future:

1. We deploy the custom resource: `custom:metric-filters:log-group:memory/warns/errors`
2. Some time later, we want to add a new metric filter. We add some dummy parameter which forces CFN to re-evaluate the custom resources
3. CFN does an UPDATE, which now returns `custom:metric-filters:log-group:memory/warns/errors/newfilter`
4. Because the resource IDs are now different, CFN does a DESTROY on the old resource, which removes all filters except the one we just added!

The moral of the story - don't change the resourceID unless you want to destroy the old resource.

## Changes

- Remove metric filter names from the custom resource ID
- Merge create/update logic

## Testing

- Fresh deploy

If someone managed to deploy #872 in the few hours since I merged, the easiest fix is to just comment out all metric filters, deploy, then put them back and deploy again. Otherwise, the next time a metric filter parameter changes, CFN will see the new resource ID and destroy the "old" resource, aka all metric filters.