### PR TITLE
Fix typo in get_alerts from merge from enterprise

### DIFF
--- a/internal/log_analysis/alerts_api/api/get_alert.go
+++ b/internal/log_analysis/alerts_api/api/get_alert.go
@@ -80,7 +80,7 @@ func (API) GetAlert(input *models.GetAlertInput) (result *models.GetAlertOutput,
 		// We only need to retrieve as many returns as to fit the EventsPageSize given by the user
 		eventsToReturn := *input.EventsPageSize - len(events)
 		eventsReturned, resultToken, getEventsErr := getEventsForLogType(logType, token.LogTypeToToken[logType], alertItem, eventsToReturn)
-		if err != nil {
+		if getEventsErr != nil {
 			err = getEventsErr // set err so it is captured in oplog
 			return nil, err
 		}


### PR DESCRIPTION
## Background
Fix error merging from Enterprise to OSS (caught when merging from OSS to Enterprise) in get_alerts.go

## Testing

- mage test:ci
