### PR TITLE
Prefix version in web app with 'v'

### DIFF
--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -352,7 +352,9 @@ Resources:
               - !Sub 349240696275.dkr.ecr.${AWS::Region}.amazonaws.com/panther-community
             tag: !FindInMap [Constants, Panther, Version]
         GraphQLApiEndpoint: !GetAtt Bootstrap.Outputs.GraphQLApiEndpoint
-        PantherVersion: !FindInMap [Constants, Panther, Version]
+        PantherVersion: !Sub
+          - v${version} # has to be prefixed with 'v' for docs link in web app to work
+          - version: !FindInMap [Constants, Panther, Version]
         SecurityGroup: !GetAtt Bootstrap.Outputs.WebSecurityGroup
         SubnetOneId: !GetAtt Bootstrap.Outputs.SubnetOneId
         SubnetTwoId: !GetAtt Bootstrap.Outputs.SubnetTwoId


### PR DESCRIPTION
## Background

In #985 , the documentation link in the wev app doesn't work. I didn't notice this until now because I didn't push the docs branch until *after* finishing the release. We can either make a new tiny release or just bump the v1.4.0 tag forward with this change.

When deploying the pre-packaged template, the version passed to the web stack is '1.4.0' But that version is used for the docs link, which expects `v1.4.0`

## Changes

- Prefix Panther version with 'v' when passing to web stack

## Testing

- Deployed via master template, link works correctly
