### PR TITLE
Improve log processor assume role usage

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -163,7 +163,7 @@ func getAwsCredentials(roleArn string) *credentials.Credentials {
 	zap.L().Debug("fetching new credentials from assumed role", zap.String("roleArn", roleArn))
 	return newCredentialsFunc(common.Session, roleArn, func(p *stscreds.AssumeRoleProvider) {
 		p.Duration = time.Duration(sessionDurationSeconds) * time.Second
-		p.ExpiryWindow = p.Duration / 2 // give plenty of time to refresh
+		p.ExpiryWindow = time.Minute // give plenty of time to refresh
 	})
 }
 


### PR DESCRIPTION
## Before
When processing an s3 object stscreds.NewCredentials() was called each time.

## After
Now  stscreds.NewCredentials() is called only when needed.

## Testing

- mage deploy, checked for any errors (were none)
