### PR TITLE
Updated prettier version

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "trailingComma": "es5",
   "printWidth": 100,
   "singleQuote": true,
   "arrowParens": "avoid"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "trailingComma": "es5",
   "printWidth": 100,
-  "singleQuote": true
+  "singleQuote": true,
+  "arrowParens": "avoid"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12574,9 +12574,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "html-webpack-plugin": "^4.0.0-beta.5",
     "husky": "^3.1.0",
     "lint-staged": "^10.0.7",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "react-dev-utils": "^10.1.0",
     "react-refresh": "^0.7.2",
     "svg-url-loader": "^4.0.0",

--- a/web/src/components/forms/AsanaDestinationForm/AsanaDestinationForm.tsx
+++ b/web/src/components/forms/AsanaDestinationForm/AsanaDestinationForm.tsx
@@ -40,9 +40,7 @@ const asanaFieldsValidationSchema = Yup.object().shape({
   outputConfig: Yup.object().shape({
     asana: Yup.object().shape({
       personalAccessToken: Yup.string().required(),
-      projectGids: Yup.array()
-        .of(Yup.number())
-        .required(),
+      projectGids: Yup.array().of(Yup.number()).required(),
     }),
   }),
 });

--- a/web/src/components/forms/CompanyInformationForm/CompanyInformationForm.tsx
+++ b/web/src/components/forms/CompanyInformationForm/CompanyInformationForm.tsx
@@ -37,9 +37,7 @@ interface CompanyInformationFormProps {
 
 const validationSchema = Yup.object({
   displayName: Yup.string().required(),
-  email: Yup.string()
-    .email()
-    .required(),
+  email: Yup.string().email().required(),
   errorReportingConsent: Yup.boolean().required(),
 });
 

--- a/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -33,9 +33,7 @@ const initialValues = {
 };
 
 const validationSchema = Yup.object().shape({
-  email: Yup.string()
-    .email('Needs to be a valid email')
-    .required(),
+  email: Yup.string().email('Needs to be a valid email').required(),
 });
 
 const ForgotPasswordForm: React.FC = () => {

--- a/web/src/components/forms/JiraDestinationForm/JiraDestination.tsx
+++ b/web/src/components/forms/JiraDestinationForm/JiraDestination.tsx
@@ -37,9 +37,7 @@ interface JiraDestinationFormProps {
 const jiraFieldsValidationSchema = Yup.object().shape({
   outputConfig: Yup.object().shape({
     jira: Yup.object().shape({
-      orgDomain: Yup.string()
-        .url('Must be a valid Jira domain')
-        .required(),
+      orgDomain: Yup.string().url('Must be a valid Jira domain').required(),
       userName: Yup.string(),
       projectKey: Yup.string().required(),
       apiKey: Yup.string().required(),

--- a/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.tsx
+++ b/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.tsx
@@ -36,9 +36,7 @@ interface MicrosoftTeamsDestinationFormProps {
 const msTeamsFieldsValidationSchema = Yup.object().shape({
   outputConfig: Yup.object().shape({
     msTeams: Yup.object().shape({
-      webhookURL: Yup.string()
-        .url('Must be a valid webhook URL')
-        .required(),
+      webhookURL: Yup.string().url('Must be a valid webhook URL').required(),
     }),
   }),
 });

--- a/web/src/components/forms/PagerdutyDestinationForm/PagerdutyDestinationForm.tsx
+++ b/web/src/components/forms/PagerdutyDestinationForm/PagerdutyDestinationForm.tsx
@@ -36,9 +36,7 @@ interface PagerDutyDestinationFormProps {
 const pagerDutyFieldsValidationSchema = Yup.object().shape({
   outputConfig: Yup.object().shape({
     pagerDuty: Yup.object().shape({
-      integrationKey: Yup.string()
-        .length(32, 'Must be exactly 32 characters')
-        .required(),
+      integrationKey: Yup.string().length(32, 'Must be exactly 32 characters').required(),
     }),
   }),
 });

--- a/web/src/components/forms/RuleForm/RuleForm.tsx
+++ b/web/src/components/forms/RuleForm/RuleForm.tsx
@@ -33,9 +33,7 @@ const validationSchema = Yup.object().shape({
   body: Yup.string().required(),
   severity: Yup.string().required(),
   dedupPeriodMinutes: Yup.number().integer(),
-  logTypes: Yup.array()
-    .of(Yup.string())
-    .required(),
+  logTypes: Yup.array().of(Yup.string()).required(),
   tests: Yup.array<PolicyUnitTest>()
     .of(
       Yup.object().shape({

--- a/web/src/components/forms/SigninForm/SigninForm.tsx
+++ b/web/src/components/forms/SigninForm/SigninForm.tsx
@@ -34,9 +34,7 @@ const initialValues = {
 };
 
 const validationSchema = Yup.object().shape({
-  username: Yup.string()
-    .email('Needs to be a valid email')
-    .required(),
+  username: Yup.string().email('Needs to be a valid email').required(),
   password: Yup.string().required(),
 });
 

--- a/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.tsx
+++ b/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.tsx
@@ -36,9 +36,7 @@ interface SlackDestinationFormProps {
 const slackFieldsValidationSchema = Yup.object().shape({
   outputConfig: Yup.object().shape({
     slack: Yup.object().shape({
-      webhookURL: Yup.string()
-        .url('Must be a valid webhook URL')
-        .required(),
+      webhookURL: Yup.string().url('Must be a valid webhook URL').required(),
     }),
   }),
 });

--- a/web/src/components/forms/SqsDestinationForm/SqsDestinationForm.tsx
+++ b/web/src/components/forms/SqsDestinationForm/SqsDestinationForm.tsx
@@ -39,9 +39,7 @@ interface SQSDestinationFormProps {
 const sqsFieldsValidationSchema = Yup.object().shape({
   outputConfig: Yup.object().shape({
     sqs: Yup.object().shape({
-      queueUrl: Yup.string()
-        .url('Queue URL must be a valid url')
-        .required('Queue URL is required'),
+      queueUrl: Yup.string().url('Queue URL must be a valid url').required('Queue URL is required'),
     }),
   }),
 });

--- a/web/src/components/wizards/S3LogSourceWizard/S3LogSourceWizard.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/S3LogSourceWizard.tsx
@@ -51,9 +51,7 @@ const validationSchema = Yup.object().shape<S3LogSourceWizardValues>({
   awsAccountId: Yup.string()
     .matches(AWS_ACCOUNT_ID_REGEX, 'Must be a valid AWS Account ID')
     .required(),
-  s3Bucket: Yup.string()
-    .matches(S3_BUCKET_NAME_REGEX, 'Must be valid S3 Bucket name')
-    .required(),
+  s3Bucket: Yup.string().matches(S3_BUCKET_NAME_REGEX, 'Must be valid S3 Bucket name').required(),
   logTypes: Yup.array()
     .of(Yup.string().oneOf((LOG_TYPES as unknown) as string[]))
     .required(),


### PR DESCRIPTION
## Background

Updated prettier version. Seeing speed improvements. 

## Changes

- Version bump for prettier
- Seeing some changes in `*.tsx` files, apparently it is [expected](https://prettier.io/blog/2020/03/21/2.0.0.html#improved-method-chain-breaking-heuristic-6685httpsgithubcomprettierprettierpull6685-by-mmkalhttpsgithubcommmkal). 
- Prettier now runs much faster. `mage fmt` used to take ~17 seconds on average, now takes ~8 seconds

## Testing

- `mage fmt`
- `mage test:ci`
