### PR TITLE
Added support for backing up processed data

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -51,6 +51,10 @@ Parameters:
     Type: String
     Description: Optional external bucket for storing S3 access logs. If not specified, the Panther audit bucket is used.
     Default: ''
+  DataReplicationBucket:
+    Type: String
+    Description: Optional external bucket for replicating processed data in s3 glacier.
+    Default: ''
   CloudWatchLogRetentionDays:
     Type: Number
     Description: CloudWatch log retention period
@@ -140,6 +144,7 @@ Conditions:
   ConfigureLogSubscriptions: !Not [!Equals [!Select [0, !Ref LogSubscriptionPrincipals], '']]
   EnableAccessLogs: !Equals [!Ref EnableS3AccessLogs, true]
   ExternalAccessLogs: !Not [!Equals [!Ref AccessLogsBucket, '']]
+  ReplicateData: !Not [!Equals [!Ref DataReplicationBucket, '']]
   TracingEnabled: !Not [!Equals [!Ref TracingMode, '']]
   UseCustomDomain: !Not [!Equals [!Ref CustomDomain, '']]
   EnableDebug: !Equals [!Ref Debug, true]
@@ -352,6 +357,16 @@ Resources:
         - DestinationBucketName: !If [ExternalAccessLogs, !Ref AccessLogsBucket, !Ref AuditLogs]
           LogFilePrefix: !Sub panther-processed-data-${AWS::AccountId}-${AWS::Region}/
         - !Ref AWS::NoValue
+      ReplicationConfiguration: !If
+        - ReplicateData
+        - Role: !Sub arn:aws:iam::${AWS::AccountId}:role/panther-data-replication-role
+          Rules:
+            - Destination:
+                Bucket: !Ref DataReplicationBucket
+                StorageClass: GLACIER
+              Prefix: ''
+              Status: Enabled
+        - !Ref AWS::NoValue
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -364,6 +379,44 @@ Resources:
       AccessControl: Private
       VersioningConfiguration:
         Status: Enabled
+
+  DataReplicationRole:
+    Condition: ReplicateData
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: panther-data-replication-role
+      Description: Role used by S3 for data replication
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: s3.amazonaws.com
+      Policies:
+        - PolicyName: ReadData
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetReplicationConfiguration
+                  - s3:ListBucket
+                Resource: !GetAtt ProcessedData.Arn
+              - Effect: Allow
+                Action:
+                  - s3:GetObjectVersion
+                  - s3:GetObjectVersionAcl
+                  - s3:GetObjectVersionTagging
+                Resource: !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/*
+        - PolicyName: ReplicateData
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - s3:ReplicateObject
+                - s3:ReplicateDelete
+                - s3:ReplicateTags
+              Resource: !Sub ${DataReplicationBucket}/*
 
   ProcessedDataPolicy: # read access on processed data bucket for log subscriptions
     Condition: ConfigureLogSubscriptions

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -90,8 +90,6 @@ Setup:
   S3AccessLogsBucket: ''
 
   # If specified, user data is replicated to this bucket.
-  #
-  # Currently only same account data replication is supported.
   DataReplicationBucket: ''
 
   # Whether or not the Panther deployment should automatically onboard itself as a data source.

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -89,6 +89,11 @@ Setup:
   # Has no effect if EnableS3AccessLogs=false above.
   S3AccessLogsBucket: ''
 
+  # If specified, user data is replicated to this bucket.
+  #
+  # Currently only same account data replication is supported.
+  DataReplicationBucket: ''
+
   # Whether or not the Panther deployment should automatically onboard itself as a data source.
   OnboardSelf: true
 

--- a/tools/config/config.go
+++ b/tools/config/config.go
@@ -49,13 +49,14 @@ type Monitoring struct {
 }
 
 type Setup struct {
-	OnboardSelf         bool             `yaml:"OnboardSelf"`
-	EnableS3AccessLogs  bool             `yaml:"EnableS3AccessLogs"`
-	EnableCloudTrail    bool             `yaml:"EnableCloudTrail"`
-	EnableGuardDuty     bool             `yaml:"EnableGuardDuty"`
-	S3AccessLogsBucket  string           `yaml:"S3AccessLogsBucket"`
-	InitialAnalysisSets []string         `yaml:"InitialAnalysisSets"`
-	LogSubscriptions    LogSubscriptions `yaml:"LogSubscriptions"`
+	OnboardSelf           bool             `yaml:"OnboardSelf"`
+	DataReplicationBucket string           `yaml:"DataReplicationBucket"`
+	EnableS3AccessLogs    bool             `yaml:"EnableS3AccessLogs"`
+	EnableCloudTrail      bool             `yaml:"EnableCloudTrail"`
+	EnableGuardDuty       bool             `yaml:"EnableGuardDuty"`
+	S3AccessLogsBucket    string           `yaml:"S3AccessLogsBucket"`
+	InitialAnalysisSets   []string         `yaml:"InitialAnalysisSets"`
+	LogSubscriptions      LogSubscriptions `yaml:"LogSubscriptions"`
 }
 
 type LogSubscriptions struct {

--- a/tools/config/config.go
+++ b/tools/config/config.go
@@ -50,11 +50,11 @@ type Monitoring struct {
 
 type Setup struct {
 	OnboardSelf           bool             `yaml:"OnboardSelf"`
-	DataReplicationBucket string           `yaml:"DataReplicationBucket"`
 	EnableS3AccessLogs    bool             `yaml:"EnableS3AccessLogs"`
 	EnableCloudTrail      bool             `yaml:"EnableCloudTrail"`
 	EnableGuardDuty       bool             `yaml:"EnableGuardDuty"`
 	S3AccessLogsBucket    string           `yaml:"S3AccessLogsBucket"`
+	DataReplicationBucket string           `yaml:"DataReplicationBucket"`
 	InitialAnalysisSets   []string         `yaml:"InitialAnalysisSets"`
 	LogSubscriptions      LogSubscriptions `yaml:"LogSubscriptions"`
 }

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -245,6 +245,7 @@ func deployBoostrapStacks(
 		"LogSubscriptionPrincipals":  strings.Join(settings.Setup.LogSubscriptions.PrincipalARNs, ","),
 		"EnableS3AccessLogs":         strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
 		"AccessLogsBucket":           settings.Setup.S3AccessLogsBucket,
+		"DataReplicationBucket":      settings.Setup.DataReplicationBucket,
 		"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
 		"CustomDomain":               settings.Web.CustomDomain,
 		"Debug":                      strconv.FormatBool(settings.Monitoring.Debug),


### PR DESCRIPTION
## Background

This change adds support for deploying the `processed-data` bucket with data replication. Currently the data replication is for same account GLACIER storage class data replication. This is the use case we have for this feature internally and seems like the most common use case, but could be expanded to cross account or different status data replication in the future if needed.

I considered making more parameters configureable, such storage class or cross account or even a prefix list (if for example you only want to replicate some of the processed data), but I decided against over complicating the feature and polluting the config file and bootstrap stack parameters for a feature that will likely only be used lightly.

Question to reviewers: should we replicate the data in other buckets? I thought about perhaps the analysis versions or audit logs buckets, but the analysis versions bucket is already a backup of data in dynamo and the audit logs buckets are generally ingested by Panther, and so end up (in a normalized form) in the processed data bucket and get replicated eventually anyways.

## Changes

- Updated bootstrap.yml to accept a `DataReplicationBucket` parameter, and if supplied appropriately configure the `processed-data` bucket to replicate data there
- Updated the deploy process to add the `DataReplicationBucket` parameter to `panther_config`

## Testing

- `mage test:ci`
- Deployed into my dev account and verified that data replication was working
