### PR TITLE
enable auditing for prod deps only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - checkout
       - run:
           name: Audit NPM packages
-          command: npm audit # does not require installing packages first
+          command: npm audit --production # does not require installing packages first
 
 workflows:
   version: 2


### PR DESCRIPTION
## Background

NPM modules have a lot of sec vulnerabilities. The packages are vulnerable most of the times are the ones that we use for local development which **don't end up in production**.

This PR makes sure to only audit the packages that actually end up in production, so that the CI checks report fewer false positives.
 
## Changes

- Run `npm audit` only on production dependencies 

## Testing

- Related CI checks pass
