### PR TITLE
Fixing bug with stack name

### DIFF
--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -226,6 +226,7 @@ func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceInt
 		metadata.CWEEnabled = input.CWEEnabled
 		metadata.RemediationEnabled = input.RemediationEnabled
 		metadata.ScanIntervalMins = input.ScanIntervalMins
+		metadata.StackName = aws.String(getStackName(*input.IntegrationType, *input.IntegrationLabel))
 	case models.IntegrationTypeAWS3:
 		metadata.AWSAccountID = input.AWSAccountID
 		metadata.S3Bucket = input.S3Bucket

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -63,6 +63,7 @@ func integrationToItem(input *models.SourceIntegration) *ddb.IntegrationItem {
 		item.LastScanErrorMessage = input.LastScanErrorMessage
 		item.LastScanStartTime = input.LastScanStartTime
 		item.LastScanEndTime = input.LastScanEndTime
+		item.StackName = input.StackName
 	}
 	return item
 }
@@ -95,6 +96,7 @@ func itemToIntegration(item *ddb.IntegrationItem) *models.SourceIntegration {
 		integration.LastScanStartTime = item.LastScanStartTime
 		integration.LastScanEndTime = item.LastScanEndTime
 		integration.LastScanErrorMessage = item.LastScanErrorMessage
+		integration.StackName = item.StackName
 	}
 	return integration
 }


### PR DESCRIPTION
## Background

One of the latest refactoring was failing to populate "stackName" property for Scan integrations. 

## Changes

- Populating Scan table property

## Testing

- deployed and verified proper behavior
