### PR TITLE
Redact destination secrets

### DIFF
--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -81,10 +81,11 @@ type DeleteOutputInput struct {
 // }
 type UpdateOutputInput struct {
 	UserID             *string       `json:"userId" validate:"required,uuid4"`
-	DisplayName        *string       `json:"displayName" validate:"required,min=1,excludesall='<>&\""`
+	DisplayName        *string       `json:"displayName" validate:"min=1,excludesall='<>&\""`
 	OutputID           *string       `json:"outputId" validate:"required,uuid4"`
-	OutputConfig       *OutputConfig `json:"outputConfig" validate:"required"`
+	OutputConfig       *OutputConfig `json:"outputConfig"`
 	DefaultForSeverity []*string     `json:"defaultForSeverity"`
+	Type               *string       `json:"type" validate:"required"`
 }
 
 // UpdateOutputOutput returns the new updated output

--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -85,7 +85,6 @@ type UpdateOutputInput struct {
 	OutputID           *string       `json:"outputId" validate:"required,uuid4"`
 	OutputConfig       *OutputConfig `json:"outputConfig"`
 	DefaultForSeverity []*string     `json:"defaultForSeverity"`
-	Type               *string       `json:"type" validate:"required"`
 }
 
 // UpdateOutputOutput returns the new updated output

--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -22,12 +22,12 @@ package models
 //
 // Exactly one action must be specified.
 type LambdaInput struct {
-	AddOutput            *AddOutputInput            `json:"addOutput"`
-	UpdateOutput         *UpdateOutputInput         `json:"updateOutput"`
-	GetOutput            *GetOutputInput            `json:"getOutput"`
-	DeleteOutput         *DeleteOutputInput         `json:"deleteOutput"`
-	GetOutputs           *GetOutputsInput           `json:"getOutputs"`
-	GetOutputsUnredacted *GetOutputsUnredactedInput `json:"getOutputsUnredacted"`
+	AddOutput             *AddOutputInput             `json:"addOutput"`
+	UpdateOutput          *UpdateOutputInput          `json:"updateOutput"`
+	GetOutput             *GetOutputInput             `json:"getOutput"`
+	DeleteOutput          *DeleteOutputInput          `json:"deleteOutput"`
+	GetOutputs            *GetOutputsInput            `json:"getOutputs"`
+	GetOutputsWithSecrets *GetOutputsWithSecretsInput `json:"getOutputsWithSecrets"`
 }
 
 // AddOutputInput adds a new encrypted alert output to DynamoDB.
@@ -106,7 +106,7 @@ type GetOutputInput struct {
 // GetOutputOutput contains the configuration for an alert
 type GetOutputOutput = AlertOutput
 
-// GetOrganizationOutputsInput fetches all alert output configuration for one organization
+// GetOutputsInput fetches all alert output configuration for one organization
 //
 // Example:
 // {
@@ -116,12 +116,12 @@ type GetOutputOutput = AlertOutput
 type GetOutputsInput struct {
 }
 
-// GetOrganizationOutputsInput fetches all alert output configuration for one organization
+// GetOutputsWithSecretsInput fetches all alert output configuration for one organization
 // without redacting their secrets
-type GetOutputsUnredactedInput struct {
+type GetOutputsWithSecretsInput struct {
 }
 
-// GetOrganizationOutputsOutput returns all the alert outputs for one organization
+// GetOutputsOutput returns all the alert outputs for one organization
 //
 // Example:
 // {

--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -22,11 +22,12 @@ package models
 //
 // Exactly one action must be specified.
 type LambdaInput struct {
-	AddOutput    *AddOutputInput    `json:"addOutput"`
-	UpdateOutput *UpdateOutputInput `json:"updateOutput"`
-	GetOutput    *GetOutputInput    `json:"getOutput"`
-	DeleteOutput *DeleteOutputInput `json:"deleteOutput"`
-	GetOutputs   *GetOutputsInput   `json:"getOutputs"`
+	AddOutput            *AddOutputInput            `json:"addOutput"`
+	UpdateOutput         *UpdateOutputInput         `json:"updateOutput"`
+	GetOutput            *GetOutputInput            `json:"getOutput"`
+	DeleteOutput         *DeleteOutputInput         `json:"deleteOutput"`
+	GetOutputs           *GetOutputsInput           `json:"getOutputs"`
+	GetOutputsUnredacted *GetOutputsUnredactedInput `json:"getOutputsUnredacted"`
 }
 
 // AddOutputInput adds a new encrypted alert output to DynamoDB.
@@ -113,6 +114,11 @@ type GetOutputOutput = AlertOutput
 //     }
 // }
 type GetOutputsInput struct {
+}
+
+// GetOrganizationOutputsInput fetches all alert output configuration for one organization
+// without redacting their secrets
+type GetOutputsUnredactedInput struct {
 }
 
 // GetOrganizationOutputsOutput returns all the alert outputs for one organization

--- a/internal/core/alert_delivery/delivery/outputs.go
+++ b/internal/core/alert_delivery/delivery/outputs.go
@@ -53,7 +53,7 @@ var (
 func getAlertOutputs(alert *alertmodels.Alert) ([]*outputmodels.AlertOutput, error) {
 	if cache == nil || time.Since(cache.Timestamp) > refreshInterval {
 		zap.L().Debug("getting cached default outputs")
-		input := outputmodels.LambdaInput{GetOutputsUnredacted: &outputmodels.GetOutputsUnredactedInput{}}
+		input := outputmodels.LambdaInput{GetOutputsWithSecrets: &outputmodels.GetOutputsWithSecretsInput{}}
 		var outputs outputmodels.GetOutputsOutput
 		if err := genericapi.Invoke(lambdaClient, outputsAPI, &input, &outputs); err != nil {
 			return nil, err

--- a/internal/core/alert_delivery/delivery/outputs.go
+++ b/internal/core/alert_delivery/delivery/outputs.go
@@ -53,7 +53,7 @@ var (
 func getAlertOutputs(alert *alertmodels.Alert) ([]*outputmodels.AlertOutput, error) {
 	if cache == nil || time.Since(cache.Timestamp) > refreshInterval {
 		zap.L().Debug("getting cached default outputs")
-		input := outputmodels.LambdaInput{GetOutputs: &outputmodels.GetOutputsInput{}}
+		input := outputmodels.LambdaInput{GetOutputsUnredacted: &outputmodels.GetOutputsUnredactedInput{}}
 		var outputs outputmodels.GetOutputsOutput
 		if err := genericapi.Invoke(lambdaClient, outputsAPI, &input, &outputs); err != nil {
 			return nil, err

--- a/internal/core/outputs_api/api/add_output.go
+++ b/internal/core/outputs_api/api/add_output.go
@@ -62,6 +62,7 @@ func (API) AddOutput(input *models.AddOutputInput) (*models.AddOutputOutput, err
 	if err != nil {
 		return nil, err
 	}
+	redactOutput(alertOutput.OutputConfig)
 
 	if err = outputsTable.PutOutput(alertOutputItem); err != nil {
 		return nil, err

--- a/internal/core/outputs_api/api/add_output.go
+++ b/internal/core/outputs_api/api/add_output.go
@@ -62,7 +62,6 @@ func (API) AddOutput(input *models.AddOutputInput) (*models.AddOutputOutput, err
 	if err != nil {
 		return nil, err
 	}
-	redactOutput(alertOutput.OutputConfig)
 
 	if err = outputsTable.PutOutput(alertOutputItem); err != nil {
 		return nil, err
@@ -71,5 +70,6 @@ func (API) AddOutput(input *models.AddOutputInput) (*models.AddOutputOutput, err
 	zap.L().Debug("stored new alert output",
 		zap.String("outputId", *alertOutput.OutputID))
 
+	redactOutput(alertOutput.OutputConfig)
 	return alertOutput, nil
 }

--- a/internal/core/outputs_api/api/add_output_test.go
+++ b/internal/core/outputs_api/api/add_output_test.go
@@ -102,7 +102,7 @@ func TestAddOutputSlack(t *testing.T) {
 		OutputType:         aws.String("slack"),
 		LastModifiedBy:     aws.String("userId"),
 		CreatedBy:          aws.String("userId"),
-		OutputConfig:       &models.OutputConfig{Slack: &models.SlackConfig{WebhookURL: aws.String("hooks.slack.com")}},
+		OutputConfig:       &models.OutputConfig{Slack: &models.SlackConfig{WebhookURL: aws.String("********")}},
 		OutputID:           result.OutputID,
 		CreationTime:       result.CreationTime,
 		LastModifiedTime:   result.LastModifiedTime,
@@ -178,7 +178,7 @@ func TestAddOutputPagerDuty(t *testing.T) {
 		CreatedBy:      aws.String("userId"),
 		OutputConfig: &models.OutputConfig{
 			PagerDuty: &models.PagerDutyConfig{
-				IntegrationKey: aws.String("93ee508cbfea4604afe1c77c2d9b5bbd"),
+				IntegrationKey: aws.String("********"),
 			},
 		},
 		OutputID:         result.OutputID,
@@ -265,7 +265,7 @@ func TestAddOutputAsana(t *testing.T) {
 		CreatedBy:      aws.String("userId"),
 		OutputConfig: &models.OutputConfig{
 			Asana: &models.AsanaConfig{
-				PersonalAccessToken: aws.String("0/8c26ac5222d539ca0ad7000000000000"),
+				PersonalAccessToken: aws.String("********"),
 				ProjectGids:         aws.StringSlice([]string{""}),
 			},
 		},

--- a/internal/core/outputs_api/api/get_outputs.go
+++ b/internal/core/outputs_api/api/get_outputs.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GetOutputs returns all the alert outputs configured for one organization
-func (API) GetOutputs(input *models.GetOutputsInput) (models.GetOutputsOutput, error) {
+func (API) GetOutputs(_ *models.GetOutputsInput) (models.GetOutputsOutput, error) {
 	outputItems, err := outputsTable.GetOutputs()
 	if err != nil {
 		return nil, err
@@ -35,7 +35,9 @@ func (API) GetOutputs(input *models.GetOutputsInput) (models.GetOutputsOutput, e
 		if err != nil {
 			return nil, err
 		}
+		redactOutput(alertOutput.OutputConfig)
 		outputs[i] = alertOutput
 	}
+
 	return outputs, nil
 }

--- a/internal/core/outputs_api/api/get_outputs_unredacted.go
+++ b/internal/core/outputs_api/api/get_outputs_unredacted.go
@@ -22,10 +22,10 @@ import (
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
 )
 
-// GetOutputsUnredacted returns all the alert outputs configured for one organization without
+// GetOutputsWithSecrets returns all the alert outputs configured for one organization without
 // redacting the secrets.
 // This endpoint should only be reachable from internal services.
-func (API) GetOutputsUnredacted(_ *models.GetOutputsUnredactedInput) (models.GetOutputsOutput, error) {
+func (API) GetOutputsWithSecrets(_ *models.GetOutputsWithSecretsInput) (models.GetOutputsOutput, error) {
 	outputItems, err := outputsTable.GetOutputs()
 	if err != nil {
 		return nil, err

--- a/internal/core/outputs_api/api/get_outputs_unredacted.go
+++ b/internal/core/outputs_api/api/get_outputs_unredacted.go
@@ -22,18 +22,23 @@ import (
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
 )
 
-// GetOutput retrieves a single alert output
-func (API) GetOutput(input *models.GetOutputInput) (*models.GetOutputOutput, error) {
-	item, err := outputsTable.GetOutput(input.OutputID)
+// GetOutputsUnredacted returns all the alert outputs configured for one organization without
+// redacting the secrets.
+// This endpoint should only be reachable from internal services.
+func (API) GetOutputsUnredacted(_ *models.GetOutputsUnredactedInput) (models.GetOutputsOutput, error) {
+	outputItems, err := outputsTable.GetOutputs()
 	if err != nil {
 		return nil, err
 	}
 
-	alertOutput, err := ItemToAlertOutput(item)
-	if err != nil {
-		return nil, err
+	outputs := make([]*models.AlertOutput, len(outputItems))
+	for i, item := range outputItems {
+		alertOutput, err := ItemToAlertOutput(item)
+		if err != nil {
+			return nil, err
+		}
+		outputs[i] = alertOutput
 	}
-	redactOutput(alertOutput.OutputConfig)
 
-	return alertOutput, nil
+	return outputs, nil
 }

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -62,6 +62,7 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 	if alertOutput, err = ItemToAlertOutput(alertOutputItem); err != nil {
 		return nil, err
 	}
+	redactOutput(alertOutput.OutputConfig)
 
 	return alertOutput, nil
 }

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -40,17 +40,12 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 			Message: "A destination with the name" + *input.DisplayName + " already exists, please choose another display name"}
 	}
 
-	outputType, err := getOutputType(input.OutputConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	alertOutput := &models.AlertOutput{
 		DisplayName:        input.DisplayName,
 		LastModifiedBy:     input.UserID,
 		LastModifiedTime:   aws.String(time.Now().Format(time.RFC3339)),
 		OutputID:           input.OutputID,
-		OutputType:         outputType,
+		OutputType:         input.Type,
 		OutputConfig:       input.OutputConfig,
 		DefaultForSeverity: input.DefaultForSeverity,
 	}

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -45,7 +45,6 @@ func (API) UpdateOutput(input *models.UpdateOutputInput) (*models.UpdateOutputOu
 		LastModifiedBy:     input.UserID,
 		LastModifiedTime:   aws.String(time.Now().Format(time.RFC3339)),
 		OutputID:           input.OutputID,
-		OutputType:         input.Type,
 		OutputConfig:       input.OutputConfig,
 		DefaultForSeverity: input.DefaultForSeverity,
 	}

--- a/internal/core/outputs_api/api/update_output_test.go
+++ b/internal/core/outputs_api/api/update_output_test.go
@@ -35,7 +35,6 @@ var mockUpdateOutputInput = &models.UpdateOutputInput{
 	UserID:             aws.String("userId"),
 	OutputConfig:       &models.OutputConfig{Sns: &models.SnsConfig{}},
 	DefaultForSeverity: aws.StringSlice([]string{"CRITICAL", "HIGH"}),
-	Type:               aws.String("sns"),
 }
 
 func TestUpdateOutput(t *testing.T) {

--- a/internal/core/outputs_api/api/update_output_test.go
+++ b/internal/core/outputs_api/api/update_output_test.go
@@ -35,6 +35,7 @@ var mockUpdateOutputInput = &models.UpdateOutputInput{
 	UserID:             aws.String("userId"),
 	OutputConfig:       &models.OutputConfig{Sns: &models.SnsConfig{}},
 	DefaultForSeverity: aws.StringSlice([]string{"CRITICAL", "HIGH"}),
+	Type:               aws.String("sns"),
 }
 
 func TestUpdateOutput(t *testing.T) {

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -21,13 +21,12 @@ package api
 import (
 	"errors"
 
-	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
 	"github.com/panther-labs/panther/internal/core/outputs_api/table"
+	"github.com/panther-labs/panther/pkg/box"
 )
 
-var redacted = aws.String("********")
+var redacted = box.String("********")
 
 // AlertOutputToItem converts an AlertOutput to an AlertOutputItem
 func AlertOutputToItem(input *models.AlertOutput) (*table.AlertOutputItem, error) {
@@ -105,34 +104,34 @@ func redactOutput(outputConfig *models.OutputConfig) {
 
 func getOutputType(outputConfig *models.OutputConfig) (*string, error) {
 	if outputConfig.Slack != nil {
-		return aws.String("slack"), nil
+		return box.String("slack"), nil
 	}
 	if outputConfig.PagerDuty != nil {
-		return aws.String("pagerduty"), nil
+		return box.String("pagerduty"), nil
 	}
 	if outputConfig.Github != nil {
-		return aws.String("github"), nil
+		return box.String("github"), nil
 	}
 	if outputConfig.Jira != nil {
-		return aws.String("jira"), nil
+		return box.String("jira"), nil
 	}
 	if outputConfig.Opsgenie != nil {
-		return aws.String("opsgenie"), nil
+		return box.String("opsgenie"), nil
 	}
 	if outputConfig.MsTeams != nil {
-		return aws.String("msteams"), nil
+		return box.String("msteams"), nil
 	}
 	if outputConfig.Sns != nil {
-		return aws.String("sns"), nil
+		return box.String("sns"), nil
 	}
 	if outputConfig.Sqs != nil {
-		return aws.String("sqs"), nil
+		return box.String("sqs"), nil
 	}
 	if outputConfig.Asana != nil {
-		return aws.String("asana"), nil
+		return box.String("asana"), nil
 	}
 	if outputConfig.CustomWebhook != nil {
-		return aws.String("customwebhook"), nil
+		return box.String("customwebhook"), nil
 	}
 
 	return nil, errors.New("no valid output configuration specified for alert output")

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -27,6 +27,8 @@ import (
 	"github.com/panther-labs/panther/internal/core/outputs_api/table"
 )
 
+var redacted = aws.String("********")
+
 // AlertOutputToItem converts an AlertOutput to an AlertOutputItem
 func AlertOutputToItem(input *models.AlertOutput) (*table.AlertOutputItem, error) {
 	item := &table.AlertOutputItem{
@@ -64,14 +66,43 @@ func ItemToAlertOutput(input *table.AlertOutputItem) (alertOutput *models.AlertO
 		DefaultForSeverity: input.DefaultForSeverity,
 	}
 
+	// Decrypt the output before returning to the caller
 	alertOutput.OutputConfig = &models.OutputConfig{}
 	err = encryptionKey.DecryptConfig(input.EncryptedConfig, alertOutput.OutputConfig)
-
 	if err != nil {
 		return nil, err
 	}
 
+	// Redact the output before returning to the caller
+	redactOutput(alertOutput.OutputConfig)
 	return alertOutput, nil
+}
+
+func redactOutput(outputConfig *models.OutputConfig) {
+	if outputConfig.Slack != nil {
+		outputConfig.Slack.WebhookURL = redacted
+	}
+	if outputConfig.PagerDuty != nil {
+		outputConfig.PagerDuty.IntegrationKey = redacted
+	}
+	if outputConfig.Github != nil {
+		outputConfig.Github.Token = redacted
+	}
+	if outputConfig.Jira != nil {
+		outputConfig.Jira.APIKey = redacted
+	}
+	if outputConfig.Opsgenie != nil {
+		outputConfig.Opsgenie.APIKey = redacted
+	}
+	if outputConfig.MsTeams != nil {
+		outputConfig.MsTeams.WebhookURL = redacted
+	}
+	if outputConfig.Asana != nil {
+		outputConfig.Asana.PersonalAccessToken = redacted
+	}
+	if outputConfig.CustomWebhook != nil {
+		outputConfig.CustomWebhook.WebhookURL = redacted
+	}
 }
 
 func getOutputType(outputConfig *models.OutputConfig) (*string, error) {

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -21,12 +21,13 @@ package api
 import (
 	"errors"
 
+	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/panther-labs/panther/api/lambda/outputs/models"
 	"github.com/panther-labs/panther/internal/core/outputs_api/table"
-	"github.com/panther-labs/panther/pkg/box"
 )
 
-var redacted = box.String("********")
+var redacted = aws.String("********")
 
 // AlertOutputToItem converts an AlertOutput to an AlertOutputItem
 func AlertOutputToItem(input *models.AlertOutput) (*table.AlertOutputItem, error) {
@@ -104,34 +105,34 @@ func redactOutput(outputConfig *models.OutputConfig) {
 
 func getOutputType(outputConfig *models.OutputConfig) (*string, error) {
 	if outputConfig.Slack != nil {
-		return box.String("slack"), nil
+		return aws.String("slack"), nil
 	}
 	if outputConfig.PagerDuty != nil {
-		return box.String("pagerduty"), nil
+		return aws.String("pagerduty"), nil
 	}
 	if outputConfig.Github != nil {
-		return box.String("github"), nil
+		return aws.String("github"), nil
 	}
 	if outputConfig.Jira != nil {
-		return box.String("jira"), nil
+		return aws.String("jira"), nil
 	}
 	if outputConfig.Opsgenie != nil {
-		return box.String("opsgenie"), nil
+		return aws.String("opsgenie"), nil
 	}
 	if outputConfig.MsTeams != nil {
-		return box.String("msteams"), nil
+		return aws.String("msteams"), nil
 	}
 	if outputConfig.Sns != nil {
-		return box.String("sns"), nil
+		return aws.String("sns"), nil
 	}
 	if outputConfig.Sqs != nil {
-		return box.String("sqs"), nil
+		return aws.String("sqs"), nil
 	}
 	if outputConfig.Asana != nil {
-		return box.String("asana"), nil
+		return aws.String("asana"), nil
 	}
 	if outputConfig.CustomWebhook != nil {
-		return box.String("customwebhook"), nil
+		return aws.String("customwebhook"), nil
 	}
 
 	return nil, errors.New("no valid output configuration specified for alert output")

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -73,8 +73,6 @@ func ItemToAlertOutput(input *table.AlertOutputItem) (alertOutput *models.AlertO
 		return nil, err
 	}
 
-	// Redact the output before returning to the caller
-	redactOutput(alertOutput.OutputConfig)
 	return alertOutput, nil
 }
 

--- a/internal/core/outputs_api/table/update.go
+++ b/internal/core/outputs_api/table/update.go
@@ -30,13 +30,21 @@ import (
 
 // UpdateOutput updates an existing item in the table
 func (table *OutputsTable) UpdateOutput(alertOutput *AlertOutputItem) (*AlertOutputItem, error) {
+	// These fields will always be sent
 	updateExpression := expression.
-		Set(expression.Name("displayName"), expression.Value(alertOutput.DisplayName)).
 		Set(expression.Name("lastModifiedBy"), expression.Value(alertOutput.LastModifiedBy)).
 		Set(expression.Name("lastModifiedTime"), expression.Value(alertOutput.LastModifiedTime)).
-		Set(expression.Name("outputType"), expression.Value(alertOutput.OutputType)).
-		Set(expression.Name("encryptedConfig"), expression.Value(alertOutput.EncryptedConfig)).
-		Set(expression.Name("defaultForSeverity"), expression.Value(alertOutput.DefaultForSeverity))
+		Set(expression.Name("outputType"), expression.Value(alertOutput.OutputType))
+
+	if alertOutput.DisplayName != nil {
+		updateExpression.Set(expression.Name("displayName"), expression.Value(alertOutput.DisplayName))
+	}
+	if alertOutput.EncryptedConfig != nil {
+		updateExpression.Set(expression.Name("encryptedConfig"), expression.Value(alertOutput.EncryptedConfig))
+	}
+	if alertOutput.DefaultForSeverity != nil {
+		updateExpression.Set(expression.Name("defaultForSeverity"), expression.Value(alertOutput.DefaultForSeverity))
+	}
 
 	conditionExpression := expression.Name("outputId").Equal(expression.Value(alertOutput.OutputID))
 	combinedExpression, err := expression.NewBuilder().

--- a/internal/core/outputs_api/table/update.go
+++ b/internal/core/outputs_api/table/update.go
@@ -33,8 +33,7 @@ func (table *OutputsTable) UpdateOutput(alertOutput *AlertOutputItem) (*AlertOut
 	// These fields will always be sent
 	updateExpression := expression.
 		Set(expression.Name("lastModifiedBy"), expression.Value(alertOutput.LastModifiedBy)).
-		Set(expression.Name("lastModifiedTime"), expression.Value(alertOutput.LastModifiedTime)).
-		Set(expression.Name("outputType"), expression.Value(alertOutput.OutputType))
+		Set(expression.Name("lastModifiedTime"), expression.Value(alertOutput.LastModifiedTime))
 
 	if alertOutput.DisplayName != nil {
 		updateExpression.Set(expression.Name("displayName"), expression.Value(alertOutput.DisplayName))

--- a/internal/core/outputs_api/table/update_test.go
+++ b/internal/core/outputs_api/table/update_test.go
@@ -53,10 +53,10 @@ func TestUpdateOutput(t *testing.T) {
 	table := &OutputsTable{client: dynamoDBClient, Name: aws.String("TableName")}
 
 	expectedUpdateExpression := expression.
-		Set(expression.Name("displayName"), expression.Value(mockUpdateItemAlertOutput.DisplayName)).
 		Set(expression.Name("lastModifiedBy"), expression.Value(mockUpdateItemAlertOutput.LastModifiedBy)).
 		Set(expression.Name("lastModifiedTime"), expression.Value(mockUpdateItemAlertOutput.LastModifiedTime)).
 		Set(expression.Name("outputType"), expression.Value(mockUpdateItemAlertOutput.OutputType)).
+		Set(expression.Name("displayName"), expression.Value(mockUpdateItemAlertOutput.DisplayName)).
 		Set(expression.Name("encryptedConfig"), expression.Value(mockUpdateItemAlertOutput.EncryptedConfig)).
 		Set(expression.Name("defaultForSeverity"), expression.Value(mockUpdateItemAlertOutput.DefaultForSeverity))
 

--- a/internal/core/outputs_api/table/update_test.go
+++ b/internal/core/outputs_api/table/update_test.go
@@ -55,7 +55,6 @@ func TestUpdateOutput(t *testing.T) {
 	expectedUpdateExpression := expression.
 		Set(expression.Name("lastModifiedBy"), expression.Value(mockUpdateItemAlertOutput.LastModifiedBy)).
 		Set(expression.Name("lastModifiedTime"), expression.Value(mockUpdateItemAlertOutput.LastModifiedTime)).
-		Set(expression.Name("outputType"), expression.Value(mockUpdateItemAlertOutput.OutputType)).
 		Set(expression.Name("displayName"), expression.Value(mockUpdateItemAlertOutput.DisplayName)).
 		Set(expression.Name("encryptedConfig"), expression.Value(mockUpdateItemAlertOutput.EncryptedConfig)).
 		Set(expression.Name("defaultForSeverity"), expression.Value(mockUpdateItemAlertOutput.DefaultForSeverity))

--- a/pkg/encryption/encrypt.go
+++ b/pkg/encryption/encrypt.go
@@ -27,6 +27,10 @@ import (
 
 // EncryptConfig uses KMS to encrypt an output configuration.
 func (key *Key) EncryptConfig(config interface{}) ([]byte, error) {
+	// Allow an empty config to be specified
+	if config == nil {
+		return nil, nil
+	}
 	body, err := jsoniter.Marshal(config)
 	if err != nil {
 		return nil, &genericapi.InternalError{


### PR DESCRIPTION
## Background

Previously, configuration secrets such as API keys were displayed in plain text to users when viewing the destination configurations. This change both redacts those secrets before returning them to the frontend, and also allows the frontend to make partial updates to destinations.

Notes to the frontend team: All API calls that return an `AlertOutput` object should now have all secret fields redacted. I redacted them with asterisks `********` but if it would be easier to just return `nil` and have you guys put in a place holder on the frontend let me know. I also changed the signature for `UpdateOutput` API calls, the `displayName`, `defaultForSeverity` and `outputConfig` fields are now optional. Feel free to still send them if you want, but at least for `outputConfig` you need to not send anything if the user didn't change it because you won't know what it's configuration is.

## Changes

- Redact destination configuration secrets before sending them to the frontend
- Allow for partial updates of destinations

## Testing

- unit testing
- deployed to dev account and created a new destination
  - Observed that upon reloading the destinations screen, I was no longer able to see the configuration's API token
  - Went to the AWS lambda console, and manually tested a partial update with the following payload:
```
{
  "UpdateOutput": {
    "userId": "8cf47b32-9e03-4a9f-9c11-704dc55e7287",
    "displayName": "New Name",
    "outputId": "f199b5e4-bfbc-42c6-82f7-a42b1b6b438c",
    "outputConfig": null,
    "defaultForSeverity": null
  }
}
```
