### PR TITLE
Removing  -v argument

### DIFF
--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -268,7 +268,7 @@ func testGoUnit() error {
 	}
 
 	// unit tests and race detection
-	return runGoTest("test", "-race", "-v", "-vet", "", "-cover", "./...")
+	return runGoTest("test", "-race", "-vet", "", "-cover", "./...")
 }
 
 func testGoLint() error {


### PR DESCRIPTION
## Background

Removing `-v` argument for `go test` operation.  Since we run multiple tests in parallel, if we stream test output, it is hard to identify the output of the failing tests

## Changes

- Removed -v argument

## Testing

- mage test:ci
