### PR TITLE
Provisioned capacity and TTL for key-value store

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -938,7 +938,7 @@ Outputs:
   # Dynamo
   DynamoScalingRoleArn:
     Description: IAM role arn for DynamoDB auto-scaling
-    Value: !Ref DynamoScalingRole
+    Value: !GetAtt DynamoScalingRole.Arn
 
   # KMS
   OutputsEncryptionKeyId:

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -498,6 +498,33 @@ Resources:
         - given_name
         - family_name
 
+  ########## Dynamo ##########
+  DynamoScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: application-autoscaling.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: DynamoScaling
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:DescribeTable
+                  - dynamodb:UpdateTable
+                  - cloudwatch:PutMetricAlarm
+                  - cloudwatch:DescribeAlarms
+                  - cloudwatch:GetMetricStatistics
+                  - cloudwatch:SetAlarmState
+                  - cloudwatch:DeleteAlarms
+                Resource: '*'
+
   ########## ECR + ECS ##########
   PantherWebImageRepository:
     Type: AWS::ECR::Repository
@@ -907,6 +934,11 @@ Outputs:
   AppClientId:
     Description: Cognito user pool client ID
     Value: !Ref AppClient
+
+  # Dynamo
+  DynamoScalingRoleArn:
+    Description: IAM role arn for DynamoDB auto-scaling
+    Value: !Ref DynamoScalingRole
 
   # KMS
   OutputsEncryptionKeyId:

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -516,14 +516,17 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - dynamodb:DescribeTable
-                  - dynamodb:UpdateTable
                   - cloudwatch:PutMetricAlarm
                   - cloudwatch:DescribeAlarms
                   - cloudwatch:GetMetricStatistics
                   - cloudwatch:SetAlarmState
                   - cloudwatch:DeleteAlarms
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - dynamodb:DescribeTable
+                  - dynamodb:UpdateTable
+                Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/panther-*
 
   ########## ECR + ECS ##########
   PantherWebImageRepository:

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -813,6 +813,7 @@ Resources:
 
   ##### Key-Value store for Python policies/rules #####
   # TODO: build conditionally (disabled by default) since you have to pay for provisioned capacity
+  # TODO: make capacity options configurable
   KeyValueStoreTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -32,6 +32,9 @@ Parameters:
   ComplianceApiId:
     Type: String
     Description: Compliance API gateway ID
+  DynamoScalingRoleArn:
+    Type: String
+    Description: IAM role arn for DynamoDB auto-scaling
   OutputsKeyId:
     Type: String
     Description: KMS key for encrypting alert outputs
@@ -809,6 +812,7 @@ Resources:
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
   ##### Key-Value store for Python policies/rules #####
+  # TODO: build conditionally (disabled by default) since you have to pay for provisioned capacity
   KeyValueStoreTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -820,7 +824,7 @@ Resources:
       # * Custom rules / policies which leverage the table may be failing
       # * Panther itself is not affected
       # </cfndoc>
-      BillingMode: PAY_PER_REQUEST
+      BillingMode: PROVISIONED
       AttributeDefinitions:
         - AttributeName: key
           AttributeType: S
@@ -829,5 +833,57 @@ Resources:
           KeyType: HASH
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: True
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
       SSESpecification:
         SSEEnabled: True
+      TimeToLiveSpecification:
+        AttributeName: expiresAt
+        Enabled: true
+
+  ReadCapacityScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 100
+      MinCapacity: 5
+      ResourceId: !Sub table/${KeyValueStoreTable}
+      RoleARN: !Ref DynamoScalingRoleArn
+      ScalableDimension: dynamodb:table:ReadCapacityUnits
+      ServiceNamespace: dynamodb
+
+  ReadScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ReadAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref ReadCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+
+  WriteCapacityScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 100
+      MinCapacity: 5
+      ResourceId: !Sub table/${KeyValueStoreTable}
+      RoleARN: !Ref DynamoScalingRoleArn
+      ScalableDimension: dynamodb:table:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+
+  WriteScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: WriteAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref WriteCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -360,6 +360,7 @@ func deployMainStacks(awsSession *session.Session, settings *config.PantherConfi
 			"AnalysisVersionsBucket": outputs["AnalysisVersionsBucket"],
 			"AnalysisApiId":          outputs["AnalysisApiId"],
 			"ComplianceApiId":        outputs["ComplianceApiId"],
+			"DynamoScalingRoleArn":   outputs["DynamoScalingRoleArn"],
 			"OutputsKeyId":           outputs["OutputsEncryptionKeyId"],
 			"SqsKeyId":               outputs["QueueEncryptionKeyId"],
 			"UserPoolId":             outputs["UserPoolId"],


### PR DESCRIPTION
## Background

Since the key-value store is designed to be accessed from user-defined Python, it would be very easy for DynamoDB costs to skyrocket. To prevent that, we're adding provisioned capacity with autoscaling.

This also adds a TTL column `expiresAt` so Python rules/policies can choose to expire items automatically if they want to.


## Changes

- Add provisioned capacity to panther-kv-store
- Add autoscaling IAM role and targets
- Add TTL column to panther-kv-store

## Testing

Deployed

Confirmed capacity settings are as expected:

<img width="612" alt="Screen Shot 2020-05-18 at 10 51 10 AM" src="https://user-images.githubusercontent.com/3608925/82244094-87254e80-98f5-11ea-8600-d7b8b33604d7.png">