### PR TITLE
Add mage temp file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ keys/
 # Terraform
 .terraform
 terraform.tfstate*
+
+# Omit mage temporary file that can be left at root path if mage does not exit gracefully.
+mage_output_file.go


### PR DESCRIPTION
## Background

Mage can leave a temp file on the root path if it doesn't exit gracefully.

## Changes

- Add the file to .gitignore to avoid pushing by mistake


