### PR TITLE
Increase retries for custom resources

### DIFF
--- a/internal/core/custom_resources/resources/clients.go
+++ b/internal/core/custom_resources/resources/clients.go
@@ -19,6 +19,7 @@ package resources
  */
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/acm/acmiface"
@@ -42,7 +43,7 @@ var (
 
 func getSession() *session.Session {
 	if awsSession == nil {
-		awsSession = session.Must(session.NewSession())
+		awsSession = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(10)))
 	}
 	return awsSession
 }


### PR DESCRIPTION
## Background

I got a lot of the following exceptions at some point: 
```
09:49:01        ERROR   stack panther-log-analysis: Custom::LambdaMetricFilters RulesEngineMetricFilters CREATE_FAILED: Failed to create resource. failed to put panther-rules-engine-errors metric filter: ThrottlingException: Rate exceeded
        status code: 400, request id: 151b519f-cee4-4f35-808b-eba0bcbfdc4f
09:49:01        ERROR       X panther-log-analysis failed (6/11): UPDATE_ROLLBACK_IN_PROGRESS
09:49:02        ERROR   stack panther-cloud-security: Custom::LambdaMetricFilters AlertForwarderMetricFilters CREATE_FAILED: Failed to create resource. failed to put panther-alert-forwarder-memory metric filter: ThrottlingException: Rate exceeded
        status code: 400, request id: e965c34e-d430-4ccd-b28d-c513fb853509
09:49:02        ERROR       X panther-cloud-security failed (7/11): UPDATE_ROLLBACK_IN_PROGRESS
```

## Changes

- Increased retries to avoid failure in case of throttling. 

## Testing

- Deployment went through without issues
