### PR TITLE
Small updates to go testing

### DIFF
--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -1,6 +1,3 @@
-// Skip -race testing for this package (takes > 2 minutes)
-// +build !race
-
 package destinations
 
 /**

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -268,12 +268,7 @@ func testGoUnit() error {
 	}
 
 	// unit tests and race detection
-	if err := runGoTest("test", "-race", "-vet", "", "-cover", "./..."); err != nil {
-		return err
-	}
-
-	// One package is explicitly skipped by -race, we have to run its unit tests separately
-	return runGoTest("test", "-vet", "", "-cover", "./internal/log_analysis/log_processor/destinations")
+	return runGoTest("test", "-race", "-v", "-vet", "", "-cover", "./...")
 }
 
 func testGoLint() error {


### PR DESCRIPTION
## Background

Small updates to the way we run go testing

## Changes

- Now running go testing with `-race` flag for all codebase. We were skipping `-race` for one specific package due to performance issues - it seems to not be the case. `mage test:ci` for this PR takes around ~75seconds to complete on my laptop.  More or less the same as before. 
- Enabling the `-v` flag for `go test` command which became available with Go 1.14. For more info see here: https://golang.org/doc/go1.14#go-command 
## Testing

-  `mage test:ci`
