### PR TITLE
Use API ID (not name) for appsync alarms

### DIFF
--- a/internal/core/custom_resources/resources/alarms_appsync.go
+++ b/internal/core/custom_resources/resources/alarms_appsync.go
@@ -65,7 +65,7 @@ func putAppSyncAlarmGroup(props AppSyncAlarmProperties) error {
 		AlarmDescription: aws.String(fmt.Sprintf(
 			"AppSync %s has elevated 4XX errors. See: %s#%s",
 			props.APIName, alarmRunbook, props.APIName)),
-		AlarmName:          aws.String(fmt.Sprintf("Panther-%s-%s", appSyncClientErrorAlarm, props.APIName)),
+		AlarmName:          aws.String(fmt.Sprintf("Panther-%s-%s", appSyncClientErrorAlarm, props.APIID)),
 		ComparisonOperator: aws.String(cloudwatch.ComparisonOperatorGreaterThanThreshold),
 		Dimensions: []*cloudwatch.Dimension{
 			{Name: aws.String("GraphQLAPIId"), Value: &props.APIID},
@@ -85,7 +85,7 @@ func putAppSyncAlarmGroup(props AppSyncAlarmProperties) error {
 	input.AlarmDescription = aws.String(fmt.Sprintf(
 		"AppSync %s is reporting server errors. See: %s#%s",
 		props.APIName, alarmRunbook, props.APIName))
-	input.AlarmName = aws.String(fmt.Sprintf("Panther-%s-%s", appSyncServerErrorAlarm, props.APIName))
+	input.AlarmName = aws.String(fmt.Sprintf("Panther-%s-%s", appSyncServerErrorAlarm, props.APIID))
 	input.MetricName = aws.String("5XXError")
 	input.Threshold = aws.Float64(float64(props.ServerErrorThreshold))
 	return putMetricAlarm(input)


### PR DESCRIPTION
## Background

The AppSync::Alarm custom resource is not being deleted when CloudFormation deletes the resource. This is because we were using the API id for the physical ID:

`custom:alarms:appsync:dp5ghc6zkfhkhgsu6qdiaqkwtm`

But we were using the API *name* for the alarm itself:

`Panther-AppSyncClientErrors-panther-graphql-api`

When the DELETE request was processed, the custom-resources Lambda function tried to delete the alarm named

`Panther-AppSyncClientErrors-dp5ghc6zkfhkhgsu6qdiaqkwtm`

The physical resource ID is how we know which alarm to delete - this succeeded because it's not an error to delete an alarm that doesn't exist, but the actual alarm remained after a teardown.

Closes: #918

## Solution
We can either change the physical resource ID to use the API name or change the alarm name to use the API ID

The alarm itself uses the API ID for the dimension - if the API ID were to change, we would want to destroy the old alarm and make a new one. That is why we use the ID for the physical ID - changing the physical ID will automatically delete the old resource.

So I've changed the alarm name to include the AppSync ID

## Testing

- Fresh deploy + teardown

Existing deployments will have to manually delete their extra alarm, but it also doesn't break anything if it stays around
