### PR TITLE
Secrets manager permissions

### DIFF
--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -1238,6 +1238,12 @@ Resources:
             - Effect: Allow
               Action: dynamodb:*Item
               Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/panther-kv-store
+        - Id: GetPantherPolicySecrets
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-policies/*
 
   PolicyEngineLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -1244,6 +1244,12 @@ Resources:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
               Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-policies/*
+        - Id: GetPantherAnalysisSecrets
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-analysis/*
 
   PolicyEngineLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -1243,13 +1243,13 @@ Resources:
           Statement:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
-              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-policies/*
+              Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:panther-policies/*
         - Id: GetPantherAnalysisSecrets
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
-              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-analysis/*
+              Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:panther-analysis/*
 
   PolicyEngineLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -856,6 +856,12 @@ Resources:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
               Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-rules/*
+        - Id: GetPantherAnalysisSecrets
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-analysis/*
 
   RulesEngineAlarms:
     Type: Custom::LambdaAlarms

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -850,6 +850,12 @@ Resources:
             - Effect: Allow
               Action: dynamodb:*Item
               Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/panther-kv-store
+        - Id: GetPantherRuleSecrets
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-rules/*
 
   RulesEngineAlarms:
     Type: Custom::LambdaAlarms

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -855,13 +855,13 @@ Resources:
           Statement:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
-              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-rules/*
+              Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:panther-rules/*
         - Id: GetPantherAnalysisSecrets
           Version: 2012-10-17
           Statement:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
-              Resource: !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:panther-analysis/*
+              Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:panther-analysis/*
 
   RulesEngineAlarms:
     Type: Custom::LambdaAlarms


### PR DESCRIPTION
## Background

Give the policy and rules engines permissions to communicate to AWS secrets manager.

I gave the two engines access to different 'paths' in secrets manager, because we separate permissions for policy/rule writing so technically one could have a secret that the other shouldn't have access to. But generally any rule can access any secret put in by any other rule.

They also have a shared path for shared secrets.

We're considering adding something to the `panther_analysis_tool` to assist in uploading these secrets, so you can securely store the initial secret. But currently you'll have to load the secret in from the AWS console.

## Changes

- Updated permissions of policy/rules engines

## Testing

- Doing a deployment to dev account currently to test this
