### PR TITLE
Fixed hardcoded doc url in StackDeployment

### DIFF
--- a/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -20,7 +20,7 @@ import { Text, Box, Heading, Spinner, Flex, Link } from 'pouncejs';
 import React from 'react';
 import { extractErrorMessage, toStackNameFormat } from 'Helpers/utils';
 import { useFormikContext } from 'formik';
-import { LOG_ONBOARDING_DOC_URL } from 'Source/constants';
+import { LOG_ONBOARDING_SNS_DOC_URL } from 'Source/constants';
 import { pantherConfig } from 'Source/config';
 import { useGetLogCfnTemplate } from './graphql/getLogCfnTemplate.generated';
 import { S3LogSourceWizardValues } from '../S3LogSourceWizard';
@@ -126,7 +126,7 @@ const StackDeployment: React.FC = () => {
               external
               color="blue300"
               title="SNS Notification Setup"
-              href={LOG_ONBOARDING_DOC_URL}
+              href={LOG_ONBOARDING_SNS_DOC_URL}
             >
               here
             </Link>{' '}

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -134,12 +134,16 @@ export const SEVERITY_COLOR_MAP: { [key in SeverityEnum]: BadgeProps['color'] } 
   [SeverityEnum.Info]: 'neutral' as const,
 };
 
+// Section with generic and specific doc URLs
 export const PANTHER_SCHEMA_DOCS_MASTER_LINK = 'https://docs.runpanther.io';
 
 export const PANTHER_SCHEMA_DOCS_LINK = generateDocUrl(
   PANTHER_SCHEMA_DOCS_MASTER_LINK,
   pantherConfig.PANTHER_VERSION
 );
+
+export const LOG_ONBOARDING_SNS_DOC_URL = `${PANTHER_SCHEMA_DOCS_LINK}/log-processing#sns-notification-setup`;
+// End of doc URLs section
 
 export const DEFAULT_SMALL_PAGE_SIZE = 10;
 export const DEFAULT_LARGE_PAGE_SIZE = 25;
@@ -150,5 +154,3 @@ export const ERROR_REPORTING_CONSENT_STORAGE_KEY = 'panther.generalSettings.erro
 
 // The default panther system user id
 export const PANTHER_USER_ID = '00000000-0000-4000-8000-000000000000';
-// Docs URL we use to prompt users for explanations
-export const LOG_ONBOARDING_DOC_URL = `https://docs.runpanther.io/log-processing#sns-notification-setup`;


### PR DESCRIPTION
## Background

There was a hardcoded URL pointing to the old doc URL located on `StackDeployment` page. In this PR, I changed that to use generated doc URL as prefix.

Broken link now redirects correctly [here](https://docs.runpanther.io/v/v1.4.0-docs/log-processing#sns-notification-setup).

Also, did a check for any other stray doc URL and didn't find any. 

Closes #1026  

## Changes

- Created a specific section in `constants` file for doc URLs, including the missing doc URL described on #1026 

## Testing

- Locally 
![Screenshot 2020-06-15 at 8 26 50 PM](https://user-images.githubusercontent.com/14179917/84688377-eb185280-af47-11ea-8dfe-8a2c654d2f9c.png)

