### PR TITLE
Fixing issue with url-encoded S3 object keys

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -23,6 +23,7 @@ import (
 	"compress/gzip"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -236,9 +237,13 @@ func parseS3Event(message string) (result []*S3ObjectInfo) {
 	}
 
 	for _, record := range notification.Records {
+		urlDecodedKey, err := url.PathUnescape(record.S3.Object.Key)
+		if err != nil {
+			return nil
+		}
 		info := &S3ObjectInfo{
 			S3Bucket:    record.S3.Bucket.Name,
-			S3ObjectKey: record.S3.Object.Key,
+			S3ObjectKey: urlDecodedKey,
 		}
 		result = append(result, info)
 	}

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -188,12 +188,12 @@ func readS3Object(s3Object *S3ObjectInfo) (dataStream *common.DataStream, err er
 
 // ParseNotification parses a message received
 func ParseNotification(message string) ([]*S3ObjectInfo, error) {
-	s3Objects, err := parseCloudTrailNotification(message)
+	s3Objects, err := tryParseCloudTrailNotification(message)
 	if err == nil {
 		return s3Objects, nil
 	}
 
-	s3Objects, err = parseS3Event(message)
+	s3Objects, err = tryParseS3Event(message)
 	if err == nil {
 		return s3Objects, nil
 	}
@@ -206,9 +206,9 @@ func ParseNotification(message string) ([]*S3ObjectInfo, error) {
 	return nil, errors.New("notification is not of known type: " + message)
 }
 
-// parseCloudTrailNotification will try to parse input as if it was a CloudTrail notification
-// If the input was not a CloudTrail notification, it will return a empty slice
-func parseCloudTrailNotification(message string) (result []*S3ObjectInfo, err error) {
+// tryParseCloudTrailNotification will try to parse input as if it was a CloudTrail notification
+// If the message is not a CloudTrail notification, the method will return an error.
+func tryParseCloudTrailNotification(message string) (result []*S3ObjectInfo, err error) {
 	cloudTrailNotification := &cloudTrailNotification{}
 	err = jsoniter.UnmarshalFromString(message, cloudTrailNotification)
 	if err != nil {
@@ -229,9 +229,9 @@ func parseCloudTrailNotification(message string) (result []*S3ObjectInfo, err er
 	return result, nil
 }
 
-// parseS3Event will try to parse input as if it was an S3 Event (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
-// If the input was not an S3 Event  notification, it will return a empty slice
-func parseS3Event(message string) (result []*S3ObjectInfo, err error) {
+// tryParseS3Event will try to parse input as if it was an S3 Event (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+// If the input was not an S3 Event  notification, it will return an error
+func tryParseS3Event(message string) (result []*S3ObjectInfo, err error) {
 	notification := &events.S3Event{}
 	err = jsoniter.UnmarshalFromString(message, notification)
 	if err != nil {

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -47,12 +47,12 @@ func TestParseS3Notification(t *testing.T) {
 		"\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AIDAJDPLRKLG7UEXAMPLE\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
 		"\"responseElements\":{\"x-amz-request-id\":\"C3D13FE58DE4C810\",\"x-amz-id-2\":\"FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD\"}," +
 		"\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"testConfigRule\"," +
-		"\"bucket\":{\"name\":\"mybucket\",\"ownerIdentity\":{\"principalId\":\"A3NL1KOZZKExample\"},\"arn\":\"arn:aws:s3:::mybucket\"},\"object\":{\"key\":\"key1\",\"size\":1024," +
+		"\"bucket\":{\"name\":\"mybucket\",\"ownerIdentity\":{\"principalId\":\"A3NL1KOZZKExample\"},\"arn\":\"arn:aws:s3:::mybucket\"},\"object\":{\"key\":\"year%3D2020/key1\",\"size\":1024," +
 		"\"eTag\":\"d41d8cd98f00b204e9800998ecf8427e\",\"versionId\":\"096fKKXTRTtl3on89fVO.nfljtsv6qko\",\"sequencer\":\"0055AED6DCD90281E5\"}}}]}"
 	expectedOutput := []*S3ObjectInfo{
 		{
 			S3Bucket:    "mybucket",
-			S3ObjectKey: "key1",
+			S3ObjectKey: "year=2020/key1",
 		},
 	}
 	s3Objects, err := ParseNotification(notification)


### PR DESCRIPTION
## Background

S3 Event notifications contain the S3 keys URL encoded. Trying to use URL encoded keys with the S3 client results to issues. 

## Changes

- URL decoding S3 object key. 

## Testing

- Unit test
- Ran in my account for few hours, verified it works fine. 
