### PR TITLE
Add glue:CreatePartition permission

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -161,6 +161,7 @@ Resources:
                 - glue:CreateTable
                 - glue:GetTable
                 - glue:UpdateTable
+                - glue:CreatePartition
                 - glue:GetPartition
                 - glue:UpdatePartition
               # used to keep table schemas updated


### PR DESCRIPTION
## Background

One of our deployment upgrades failed because the custom-resources Lambda was missing a `glue` permission

