### PR TITLE
Remove extraneous statistic from ELB alarm group

### DIFF
--- a/internal/core/custom_resources/resources/alarms_elb.go
+++ b/internal/core/custom_resources/resources/alarms_elb.go
@@ -146,7 +146,7 @@ func putElbAlarmGroup(props ElbAlarmProperties) error {
 	input.ExtendedStatistic = aws.String("p95")
 	input.MetricName = aws.String("TargetResponseTime")
 	input.Period = aws.Int64(25 * 60)
-	input.Statistic = aws.String(cloudwatch.StatisticMaximum)
+	input.Statistic = nil
 	input.Threshold = aws.Float64(props.LatencyThresholdSeconds)
 	input.Unit = aws.String(cloudwatch.StandardUnitSeconds)
 	return putMetricAlarm(input)


### PR DESCRIPTION
## Background

#887 added ELB alarms, but changed some default settings right before merging that broke fresh deploys.

Alarms can have either `Statistic` or `ExtendedStatistic`, but not both

## Changes

- Remove `Statistic` from p95 alarm

## Testing

- Fresh deploy + teardown