### PR TITLE
Fix outputs-api integration tests

### DIFF
--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -40,12 +40,6 @@ Parameters:
   LayerVersionArns:
     Type: CommaDelimitedList
     Description: List of base LayerVersion ARNs to attach to every Lambda function
-  RemediationApiId:
-    Type: String
-    Description: API Gateway for remediation-api
-  ResourcesApiId:
-    Type: String
-    Description: API Gateway for resources-api
   ProcessedDataBucket:
     Type: String
     Description: Name of the S3 bucket for storing processed logs
@@ -55,6 +49,12 @@ Parameters:
   PythonLayerVersionArn:
     Type: String
     Description: Pip libraries for python analysis and remediation
+  RemediationApiId:
+    Type: String
+    Description: API Gateway for remediation-api
+  ResourcesApiId:
+    Type: String
+    Description: API Gateway for resources-api
   SqsKeyId:
     Type: String
     Description: KMS key ID for SQS encryption

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -24,9 +24,6 @@ Parameters:
   AlarmTopicArn:
     Type: String
     Description: SNS topic for CloudWatch alarms
-  AppDomainURL:
-    Type: String
-    Description: Panther App Domain used as a link for the customer in the password reset email
   AnalysisApiEndpoint:
     Type: String
     Description: Analysis API gateway FQDN
@@ -36,6 +33,9 @@ Parameters:
   AnalysisVersionsBucket:
     Type: String
     Description: S3 bucket for python revision history
+  AppDomainURL:
+    Type: String
+    Description: Panther App Domain used as a link for the customer in the password reset email
   AthenaResultsBucket:
     Type: String
     Description: Bucket created to hold Athena results

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -236,10 +236,10 @@ Resources:
       TemplateURL: core.yml
       Parameters:
         AlarmTopicArn: !GetAtt Bootstrap.Outputs.AlarmTopicArn
-        AppDomainURL: !GetAtt Bootstrap.Outputs.LoadBalancerUrl
         AnalysisApiEndpoint: !GetAtt BootstrapGateway.Outputs.AnalysisApiEndpoint
         AnalysisApiId: !GetAtt BootstrapGateway.Outputs.AnalysisApiId
         AnalysisVersionsBucket: !GetAtt Bootstrap.Outputs.AnalysisVersionsBucket
+        AppDomainURL: !GetAtt Bootstrap.Outputs.LoadBalancerUrl
         AthenaResultsBucket: !GetAtt Bootstrap.Outputs.AthenaResultsBucket
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
         CompanyDisplayName: !Ref CompanyDisplayName
@@ -339,14 +339,15 @@ Resources:
       Parameters:
         AlarmTopicArn: !GetAtt Bootstrap.Outputs.AlarmTopicArn
         AppClientId: !GetAtt Bootstrap.Outputs.AppClientId
-        CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
         CertificateArn: !Ref CertificateArn
+        CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
         ElbArn: !GetAtt Bootstrap.Outputs.LoadBalancerArn
         ElbFullName: !GetAtt Bootstrap.Outputs.LoadBalancerFullName
         ElbTargetGroup: !GetAtt Bootstrap.Outputs.LoadBalancerTargetGroup
-        FirstUserGivenName: !Ref FirstUserGivenName
-        FirstUserFamilyName: !Ref FirstUserFamilyName
         FirstUserEmail: !Ref FirstUserEmail
+        FirstUserFamilyName: !Ref FirstUserFamilyName
+        FirstUserGivenName: !Ref FirstUserGivenName
+        GraphQLApiEndpoint: !GetAtt Bootstrap.Outputs.GraphQLApiEndpoint
         Image: !Sub
           - '${registry}:${tag}'
           - registry: !If
@@ -354,7 +355,6 @@ Resources:
               - !Ref ImageRegistry
               - !Sub 349240696275.dkr.ecr.${AWS::Region}.amazonaws.com/panther-community
             tag: !FindInMap [Constants, Panther, Version]
-        GraphQLApiEndpoint: !GetAtt Bootstrap.Outputs.GraphQLApiEndpoint
         PantherVersion: !Sub
           - v${version} # has to be prefixed with 'v' for docs link in web app to work
           - version: !FindInMap [Constants, Panther, Version]

--- a/internal/core/outputs_api/main/integration_test.go
+++ b/internal/core/outputs_api/main/integration_test.go
@@ -254,11 +254,6 @@ func updateSlack(t *testing.T) {
 	var output models.UpdateOutputOutput
 	require.NoError(t, genericapi.Invoke(lambdaClient, outputsAPI, &input, &output))
 
-	assert.Equal(t, aws.StringSlice([]string{"CRITICAL"}), output.DefaultForSeverity)
-	assert.Equal(t, slackOutputID, output.OutputID)
-	assert.Equal(t, aws.String("alert-channel-new"), output.DisplayName)
-	assert.Equal(t, aws.String("slack"), output.OutputType)
-
 	expected := models.UpdateOutputOutput{
 		CreatedBy:          userID,
 		CreationTime:       output.CreationTime,
@@ -270,7 +265,6 @@ func updateSlack(t *testing.T) {
 		OutputID:           slackOutputID,
 		OutputType:         aws.String("slack"),
 	}
-
 	assert.Equal(t, expected, output)
 }
 
@@ -357,12 +351,12 @@ func deleteSnsEmpty(t *testing.T) {
 }
 
 func getOutputs(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	verifyListOutputs(t, false)
 }
 
 func getOutputsWithSecrets(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	verifyListOutputs(t, true)
 }
 

--- a/internal/core/outputs_api/main/integration_test.go
+++ b/internal/core/outputs_api/main/integration_test.go
@@ -93,6 +93,7 @@ func TestIntegrationAPI(t *testing.T) {
 	// Get outputs in parallel
 	t.Run("Get", func(t *testing.T) {
 		t.Run("GetOutputs", getOutputs)
+		t.Run("GetOutputsWithSecrets", getOutputsWithSecrets)
 		t.Run("GetOutput", getOutput)
 	})
 	if t.Failed() {
@@ -102,6 +103,7 @@ func TestIntegrationAPI(t *testing.T) {
 	// Update each output in parallel.
 	t.Run("Update", func(t *testing.T) {
 		t.Run("UpdateInvalid", updateInvalid)
+		t.Run("UpdateSlack", updateSlack)
 		t.Run("UpdateSns", updateSns)
 	})
 	if t.Failed() {
@@ -239,6 +241,39 @@ func updateInvalid(t *testing.T) {
 	assert.Equal(t, expected, err)
 }
 
+func updateSlack(t *testing.T) {
+	t.Parallel()
+	input := models.LambdaInput{
+		UpdateOutput: &models.UpdateOutputInput{
+			UserID:             userID,
+			OutputID:           slackOutputID,
+			DisplayName:        aws.String("alert-channel-new"),
+			DefaultForSeverity: aws.StringSlice([]string{"CRITICAL"}),
+		},
+	}
+	var output models.UpdateOutputOutput
+	require.NoError(t, genericapi.Invoke(lambdaClient, outputsAPI, &input, &output))
+
+	assert.Equal(t, aws.StringSlice([]string{"CRITICAL"}), output.DefaultForSeverity)
+	assert.Equal(t, slackOutputID, output.OutputID)
+	assert.Equal(t, aws.String("alert-channel-new"), output.DisplayName)
+	assert.Equal(t, aws.String("slack"), output.OutputType)
+
+	expected := models.UpdateOutputOutput{
+		CreatedBy:          userID,
+		CreationTime:       output.CreationTime,
+		DefaultForSeverity: input.UpdateOutput.DefaultForSeverity,
+		DisplayName:        input.UpdateOutput.DisplayName,
+		LastModifiedBy:     userID,
+		LastModifiedTime:   output.LastModifiedTime,
+		OutputConfig:       &models.OutputConfig{}, // no webhook URL in response
+		OutputID:           slackOutputID,
+		OutputType:         aws.String("slack"),
+	}
+
+	assert.Equal(t, expected, output)
+}
+
 func updateSns(t *testing.T) {
 	t.Parallel()
 	sns.TopicArn = aws.String("arn:aws:sns:us-west-2:123456789012:MyTopic")
@@ -322,46 +357,85 @@ func deleteSnsEmpty(t *testing.T) {
 }
 
 func getOutputs(t *testing.T) {
-	t.Parallel()
-	input := models.LambdaInput{GetOutputs: &models.GetOutputsInput{}}
-	var output models.GetOutputsOutput
-	require.NoError(t, genericapi.Invoke(lambdaClient, outputsAPI, &input, &output))
+	//t.Parallel()
+	verifyListOutputs(t, false)
+}
+
+func getOutputsWithSecrets(t *testing.T) {
+	//t.Parallel()
+	verifyListOutputs(t, true)
+}
+
+func verifyListOutputs(t *testing.T, withSecrets bool) {
+	var input models.LambdaInput
+	if withSecrets {
+		input.GetOutputsWithSecrets = &models.GetOutputsWithSecretsInput{}
+	} else {
+		input.GetOutputs = &models.GetOutputsInput{}
+	}
+
+	var outputs models.GetOutputsOutput
+	require.NoError(t, genericapi.Invoke(lambdaClient, outputsAPI, &input, &outputs))
 
 	// We need to sort the output because order of returned outputItems is not guaranteed by DDB
-	sort.Slice(output, func(i, j int) bool {
-		return *output[i].OutputType > *output[j].OutputType
+	sort.Slice(outputs, func(i, j int) bool {
+		return *outputs[i].OutputType > *outputs[j].OutputType
 	})
-	assert.Len(t, output, 3)
+	assert.Len(t, outputs, 3)
 
-	assert.Equal(t, snsOutputID, output[0].OutputID)
-	assert.Equal(t, aws.String("sns"), output[0].OutputType)
-	assert.Equal(t, userID, output[0].CreatedBy)
-	assert.Equal(t, userID, output[0].LastModifiedBy)
-	assert.Equal(t, aws.String("alert-topic"), output[0].DisplayName)
-	assert.Nil(t, output[0].OutputConfig.Slack)
-	assert.Nil(t, output[0].OutputConfig.PagerDuty)
-	assert.Equal(t, sns, output[0].OutputConfig.Sns)
-	assert.Equal(t, []*string{}, output[0].DefaultForSeverity)
+	// Verify timestamps and ids since we don't know their value ahead of time
+	for _, output := range outputs {
+		assert.NotNil(t, output.CreationTime)
+		assert.NotNil(t, output.OutputID)
+	}
 
-	assert.Equal(t, slackOutputID, output[1].OutputID)
-	assert.Equal(t, aws.String("slack"), output[1].OutputType)
-	assert.Equal(t, userID, output[1].CreatedBy)
-	assert.Equal(t, userID, output[1].LastModifiedBy)
-	assert.Equal(t, aws.String("alert-channel"), output[1].DisplayName)
-	assert.Nil(t, output[1].OutputConfig.Sns)
-	assert.Nil(t, output[1].OutputConfig.PagerDuty)
-	assert.Equal(t, aws.String("********"), output[1].OutputConfig.Slack.WebhookURL)
-	assert.Equal(t, aws.StringSlice([]string{"HIGH"}), output[1].DefaultForSeverity)
+	expected := models.GetOutputsOutput{
+		{
+			CreatedBy:          userID,
+			CreationTime:       outputs[0].CreationTime,
+			DefaultForSeverity: []*string{},
+			DisplayName:        aws.String("alert-topic"),
+			LastModifiedBy:     userID,
+			LastModifiedTime:   outputs[0].LastModifiedTime,
+			OutputID:           outputs[0].OutputID,
+			OutputType:         aws.String("sns"),
+			OutputConfig:       &models.OutputConfig{Sns: sns},
+		},
+		{
+			CreatedBy:          userID,
+			CreationTime:       outputs[1].CreationTime,
+			DefaultForSeverity: aws.StringSlice([]string{"HIGH"}),
+			DisplayName:        aws.String("alert-channel"),
+			LastModifiedBy:     userID,
+			LastModifiedTime:   outputs[1].LastModifiedTime,
+			OutputID:           outputs[1].OutputID,
+			OutputType:         aws.String("slack"),
+			OutputConfig:       &models.OutputConfig{Slack: slack},
+		},
+		{
+			CreatedBy:          userID,
+			CreationTime:       outputs[2].CreationTime,
+			DefaultForSeverity: []*string{},
+			DisplayName:        aws.String("pagerduty-integration"),
+			LastModifiedBy:     userID,
+			LastModifiedTime:   outputs[2].LastModifiedTime,
+			OutputID:           outputs[2].OutputID,
+			OutputType:         aws.String("pagerduty"),
+			OutputConfig:       &models.OutputConfig{PagerDuty: pagerDuty},
+		},
+	}
 
-	assert.Equal(t, pagerDutyOutputID, output[2].OutputID)
-	assert.Equal(t, aws.String("pagerduty"), output[2].OutputType)
-	assert.Equal(t, userID, output[2].CreatedBy)
-	assert.Equal(t, userID, output[2].LastModifiedBy)
-	assert.Equal(t, aws.String("pagerduty-integration"), output[2].DisplayName)
-	assert.Nil(t, output[2].OutputConfig.Slack)
-	assert.Nil(t, output[2].OutputConfig.Sns)
-	assert.Equal(t, aws.String("********"), output[2].OutputConfig.PagerDuty.IntegrationKey)
-	assert.Equal(t, aws.StringSlice([]string{}), output[2].DefaultForSeverity)
+	if !withSecrets {
+		// Credentials are obfuscated
+		expected[1].OutputConfig.Slack = &models.SlackConfig{
+			WebhookURL: aws.String("********"),
+		}
+		expected[2].OutputConfig.PagerDuty = &models.PagerDutyConfig{
+			IntegrationKey: aws.String("********"),
+		}
+	}
+
+	assert.Equal(t, expected, outputs)
 }
 
 func getOutput(t *testing.T) {

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -446,10 +446,10 @@ func deployCloudSecurityStack(settings *config.PantherConfig, outputs map[string
 func deployCoreStack(settings *config.PantherConfig, outputs map[string]string) error {
 	_, err := deployTemplate(coreTemplate, outputs["SourceBucket"], coreStack, map[string]string{
 		"AlarmTopicArn":              outputs["AlarmTopicArn"],
-		"AppDomainURL":               outputs["LoadBalancerUrl"],
 		"AnalysisApiEndpoint":        outputs["AnalysisApiEndpoint"],
 		"AnalysisApiId":              outputs["AnalysisApiId"],
 		"AnalysisVersionsBucket":     outputs["AnalysisVersionsBucket"],
+		"AppDomainURL":               outputs["LoadBalancerUrl"],
 		"AthenaResultsBucket":        outputs["AthenaResultsBucket"],
 		"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
 		"CompanyDisplayName":         settings.Setup.Company.DisplayName,

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -418,24 +418,35 @@ func (t Test) Integration() {
 
 	if pkg := os.Getenv("PKG"); pkg != "" {
 		// One specific package requested: run integration tests just for that
-		goPkgIntegrationTest(pkg)
+		if err := goPkgIntegrationTest(pkg); err != nil {
+			logger.Fatal(err)
+		}
 		return
 	}
 
+	errCount := 0
 	walk(".", func(path string, info os.FileInfo) {
 		if filepath.Base(path) == "integration_test.go" {
-			goPkgIntegrationTest("./" + filepath.Dir(path))
+			if err := goPkgIntegrationTest("./" + filepath.Dir(path)); err != nil {
+				logger.Error(err)
+				errCount++
+			}
 		}
 	})
 
 	logger.Info("test:integration: python policy engine")
 	if err := sh.RunV(pythonLibPath("python3"), "internal/compliance/policy_engine/tests/integration.py"); err != nil {
-		logger.Fatalf("python integration test failed: %v", err)
+		logger.Errorf("python integration test failed: %v", err)
+		errCount++
+	}
+
+	if errCount > 1 {
+		logger.Fatalf("%d integration test(s) failed", errCount)
 	}
 }
 
 // Run integration tests for a single Go package.
-func goPkgIntegrationTest(pkg string) {
+func goPkgIntegrationTest(pkg string) error {
 	if err := os.Setenv("INTEGRATION_TEST", "True"); err != nil {
 		logger.Fatalf("failed to set INTEGRATION_TEST environment variable: %v", err)
 	}
@@ -447,7 +458,6 @@ func goPkgIntegrationTest(pkg string) {
 	if mg.Verbose() {
 		args = append(args, "-v")
 	}
-	if err := sh.RunV("go", args...); err != nil {
-		logger.Fatalf("go test %s failed: %v", pkg, err)
-	}
+
+	return sh.RunV("go", args...)
 }

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -440,7 +440,7 @@ func (t Test) Integration() {
 		errCount++
 	}
 
-	if errCount > 1 {
+	if errCount > 0 {
 		logger.Fatalf("%d integration test(s) failed", errCount)
 	}
 }


### PR DESCRIPTION
## Background

#1033 broke the `outputs-api` integration tests

## Changes

- Fix `outputs-api` integration tests
- Change `mage test:integration` so that errors are not blocking

It takes several minutes to run all integration tests, a failure halfway through is frustrating because `mage` will stop immediately and you'll have no way to know if the remaining tests would have passed.

Now, all errors are logged so you can address all integration test failures at once

## Testing

- `mage test:integration` 3 times plus `PKG=./internal/core/outputs_api/main mage test:integration` a few times
