### PR TITLE
Removing 4XX alarms for ALB

### DIFF
--- a/deployments/web_server.yml
+++ b/deployments/web_server.yml
@@ -94,7 +94,6 @@ Resources:
     Type: Custom::ElbAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
-      ClientErrorThreshold: 10 # within 5 minutes
       LatencyThresholdSeconds: 0.5
       LoadBalancerFriendlyName: web
       LoadBalancerFullName: !Ref ElbFullName

--- a/internal/core/custom_resources/resources/alarms_elb.go
+++ b/internal/core/custom_resources/resources/alarms_elb.go
@@ -41,7 +41,6 @@ type ElbAlarmProperties struct {
 	LoadBalancerFriendlyName string `validate:"required"`
 	LoadBalancerFullName     string `validate:"required"`
 
-	ClientErrorThreshold    int     `json:",string" validate:"omitempty,min=0"`
 	LatencyThresholdSeconds float64 `json:",string" validate:"omitempty,min=0"`
 }
 
@@ -72,44 +71,22 @@ func putElbAlarmGroup(props ElbAlarmProperties) error {
 	input := cloudwatch.PutMetricAlarmInput{
 		AlarmActions: []*string{&props.AlarmTopicArn},
 		AlarmDescription: aws.String(fmt.Sprintf(
-			"Load balancer %s has elevated 4XX errors (before reaching the target). See: %s#%s",
+			"Load balancer %s has 5XX errors (before reaching the target). See: %s#%s",
 			props.LoadBalancerFriendlyName, alarmRunbook, props.LoadBalancerFriendlyName)),
 		AlarmName: aws.String(
-			fmt.Sprintf("Panther-%s-%s", elbClientErrorAlarm, props.LoadBalancerFriendlyName)),
+			fmt.Sprintf("Panther-%s-%s", elbServerErrorAlarm, props.LoadBalancerFriendlyName)),
 		ComparisonOperator: aws.String(cloudwatch.ComparisonOperatorGreaterThanThreshold),
 		Dimensions: []*cloudwatch.Dimension{
 			{Name: aws.String("LoadBalancer"), Value: &props.LoadBalancerFullName},
 		},
 		EvaluationPeriods: aws.Int64(3),
-		MetricName:        aws.String("HTTPCode_ELB_4XX_Count"),
+		MetricName:        aws.String("HTTPCode_ELB_5XX_Count"),
 		Namespace:         aws.String("AWS/ApplicationELB"),
 		Period:            aws.Int64(300),
 		Statistic:         aws.String(cloudwatch.StatisticSum),
-		Threshold:         aws.Float64(float64(props.ClientErrorThreshold)),
+		Threshold:         aws.Float64(0),
 		Unit:              aws.String(cloudwatch.StandardUnitCount),
 	}
-	if err := putMetricAlarm(input); err != nil {
-		return err
-	}
-
-	input.AlarmDescription = aws.String(fmt.Sprintf(
-		"Load balancer %s has 5XX errors (before reaching the target). See: %s#%s",
-		props.LoadBalancerFriendlyName, alarmRunbook, props.LoadBalancerFriendlyName))
-	input.AlarmName = aws.String(
-		fmt.Sprintf("Panther-%s-%s", elbServerErrorAlarm, props.LoadBalancerFriendlyName))
-	input.MetricName = aws.String("HTTPCode_ELB_5XX_Count")
-	input.Threshold = aws.Float64(0)
-	if err := putMetricAlarm(input); err != nil {
-		return err
-	}
-
-	input.AlarmDescription = aws.String(fmt.Sprintf(
-		"Load balancer %s has elevated 4XX errors from its target. See: %s#%s",
-		props.LoadBalancerFriendlyName, alarmRunbook, props.LoadBalancerFriendlyName))
-	input.AlarmName = aws.String(
-		fmt.Sprintf("Panther-%s-%s", elbTargetClientErrorAlarm, props.LoadBalancerFriendlyName))
-	input.MetricName = aws.String("HTTPCode_Target_4XX_Count")
-	input.Threshold = aws.Float64(float64(props.ClientErrorThreshold))
 	if err := putMetricAlarm(input); err != nil {
 		return err
 	}

--- a/internal/core/custom_resources/resources/alarms_elb.go
+++ b/internal/core/custom_resources/resources/alarms_elb.go
@@ -80,7 +80,7 @@ func putElbAlarmGroup(props ElbAlarmProperties) error {
 		Dimensions: []*cloudwatch.Dimension{
 			{Name: aws.String("LoadBalancer"), Value: &props.LoadBalancerFullName},
 		},
-		EvaluationPeriods: aws.Int64(1),
+		EvaluationPeriods: aws.Int64(3),
 		MetricName:        aws.String("HTTPCode_ELB_4XX_Count"),
 		Namespace:         aws.String("AWS/ApplicationELB"),
 		Period:            aws.Int64(300),


### PR DESCRIPTION
## Background

~Configuration ALB alarms to trigger only if we see persistent issues. AWS can occasionally encounter some "glitches", with this update we make sure we trigger an alarm only if the issues persist.~
After some consideration, thinking the best way to move forward is to get rid of the 4XX alarms. 
Some reasons why I think this is the best way of action: 

1. There is a very high chance for a false positive due to "expected" user activity. 
2. If the increased 4XX is due to some of our Lambdas experiencing issues, we will identify such issues from Lambda alarms.
3. Elevated 4XX might be a sign of a security issue. We should rely on Panther log (ALB) processing for this instead of CW Alarms. 

## Testing
* `mage test:ci`
* Deployed

