### PR TITLE
Add CustomResourceVersion

### DIFF
--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -37,7 +37,7 @@ Parameters:
     Description: API Gateway HTTPS endpoint for panther-compliance-api
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   RemediationApi:
     Type: String
     Description: API Gateway HTTPS endpoint for panther-remediation-api

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -35,6 +35,9 @@ Parameters:
   ComplianceApi:
     Type: String
     Description: API Gateway HTTPS endpoint for panther-compliance-api
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   RemediationApi:
     Type: String
     Description: API Gateway HTTPS endpoint for panther-remediation-api
@@ -53,6 +56,7 @@ Resources:
       ApiName: panther-graphql-api
       AlarmTopicArn: !Ref AlarmTopicArn
       ClientErrorThreshold: 20 # per 5-minute window
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
   GraphQLSchema:

--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -42,6 +42,9 @@ Parameters:
   CloudWatchLogRetentionDays:
     Type: Number
     Description: CloudWatch log retention period
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   ImageRegistryName:
     Type: String
     Description: Name of the ECR repository hosting web images (blank when deploying from source)
@@ -230,6 +233,7 @@ Resources:
   CustomResourceMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref CustomResourceLogGroup
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
@@ -237,6 +241,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, CustomResource, Memory]
       FunctionName: !Ref CustomResourceFunction
       FunctionTimeoutSec: !FindInMap [Functions, CustomResource, Timeout]
@@ -250,6 +255,7 @@ Resources:
     #   - Lambda layers
     Type: Custom::PantherTeardown
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       EcrRepoName: !Ref ImageRegistryName
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
@@ -258,6 +264,7 @@ Resources:
     Type: Custom::SNSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
       TopicName: panther-processed-data-notifications
 
@@ -268,6 +275,7 @@ Resources:
     Type: Custom::SNSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
       TopicName: panther-cw-alarms
 
@@ -276,6 +284,7 @@ Resources:
   UserPoolMfa:
     Type: Custom::CognitoUserPoolMfa
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
       UserPoolId: !Ref UserPoolId
 
@@ -296,6 +305,7 @@ Resources:
     Properties:
       ApiName: panther-analysis-api
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
   ComplianceApi:
@@ -315,6 +325,7 @@ Resources:
     Properties:
       ApiName: panther-compliance-api
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
   RemediationApi:
@@ -334,6 +345,7 @@ Resources:
     Properties:
       ApiName: panther-remediation-api
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
   ResourcesApi:
@@ -353,6 +365,7 @@ Resources:
     Properties:
       ApiName: panther-resources-api
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
 Outputs:

--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -44,7 +44,7 @@ Parameters:
     Description: CloudWatch log retention period
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   ImageRegistryName:
     Type: String
     Description: Name of the ECR repository hosting web images (blank when deploying from source)

--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -35,7 +35,7 @@ Parameters:
     Description: API Gateway for compliance-api
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   Debug:
     Type: String
     Description: Toggle debug logging

--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -33,6 +33,9 @@ Parameters:
   ComplianceApiId:
     Type: String
     Description: API Gateway for compliance-api
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   Debug:
     Type: String
     Description: Toggle debug logging
@@ -133,6 +136,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt AlertProcessorQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -153,6 +157,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt AlertProcessorDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -166,6 +171,7 @@ Resources:
   AlertProcessorMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref AlertProcessorLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -239,6 +245,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, AlertProcessor, Memory]
       FunctionName: !Ref AlertProcessorFunction
       FunctionTimeoutSec: !FindInMap [Functions, AlertProcessor, Timeout]
@@ -277,6 +284,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref AlertForwarderTable
 
@@ -289,6 +297,7 @@ Resources:
   AlertForwarderMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref AlertForwarderLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -351,6 +360,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, AlertForwarder, Memory]
       FunctionName: !Ref AlertForwarderFunction
       FunctionTimeoutSec: !FindInMap [Functions, AlertForwarder, Timeout]
@@ -383,6 +393,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt EventQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -403,6 +414,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt EventDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -453,6 +465,7 @@ Resources:
   EventProcessorMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref EventProcessorLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -538,6 +551,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, EventProcessor, Memory]
       FunctionName: !Ref EventProcessorFunction
       FunctionTimeoutSec: !FindInMap [Functions, EventProcessor, Timeout]
@@ -593,6 +607,7 @@ Resources:
   ComplianceApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref ComplianceApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -600,6 +615,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, ComplianceApi, Memory]
       FunctionName: !Ref ComplianceApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, ComplianceApi, Timeout]
@@ -654,6 +670,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref ComplianceTable
 
@@ -728,6 +745,7 @@ Resources:
   RemediationApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref RemediationApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -735,6 +753,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, RemediationApi, Memory]
       FunctionName: !Ref RemediationApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, RemediationApi, Timeout]
@@ -764,6 +783,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt RemediationQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -784,6 +804,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt RemediationDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -797,6 +818,7 @@ Resources:
   RemediationProcessorMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref RemediationProcessorLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -859,6 +881,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, RemediationProcessor, Memory]
       FunctionName: !Ref RemediationProcessorFunction
       FunctionTimeoutSec: !FindInMap [Functions, RemediationProcessor, Timeout]
@@ -874,6 +897,7 @@ Resources:
   RemediationMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LambdaRuntime: Python
       LogGroupName: !Ref RemediationLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -920,6 +944,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, Remediation, Memory]
       FunctionName: !Ref RemediationFunction
       FunctionTimeoutSec: !FindInMap [Functions, Remediation, Timeout]
@@ -1001,6 +1026,7 @@ Resources:
   ResourcesApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref ResourcesApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -1008,6 +1034,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, ResourcesApi, Memory]
       FunctionName: !Ref ResourcesApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, ResourcesApi, Timeout]
@@ -1044,6 +1071,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref ResourcesTable
 
@@ -1071,6 +1099,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt ResourcesQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -1091,6 +1120,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt ResourcesDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -1104,6 +1134,7 @@ Resources:
   ResourceProcessorMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref ResourceProcessorLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -1193,6 +1224,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, ResourceProcessor, Memory]
       FunctionName: !Ref ResourceProcessorFunction
       FunctionTimeoutSec: !FindInMap [Functions, ResourceProcessor, Timeout]
@@ -1260,6 +1292,7 @@ Resources:
   PolicyEngineMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LambdaRuntime: Python
       LogGroupName: !Ref PolicyEngineLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -1268,6 +1301,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, PolicyEngine, Memory]
       FunctionName: !Ref PolicyEngineFunction
       FunctionTimeoutSec: !FindInMap [Functions, PolicyEngine, Timeout]
@@ -1295,6 +1329,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt SnapshotQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -1315,6 +1350,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt SnapshotDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -1391,6 +1427,7 @@ Resources:
   PollerMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref PollerLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -1398,6 +1435,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, Poller, Memory]
       FunctionName: !Ref PollerFunction
       FunctionTimeoutSec: !FindInMap [Functions, Poller, Timeout]
@@ -1462,6 +1500,7 @@ Resources:
   SnapshotSchedulerMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref SnapshotSchedulerLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -1469,6 +1508,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, SnapshotScheduler, Memory]
       FunctionName: !Ref SnapshotSchedulerFunction
       FunctionTimeoutSec: !FindInMap [Functions, SnapshotScheduler, Timeout]

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -53,7 +53,7 @@ Parameters:
     Description: Compliance API gateway ID
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   Debug:
     Type: String
     Description: Toggle debug logging

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -51,6 +51,9 @@ Parameters:
   ComplianceApiId:
     Type: String
     Description: Compliance API gateway ID
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   Debug:
     Type: String
     Description: Toggle debug logging
@@ -130,6 +133,7 @@ Resources:
   UsersAPIMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref UsersAPILogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -177,6 +181,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, UsersAPI, Memory]
       FunctionName: !Ref UsersAPIFunction
       FunctionTimeoutSec: !FindInMap [Functions, UsersAPI, Timeout]
@@ -215,6 +220,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref OrganizationTable
 
@@ -227,6 +233,7 @@ Resources:
   OrganizationAPIMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref OrganizationAPILogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -263,6 +270,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, OrganizationAPI, Memory]
       FunctionName: !Ref OrganizationAPIFunction
       FunctionTimeoutSec: !FindInMap [Functions, OrganizationAPI, Timeout]
@@ -272,6 +280,8 @@ Resources:
     Type: Custom::PantherSettings
     DependsOn: OrganizationAPIFunction
     Properties:
+      # No CustomResourceVersion here because then every release would overwrite these settings,
+      # which the user might have changed from the general settings page in the web app.
       DisplayName: !Ref CompanyDisplayName
       Email: !Ref CompanyEmail
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -371,6 +381,7 @@ Resources:
   AnalysisApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref AnalysisApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -378,6 +389,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, AnalysisAPI, Memory]
       FunctionName: !Ref AnalysisApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, AnalysisAPI, Timeout]
@@ -419,6 +431,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref AnalysisTable
 
@@ -471,6 +484,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref OutputsTable
 
@@ -532,6 +546,7 @@ Resources:
   OutputsApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref OutputsApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -539,6 +554,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, OutputsAPI, Memory]
       FunctionName: !Ref OutputsApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, OutputsAPI, Timeout]
@@ -567,6 +583,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt AlertQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -587,6 +604,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt AlertDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -673,6 +691,7 @@ Resources:
   AlertDeliveryMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref AlertDeliveryLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -680,6 +699,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, AlertDelivery, Memory]
       FunctionName: !Ref AlertDeliveryFunction
       FunctionTimeoutSec: !FindInMap [Functions, AlertDelivery, Timeout]
@@ -713,6 +733,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref IntegrationsTable
 
@@ -829,6 +850,7 @@ Resources:
   SourceApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref SourceApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -836,6 +858,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, SourceAPI, Memory]
       FunctionName: !Ref SourceApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, SourceAPI, Timeout]
@@ -864,6 +887,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt LayerQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -884,6 +908,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt LayerDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -988,6 +1013,7 @@ Resources:
   LayerManagerMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref LayerManagerLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -995,6 +1021,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, LayerManager, Memory]
       FunctionName: !Ref LayerManagerFunction
       FunctionTimeoutSec: !FindInMap [Functions, LayerManager, Timeout]
@@ -1036,6 +1063,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref KeyValueStoreTable
 

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -35,7 +35,7 @@ Parameters:
     Description: CloudWatch log retention period
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   Debug:
     Type: String
     Description: Toggle debug logging

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -33,6 +33,9 @@ Parameters:
   CloudWatchLogRetentionDays:
     Type: Number
     Description: CloudWatch log retention period
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   Debug:
     Type: String
     Description: Toggle debug logging
@@ -93,6 +96,7 @@ Resources:
     Type: Custom::AthenaInit # this will associate the bucket as the default location for results
     Properties:
       AthenaResultsBucket: !Ref AthenaResultsBucket
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
   ###### Update Glue Table Schemas for Deployed Tables #####
@@ -100,7 +104,8 @@ Resources:
     DependsOn: AthenaConfigure
     Type: Custom::UpdateGlueTables
     Properties:
-      TablesSignature: !Ref TablesSignature # this should change when tables need to be updated, for CF this can be the Panther version
+      # Here we use TablesSignature instead of CustomResourceVersion to trigger updates
+      TablesSignature: !Ref TablesSignature
       ProcessedDataBucket: !Ref ProcessedDataBucket
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -114,6 +119,7 @@ Resources:
   AlertsApiMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref AlertsApiLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -170,6 +176,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, AlertsApi, Memory]
       FunctionName: !Ref AlertsApiFunction
       FunctionTimeoutSec: !FindInMap [Functions, AlertsApi, Timeout]
@@ -227,6 +234,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref LogAlertsTable
 
@@ -240,6 +248,7 @@ Resources:
   AlertsForwarderMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref AlertForwarderLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -310,6 +319,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, AlertsForwarder, Memory]
       FunctionName: !Ref AlertsForwarderFunction
       FunctionTimeoutSec: !FindInMap [Functions, AlertsForwarder, Timeout]
@@ -340,6 +350,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt LogProcessorQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -359,6 +370,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt LogProcessorDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -372,6 +384,7 @@ Resources:
   LogProcessorMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref LogProcessorLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -468,6 +481,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !Ref LogProcessorLambdaMemorySize
       FunctionName: !Ref LogProcessorFunction
       FunctionTimeoutSec: !FindInMap [Functions, LogProcessor, Timeout]
@@ -520,6 +534,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt UpdaterQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -539,6 +554,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt UpdaterDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -552,6 +568,7 @@ Resources:
   UpdaterMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LogGroupName: !Ref UpdaterFunctionLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -625,6 +642,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !FindInMap [Functions, Updater, Memory]
       FunctionName: !Ref UpdaterFunction
       FunctionTimeoutSec: !FindInMap [Functions, Updater, Timeout]
@@ -684,6 +702,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       QueueName: !GetAtt RulesEngineQueue.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
@@ -703,6 +722,7 @@ Resources:
     Type: Custom::SQSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       IsDLQ: true
       QueueName: !GetAtt RulesEngineDLQ.QueueName
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -734,6 +754,7 @@ Resources:
     Type: Custom::DynamoDBAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TableName: !Ref AlertsDedup
 
@@ -746,6 +767,7 @@ Resources:
   RulesEngineMetricFilters:
     Type: Custom::LambdaMetricFilters
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       LambdaRuntime: Python
       LogGroupName: !Ref RulesEngineLogGroup
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
@@ -867,6 +889,7 @@ Resources:
     Type: Custom::LambdaAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       FunctionMemoryMB: !Ref LogProcessorLambdaMemorySize
       FunctionName: !Ref RulesEngineFunction
       FunctionTimeoutSec: !FindInMap [Functions, RulesEngine, Timeout]

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -164,6 +164,7 @@ Resources:
         AthenaResultsBucket: !GetAtt Bootstrap.Outputs.AthenaResultsBucket
         AuditLogsBucket: !GetAtt Bootstrap.Outputs.AuditLogsBucket
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         ImageRegistryName: !GetAtt Bootstrap.Outputs.ImageRegistryName
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
         ProcessedDataBucket: !GetAtt Bootstrap.Outputs.ProcessedDataBucket
@@ -189,6 +190,7 @@ Resources:
         AnalysisApi: !Sub https://${BootstrapGateway.Outputs.AnalysisApiEndpoint}
         ApiId: !GetAtt Bootstrap.Outputs.GraphQLApiId
         ComplianceApi: !Sub https://${BootstrapGateway.Outputs.ComplianceApiEndpoint}
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         RemediationApi: !Sub https://${BootstrapGateway.Outputs.RemediationApiEndpoint}
         ResourcesApi: !Sub https://${BootstrapGateway.Outputs.ResourcesApiEndpoint}
         ServiceRole: !GetAtt Bootstrap.Outputs.AppsyncServiceRoleArn
@@ -211,6 +213,7 @@ Resources:
         AnalysisApiId: !GetAtt BootstrapGateway.Outputs.AnalysisApiId
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
         ComplianceApiId: !GetAtt BootstrapGateway.Outputs.ComplianceApiId
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         Debug: !Ref Debug
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
         ProcessedDataBucket: !GetAtt Bootstrap.Outputs.ProcessedDataBucket
@@ -245,6 +248,7 @@ Resources:
         CompanyDisplayName: !Ref CompanyDisplayName
         CompanyEmail: !Ref FirstUserEmail
         ComplianceApiId: !GetAtt BootstrapGateway.Outputs.ComplianceApiId
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         Debug: !Ref Debug
         DynamoScalingRoleArn: !GetAtt Bootstrap.Outputs.DynamoScalingRoleArn
         InitialAnalysisPackUrls: !Join [',', !Ref InitialAnalysisPackUrls]
@@ -287,6 +291,7 @@ Resources:
         AnalysisApiId: !GetAtt BootstrapGateway.Outputs.AnalysisApiId
         AthenaResultsBucket: !GetAtt Bootstrap.Outputs.AthenaResultsBucket
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         Debug: !Ref Debug
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
         LogProcessorLambdaMemorySize: !Ref LogProcessorLambdaMemorySize
@@ -317,6 +322,7 @@ Resources:
       Parameters:
         AlarmTopicArn: !GetAtt Bootstrap.Outputs.AlarmTopicArn
         AuditLogsBucket: !GetAtt Bootstrap.Outputs.AuditLogsBucket
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         EnableCloudTrail: !Ref EnableCloudTrail
         EnableGuardDuty: !Ref EnableGuardDuty
         EnableS3AccessLogs: !Ref EnableS3AccessLogs
@@ -341,6 +347,7 @@ Resources:
         AppClientId: !GetAtt Bootstrap.Outputs.AppClientId
         CertificateArn: !Ref CertificateArn
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
+        CustomResourceVersion: !FindInMap [Constants, Panther, Version]
         ElbArn: !GetAtt Bootstrap.Outputs.LoadBalancerArn
         ElbFullName: !GetAtt Bootstrap.Outputs.LoadBalancerFullName
         ElbTargetGroup: !GetAtt Bootstrap.Outputs.LoadBalancerTargetGroup

--- a/deployments/onboard.yml
+++ b/deployments/onboard.yml
@@ -26,6 +26,9 @@ Parameters:
   AuditLogsBucket:
     Type: String
     Description: The name of the S3 bucket which stores Panther audit logs
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   EnableCloudTrail:
     Type: String
     Description: If true, create a Panther CloudTrail in this account configured for log processing
@@ -121,6 +124,7 @@ Resources:
     Condition: EnableGuardDuty
     Type: Custom::GuardDutyDestination
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       DetectorId: !Ref GuardDutyDetector
       DestinationType: S3
       DestinationProperties:
@@ -182,6 +186,7 @@ Resources:
     Type: Custom::SNSAlarms
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
       TopicName: !GetAtt Topic.TopicName
 
@@ -199,6 +204,7 @@ Resources:
     DependsOn: TopicPolicy
     Properties:
       Bucket: !Ref AuditLogsBucket
+      CustomResourceVersion: !Ref CustomResourceVersion
       NotificationConfiguration:
         TopicConfigurations:
           - Events:
@@ -212,6 +218,7 @@ Resources:
     Properties:
       AccountID: !Ref AWS::AccountId
       AuditLogsBucket: !Ref AuditLogsBucket
+      CustomResourceVersion: !Ref CustomResourceVersion
       EnableCloudTrail: !Ref EnableCloudTrail
       EnableGuardDuty: !Ref EnableGuardDuty
       EnableS3AccessLogs: !Ref EnableS3AccessLogs

--- a/deployments/onboard.yml
+++ b/deployments/onboard.yml
@@ -28,7 +28,7 @@ Parameters:
     Description: The name of the S3 bucket which stores Panther audit logs
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   EnableCloudTrail:
     Type: String
     Description: If true, create a Panther CloudTrail in this account configured for log processing

--- a/deployments/web_server.yml
+++ b/deployments/web_server.yml
@@ -34,7 +34,7 @@ Parameters:
     Description: CloudWatch log retention period
   CustomResourceVersion:
     Type: String
-    Description: Dummy parameter which forces updates to custom resources when changed
+    Description: Forces updates to custom resources when changed
   ElbArn:
     Type: String
     Description: The ARN of the load balancer

--- a/deployments/web_server.yml
+++ b/deployments/web_server.yml
@@ -32,6 +32,9 @@ Parameters:
   CloudWatchLogRetentionDays:
     Type: Number
     Description: CloudWatch log retention period
+  CustomResourceVersion:
+    Type: String
+    Description: Dummy parameter which forces updates to custom resources when changed
   ElbArn:
     Type: String
     Description: The ARN of the load balancer
@@ -88,6 +91,7 @@ Resources:
     Condition: CreateCertificate
     Type: Custom::Certificate
     Properties:
+      CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
   LoadBalancerAlarms:
@@ -95,6 +99,7 @@ Resources:
     Properties:
       AlarmTopicArn: !Ref AlarmTopicArn
       ClientErrorThreshold: 10 # within 5 minutes
+      CustomResourceVersion: !Ref CustomResourceVersion
       LatencyThresholdSeconds: 0.5
       LoadBalancerFriendlyName: web
       LoadBalancerFullName: !Ref ElbFullName
@@ -248,6 +253,8 @@ Resources:
     DeletionPolicy: Retain # users-api refuses to delete the last user, which would then fail teardown
     UpdateReplacePolicy: Retain
     Properties:
+      # No CustomResourceVersion here because that would reset the first user on every upgrade.
+      # The user might have changed their name or email through the web app, we don't want to revert.
       GivenName: !Ref FirstUserGivenName
       FamilyName: !Ref FirstUserFamilyName
       Email: !Ref FirstUserEmail

--- a/docs/gitbook/development.md
+++ b/docs/gitbook/development.md
@@ -161,6 +161,11 @@ Now you can run `mage deploy`
 This will deploy the main CloudFormation stacks independently and is optimized for development.
 If instead you want to deploy the single master template: `mage master:deploy`
 
+Panther relies on a number of [custom CloudFormation resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html). Like any
+CloudFormation resource, these will not be updated unless the input parameters have changed.
+To force an update of most custom resources: `FORCE_CUSTOM_RESOURCE_UPDATE=1 mage deploy`
+This will, for example, recreate every CloudWatch metric filter and alarm.
+
 ### From an EC2 Instance
 
 You can also deploy from an EC2 instance with Docker and git installed in the same region you're deploying Panther to.

--- a/docs/gitbook/development.md
+++ b/docs/gitbook/development.md
@@ -162,9 +162,9 @@ This will deploy the main CloudFormation stacks independently and is optimized f
 If instead you want to deploy the single master template: `mage master:deploy`
 
 Panther relies on a number of [custom CloudFormation resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html). Like any
-CloudFormation resource, these will not be updated unless the input parameters have changed.
-To force an update of most custom resources: `FORCE_CUSTOM_RESOURCE_UPDATE=1 mage deploy`
-This will, for example, recreate every CloudWatch metric filter and alarm.
+resource, these will not be updated unless the input parameters have changed.
+You can force an update of most custom resources by overriding their version:
+`CUSTOM_RESOURCE_VERSION=v1.5.0 mage deploy`
 
 ### From an EC2 Instance
 

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -530,8 +530,8 @@ func deployOnboardStack(settings *config.PantherConfig, outputs map[string]strin
 // Determine the custom resource "version" - if this value changes, it will force an update for
 // most of our CloudFormation custom resources.
 func customResourceVersion() string {
-	if os.Getenv("FORCE_CUSTOM_RESOURCE_UPDATE") == "1" {
-		return strconv.FormatInt(time.Now().UnixNano(), 10) // random number
+	if v := os.Getenv("CUSTOM_RESOURCE_VERSION"); v != "" {
+		return v
 	}
 
 	// By default, just use the major release version so developers do not have to trigger every

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -369,6 +369,7 @@ func deployBootstrapGatewayStack(
 		"AthenaResultsBucket":        outputs["AthenaResultsBucket"],
 		"AuditLogsBucket":            outputs["AuditLogsBucket"],
 		"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
+		"CustomResourceVersion":      customResourceVersion(),
 		"ImageRegistryName":          outputs["ImageRegistryName"],
 		"LayerVersionArns":           settings.Infra.BaseLayerVersionArns,
 		"ProcessedDataBucket":        outputs["ProcessedDataBucket"],
@@ -413,13 +414,14 @@ func buildLayer(libs []string) error {
 
 func deployAppsyncStack(outputs map[string]string) error {
 	_, err := deployTemplate(appsyncTemplate, outputs["SourceBucket"], appsyncStack, map[string]string{
-		"AlarmTopicArn":  outputs["AlarmTopicArn"],
-		"AnalysisApi":    "https://" + outputs["AnalysisApiEndpoint"],
-		"ApiId":          outputs["GraphQLApiId"],
-		"ComplianceApi":  "https://" + outputs["ComplianceApiEndpoint"],
-		"RemediationApi": "https://" + outputs["RemediationApiEndpoint"],
-		"ResourcesApi":   "https://" + outputs["ResourcesApiEndpoint"],
-		"ServiceRole":    outputs["AppsyncServiceRoleArn"],
+		"AlarmTopicArn":         outputs["AlarmTopicArn"],
+		"AnalysisApi":           "https://" + outputs["AnalysisApiEndpoint"],
+		"ApiId":                 outputs["GraphQLApiId"],
+		"ComplianceApi":         "https://" + outputs["ComplianceApiEndpoint"],
+		"CustomResourceVersion": customResourceVersion(),
+		"RemediationApi":        "https://" + outputs["RemediationApiEndpoint"],
+		"ResourcesApi":          "https://" + outputs["ResourcesApiEndpoint"],
+		"ServiceRole":           outputs["AppsyncServiceRoleArn"],
 	})
 	return err
 }
@@ -430,6 +432,7 @@ func deployCloudSecurityStack(settings *config.PantherConfig, outputs map[string
 		"AnalysisApiId":              outputs["AnalysisApiId"],
 		"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
 		"ComplianceApiId":            outputs["ComplianceApiId"],
+		"CustomResourceVersion":      customResourceVersion(),
 		"Debug":                      strconv.FormatBool(settings.Monitoring.Debug),
 		"LayerVersionArns":           settings.Infra.BaseLayerVersionArns,
 		"ProcessedDataBucket":        outputs["ProcessedDataBucket"],
@@ -455,6 +458,7 @@ func deployCoreStack(settings *config.PantherConfig, outputs map[string]string) 
 		"CompanyDisplayName":         settings.Setup.Company.DisplayName,
 		"CompanyEmail":               settings.Setup.Company.Email,
 		"ComplianceApiId":            outputs["ComplianceApiId"],
+		"CustomResourceVersion":      customResourceVersion(),
 		"Debug":                      strconv.FormatBool(settings.Monitoring.Debug),
 		"DynamoScalingRoleArn":       outputs["DynamoScalingRoleArn"],
 		"InitialAnalysisPackUrls":    strings.Join(settings.Setup.InitialAnalysisSets, ","),
@@ -489,6 +493,7 @@ func deployLogAnalysisStack(settings *config.PantherConfig, outputs map[string]s
 		"AnalysisApiId":                outputs["AnalysisApiId"],
 		"AthenaResultsBucket":          outputs["AthenaResultsBucket"],
 		"CloudWatchLogRetentionDays":   strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
+		"CustomResourceVersion":        customResourceVersion(),
 		"Debug":                        strconv.FormatBool(settings.Monitoring.Debug),
 		"LayerVersionArns":             settings.Infra.BaseLayerVersionArns,
 		"LogProcessorLambdaMemorySize": strconv.Itoa(settings.Infra.LogProcessorLambdaMemorySize),
@@ -506,12 +511,13 @@ func deployOnboardStack(settings *config.PantherConfig, outputs map[string]strin
 	var err error
 	if settings.Setup.OnboardSelf {
 		_, err = deployTemplate(onboardTemplate, outputs["SourceBucket"], onboardStack, map[string]string{
-			"AlarmTopicArn":      outputs["AlarmTopicArn"],
-			"AuditLogsBucket":    outputs["AuditLogsBucket"],
-			"EnableCloudTrail":   strconv.FormatBool(settings.Setup.EnableCloudTrail),
-			"EnableGuardDuty":    strconv.FormatBool(settings.Setup.EnableGuardDuty),
-			"EnableS3AccessLogs": strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
-			"VpcId":              outputs["VpcId"],
+			"AlarmTopicArn":         outputs["AlarmTopicArn"],
+			"AuditLogsBucket":       outputs["AuditLogsBucket"],
+			"CustomResourceVersion": customResourceVersion(),
+			"EnableCloudTrail":      strconv.FormatBool(settings.Setup.EnableCloudTrail),
+			"EnableGuardDuty":       strconv.FormatBool(settings.Setup.EnableGuardDuty),
+			"EnableS3AccessLogs":    strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
+			"VpcId":                 outputs["VpcId"],
 		})
 	} else {
 		// Delete the onboard stack if OnboardSelf was toggled off
@@ -519,4 +525,17 @@ func deployOnboardStack(settings *config.PantherConfig, outputs map[string]strin
 	}
 
 	return err
+}
+
+// Determine the custom resource "version" - if this value changes, it will force an update for
+// most of our CloudFormation custom resources.
+func customResourceVersion() string {
+	if os.Getenv("FORCE_CUSTOM_RESOURCE_UPDATE") == "1" {
+		return strconv.FormatInt(time.Now().UnixNano(), 10) // random number
+	}
+
+	// By default, just use the major release version so developers do not have to trigger every
+	// custom resource on every deploy.
+	// The gitVersion is "v0.3.0" on tagged release, otherwise something like "v0.3.0-128-g77fd9ff"
+	return strings.Split(gitVersion, "-")[0]
 }

--- a/tools/mage/deploy_frontend.go
+++ b/tools/mage/deploy_frontend.go
@@ -59,6 +59,7 @@ func deployFrontend(accountID string, bootstrapOutputs map[string]string, settin
 		"AppClientId":                bootstrapOutputs["AppClientId"],
 		"CertificateArn":             settings.Web.CertificateArn,
 		"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
+		"CustomResourceVersion":      customResourceVersion(),
 		"ElbArn":                     bootstrapOutputs["LoadBalancerArn"],
 		"ElbFullName":                bootstrapOutputs["LoadBalancerFullName"],
 		"ElbTargetGroup":             bootstrapOutputs["LoadBalancerTargetGroup"],

--- a/tools/mage/master_namespace.go
+++ b/tools/mage/master_namespace.go
@@ -60,7 +60,7 @@ func (Master) Deploy() {
 	err := sh.RunV(filepath.Join(pythonVirtualEnvPath, "bin", "sam"), "deploy",
 		"--capabilities", "CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND",
 		"--region", region,
-		"--stack-name", "panther-master",
+		"--stack-name", "panther",
 		"-t", pkg,
 		"--parameter-overrides", "FirstUserEmail="+firstUserEmail, "ImageRegistry="+ecrRegistry)
 	if err != nil {


### PR DESCRIPTION
## Background

Like all CloudFormation resources, custom resources are not updated until their input parameters change.

This is not necessarily intuitive - for example #1049 tried to update an alarm group by changing the Go code in the custom resources Lambda function. That will work for new deployments, but will not be applied to existing deployments. Similarly, @rleighton is working on correcting the Python metric filters.

In both cases, the input parameters must change in some way to update existing deployments. To that end, this PR introduces a "CustomResourceVersion" parameter to most stacks which isn't used for anything except triggering custom resource updates.

For pre-packaged deployments, this will be the Panther release version, which will guarantee bug fixes like #1049 are applied. For `mage deploy`, this is the major release version by default. The developer can also force custom resource updates with `FORCE_CUSTOM_RESOURCE_UPDATE=1 dev -- mage deploy`

## Changes

- Add `CustomResourceVersion` parameter to most CloudFormation stacks and most custom resources

## Testing

- `mage deploy`
- `CUSTOM_RESOURCE_VERSION=v1.5.0 mage deploy`
