### PR TITLE
Changing serde to org.apache.hive.hcatalog.data.JsonSerDe

### DIFF
--- a/internal/log_analysis/awsglue/table_metadata.go
+++ b/internal/log_analysis/awsglue/table_metadata.go
@@ -179,7 +179,7 @@ func (gm *GlueTableMetadata) glueTableInput(bucketName string) *glue.TableInput 
 			InputFormat:  aws.String("org.apache.hadoop.mapred.TextInputFormat"),
 			OutputFormat: aws.String("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"),
 			SerdeInfo: &glue.SerDeInfo{
-				SerializationLibrary: aws.String("org.openx.data.jsonserde.JsonSerDe"),
+				SerializationLibrary: aws.String("org.apache.hive.hcatalog.data.JsonSerDe"),
 				Parameters:           descriptorParameters,
 			},
 		},

--- a/internal/log_analysis/awsglue/table_metadata_test.go
+++ b/internal/log_analysis/awsglue/table_metadata_test.go
@@ -53,7 +53,7 @@ var (
 		Columns:  testColumns,
 		Location: aws.String("s3://testbucket/logs/table"),
 		SerdeInfo: &glue.SerDeInfo{
-			SerializationLibrary: aws.String("org.openx.data.jsonserde.JsonSerDe"),
+			SerializationLibrary: aws.String("org.apache.hive.hcatalog.data.JsonSerDe"),
 			Parameters: map[string]*string{
 				"serialization.format": aws.String("1"),
 				"case.insensitive":     aws.String("TRUE"),
@@ -115,7 +115,7 @@ func TestGlueTableMetadataSignature(t *testing.T) {
 	gm := NewGlueTableMetadata(models.LogData, "My.Logs.Type", "description", GlueTableHourly, partitionTestEvent{})
 	sig, err := gm.Signature()
 	require.NoError(t, err)
-	assert.Equal(t, "5a3ca736985afab5ba83361dcb17ecb4fd1ea5632b11674137e6887148556e67", sig)
+	assert.Equal(t, "dacc00b57a8ac738b89d8ecbe3dc86c9beaf952abe164f6c5735de63a29552b9", sig)
 }
 
 func TestCreateJSONPartition(t *testing.T) {

--- a/internal/log_analysis/awsglue/wrappers.go
+++ b/internal/log_analysis/awsglue/wrappers.go
@@ -133,7 +133,7 @@ func UpdatePartition(client glueiface.GlueAPI, databaseName, tableName string,
 }
 
 func IsJSONPartition(storageDescriptor *glue.StorageDescriptor) bool {
-	return strings.Contains(*storageDescriptor.SerdeInfo.SerializationLibrary, "json")
+	return strings.Contains(strings.ToLower(*storageDescriptor.SerdeInfo.SerializationLibrary), "json")
 }
 
 func ParseS3URL(s3URL string) (bucket, key string, err error) {


### PR DESCRIPTION
## Background

Fixing an issue where camelCase fields in a struct would be always null. 

## Changes

- Changed serde

## Testing

- Deployed. Verified that camelCase fields inside structs are now populated:

```
SELECT useridentity.principalid from panther_logs.aws_cloudtrail WHERE useridentity.principalid IS NOT NULL LIMIT 100
```
