### PR TITLE
Log processor update source status with the time it received the last event

### DIFF
--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -34,7 +34,8 @@ type LambdaInput struct {
 	UpdateIntegrationLastScanEnd   *UpdateIntegrationLastScanEndInput   `json:"updateIntegrationLastScanEnd"`
 	UpdateIntegrationLastScanStart *UpdateIntegrationLastScanStartInput `json:"updateIntegrationLastScanStart"`
 
-	FullScan *FullScanInput `json:"fullScan"`
+	FullScan     *FullScanInput     `json:"fullScan"`
+	UpdateStatus *UpdateStatusInput `json:"updateIntegrationStatusInput"`
 }
 
 //
@@ -152,4 +153,16 @@ type UpdateIntegrationLastScanEndInput struct {
 	LastScanEndTime      *time.Time `json:"lastScanEndTime" validate:"required"`
 	LastScanErrorMessage *string    `json:"lastScanErrorMessage"`
 	ScanStatus           *string    `json:"scanStatus" validate:"required,oneof=ok error scanning"`
+}
+
+// Updates the status of an integration
+// Sample request:
+// {
+// 	"integrationId": "uuid",
+//	"lastEventReceived":"2020-10-10T05:03:01Z"
+//}
+//
+type UpdateStatusInput struct {
+	IntegrationID     string    `json:"integrationId" validate:"required,uuid4"`
+	LastEventReceived time.Time `json:"lastEventReceived" validate:"required"`
 }

--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -35,7 +35,7 @@ type LambdaInput struct {
 	UpdateIntegrationLastScanStart *UpdateIntegrationLastScanStartInput `json:"updateIntegrationLastScanStart"`
 
 	FullScan     *FullScanInput     `json:"fullScan"`
-	UpdateStatus *UpdateStatusInput `json:"updateIntegrationStatusInput"`
+	UpdateStatus *UpdateStatusInput `json:"updateStatus"`
 }
 
 //
@@ -158,8 +158,10 @@ type UpdateIntegrationLastScanEndInput struct {
 // Updates the status of an integration
 // Sample request:
 // {
-// 	"integrationId": "uuid",
-//	"lastEventReceived":"2020-10-10T05:03:01Z"
+//	"updateStatus": {
+// 		"integrationId": "uuid",
+//		"lastEventReceived":"2020-10-10T05:03:01Z"
+// 	}
 //}
 //
 type UpdateStatusInput struct {

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -27,30 +27,31 @@ type SourceIntegration struct {
 	SourceIntegrationScanInformation
 }
 
-// SourceIntegrationStatus provides context that the full scan works and that events are being received.
+// SourceIntegrationStatus provides information about the status of a source
 type SourceIntegrationStatus struct {
-	ScanStatus  *string `json:"scanStatus"`
-	EventStatus *string `json:"eventStatus"`
+	ScanStatus        *string   `json:"scanStatus,omitempty"`
+	EventStatus       *string   `json:"eventStatus,omitempty"`
+	LastEventReceived time.Time `json:"lastEventReceived,omitempty"`
 }
 
 // SourceIntegrationScanInformation is detail about the last snapshot.
 type SourceIntegrationScanInformation struct {
-	LastScanEndTime      *time.Time `json:"lastScanEndTime"`
-	LastScanErrorMessage *string    `json:"lastScanErrorMessage"`
-	LastScanStartTime    *time.Time `json:"lastScanStartTime"`
+	LastScanEndTime      *time.Time `json:"lastScanEndTime,omitempty"`
+	LastScanErrorMessage *string    `json:"lastScanErrorMessage,omitempty"`
+	LastScanStartTime    *time.Time `json:"lastScanStartTime,omitempty"`
 }
 
 // SourceIntegrationMetadata is general settings and metadata for an integration.
 type SourceIntegrationMetadata struct {
-	AWSAccountID       *string    `json:"awsAccountId"`
-	CreatedAtTime      *time.Time `json:"createdAtTime"`
-	CreatedBy          *string    `json:"createdBy"`
-	IntegrationID      *string    `json:"integrationId"`
-	IntegrationLabel   *string    `json:"integrationLabel"`
-	IntegrationType    *string    `json:"integrationType"`
-	RemediationEnabled *bool      `json:"remediationEnabled"`
-	CWEEnabled         *bool      `json:"cweEnabled"`
-	ScanIntervalMins   *int       `json:"scanIntervalMins"`
+	AWSAccountID       *string    `json:"awsAccountId,omitempty"`
+	CreatedAtTime      *time.Time `json:"createdAtTime,omitempty"`
+	CreatedBy          *string    `json:"createdBy,omitempty"`
+	IntegrationID      *string    `json:"integrationId,omitempty"`
+	IntegrationLabel   *string    `json:"integrationLabel,omitempty"`
+	IntegrationType    *string    `json:"integrationType,omitempty"`
+	RemediationEnabled *bool      `json:"remediationEnabled,omitempty"`
+	CWEEnabled         *bool      `json:"cweEnabled,omitempty"`
+	ScanIntervalMins   *int       `json:"scanIntervalMins,omitempty"`
 	S3Bucket           *string    `json:"s3Bucket,omitempty"`
 	S3Prefix           *string    `json:"s3Prefix,omitempty"`
 	KmsKey             *string    `json:"kmsKey,omitempty"`
@@ -64,19 +65,19 @@ type SourceIntegrationHealth struct {
 	IntegrationType string `json:"integrationType"`
 
 	// Checks for cloudsec integrations
-	AuditRoleStatus       SourceIntegrationItemStatus `json:"auditRoleStatus"`
-	CWERoleStatus         SourceIntegrationItemStatus `json:"cweRoleStatus"`
-	RemediationRoleStatus SourceIntegrationItemStatus `json:"remediationRoleStatus"`
+	AuditRoleStatus       SourceIntegrationItemStatus `json:"auditRoleStatus,omitempty"`
+	CWERoleStatus         SourceIntegrationItemStatus `json:"cweRoleStatus,omitempty"`
+	RemediationRoleStatus SourceIntegrationItemStatus `json:"remediationRoleStatus,omitempty"`
 
 	// Checks for log analysis integrations
-	ProcessingRoleStatus SourceIntegrationItemStatus `json:"processingRoleStatus"`
-	S3BucketStatus       SourceIntegrationItemStatus `json:"s3BucketStatus"`
-	KMSKeyStatus         SourceIntegrationItemStatus `json:"kmsKeyStatus"`
+	ProcessingRoleStatus SourceIntegrationItemStatus `json:"processingRoleStatus,omitempty"`
+	S3BucketStatus       SourceIntegrationItemStatus `json:"s3BucketStatus,omitempty"`
+	KMSKeyStatus         SourceIntegrationItemStatus `json:"kmsKeyStatus,omitempty"`
 }
 
 type SourceIntegrationItemStatus struct {
-	Healthy      *bool   `json:"healthy"`
-	ErrorMessage *string `json:"errorMessage"`
+	Healthy      *bool   `json:"healthy,omitempty"`
+	ErrorMessage *string `json:"errorMessage,omitempty"`
 }
 
 type SourceIntegrationTemplate struct {

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -29,9 +29,9 @@ type SourceIntegration struct {
 
 // SourceIntegrationStatus provides information about the status of a source
 type SourceIntegrationStatus struct {
-	ScanStatus        *string   `json:"scanStatus,omitempty"`
-	EventStatus       *string   `json:"eventStatus,omitempty"`
-	LastEventReceived time.Time `json:"lastEventReceived,omitempty"`
+	ScanStatus        *string    `json:"scanStatus,omitempty"`
+	EventStatus       *string    `json:"eventStatus,omitempty"`
+	LastEventReceived *time.Time `json:"lastEventReceived,omitempty"`
 }
 
 // SourceIntegrationScanInformation is detail about the last snapshot.

--- a/internal/core/source_api/api/delete_integration.go
+++ b/internal/core/source_api/api/delete_integration.go
@@ -48,7 +48,7 @@ func (API) DeleteIntegration(input *models.DeleteIntegrationInput) (err error) {
 		}
 	}()
 
-	var integrationItem *ddb.IntegrationItem
+	var integrationItem *ddb.Integration
 	integrationItem, err = dynamoClient.GetItem(input.IntegrationID)
 	if err != nil {
 		errMsg := "failed to get integrationItem"

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -133,7 +133,7 @@ func (API) UpdateIntegrationLastScanEnd(input *models.UpdateIntegrationLastScanE
 	return nil
 }
 
-func getItem(integrationID *string) (*ddb.IntegrationItem, error) {
+func getItem(integrationID *string) (*ddb.Integration, error) {
 	item, err := dynamoClient.GetItem(integrationID)
 	if err != nil {
 		return nil, &genericapi.InternalError{Message: "Encountered issue while updating integration"}

--- a/internal/core/source_api/api/update_status.go
+++ b/internal/core/source_api/api/update_status.go
@@ -33,7 +33,7 @@ var (
 // It updates the status of an integration
 func (api API) UpdateStatus(input *models.UpdateStatusInput) error {
 	status := ddb.IntegrationStatus{
-		LastEventReceived: input.LastEventReceived,
+		LastEventReceived: &input.LastEventReceived,
 	}
 	err := dynamoClient.UpdateStatus(input.IntegrationID, status)
 	if err != nil {

--- a/internal/core/source_api/api/update_status.go
+++ b/internal/core/source_api/api/update_status.go
@@ -30,6 +30,7 @@ var (
 	updateStatusInternalError = &genericapi.InternalError{Message: "Failed to update source status, please try again later"}
 )
 
+// It updates the status of an integration
 func (api API) UpdateStatus(input *models.UpdateStatusInput) error {
 	status := ddb.IntegrationStatus{
 		LastEventReceived: input.LastEventReceived,

--- a/internal/core/source_api/api/update_status.go
+++ b/internal/core/source_api/api/update_status.go
@@ -1,4 +1,4 @@
-package ddb
+package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
@@ -19,26 +19,25 @@ package ddb
  */
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/internal/core/source_api/ddb"
+	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-// PutItem adds a source integration to the database
-func (ddb *DDB) PutItem(input *Integration) error {
-	item, err := dynamodbattribute.MarshalMap(input)
-	if err != nil {
-		return errors.Wrapf(err, "failed to marshal integration metadata")
-	}
+var (
+	updateStatusInternalError = &genericapi.InternalError{Message: "Failed to update source status, please try again later"}
+)
 
-	putRequest := &dynamodb.PutItemInput{
-		TableName: aws.String(ddb.TableName),
-		Item:      item,
+func (api API) UpdateStatus(input *models.UpdateStatusInput) error {
+	status := ddb.IntegrationStatus{
+		LastEventReceived: input.LastEventReceived,
 	}
-	_, err = ddb.Client.PutItem(putRequest)
+	err := dynamoClient.UpdateStatus(input.IntegrationID, status)
 	if err != nil {
-		return errors.Wrap(err, "failed to put item")
+		zap.L().Error("failed to update integration status", zap.Error(err), zap.String("integrationId", input.IntegrationID))
+		return updateStatusInternalError
 	}
 	return nil
 }

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -25,15 +25,16 @@ import (
 	"github.com/panther-labs/panther/internal/core/source_api/ddb"
 )
 
-func integrationToItem(input *models.SourceIntegration) *ddb.IntegrationItem {
+func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 	// Initializing the fields common for all integration types
-	item := &ddb.IntegrationItem{
+	item := &ddb.Integration{
 		CreatedAtTime:    input.CreatedAtTime,
 		CreatedBy:        input.CreatedBy,
 		IntegrationID:    input.IntegrationID,
 		IntegrationLabel: input.IntegrationLabel,
 		IntegrationType:  input.IntegrationType,
 	}
+	item.LastEventReceived = input.LastEventReceived
 
 	switch aws.StringValue(input.IntegrationType) {
 	case models.IntegrationTypeAWS3:
@@ -59,7 +60,7 @@ func integrationToItem(input *models.SourceIntegration) *ddb.IntegrationItem {
 	return item
 }
 
-func itemToIntegration(item *ddb.IntegrationItem) *models.SourceIntegration {
+func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 	// Initializing the fields common for all integration types
 	integration := &models.SourceIntegration{}
 	integration.IntegrationID = item.IntegrationID
@@ -67,6 +68,7 @@ func itemToIntegration(item *ddb.IntegrationItem) *models.SourceIntegration {
 	integration.IntegrationLabel = item.IntegrationLabel
 	integration.CreatedAtTime = item.CreatedAtTime
 	integration.CreatedBy = item.CreatedBy
+	integration.LastEventReceived = item.LastEventReceived
 
 	switch aws.StringValue(item.IntegrationType) {
 	case models.IntegrationTypeAWS3:

--- a/internal/core/source_api/ddb/get_item.go
+++ b/internal/core/source_api/ddb/get_item.go
@@ -28,7 +28,7 @@ import (
 )
 
 // GetItem returns an integration by its ID
-func (ddb *DDB) GetItem(integrationID *string) (*IntegrationItem, error) {
+func (ddb *DDB) GetItem(integrationID *string) (*Integration, error) {
 	output, err := ddb.Client.GetItem(&dynamodb.GetItemInput{
 		TableName: aws.String(ddb.TableName),
 		Key: map[string]*dynamodb.AttributeValue{
@@ -39,7 +39,7 @@ func (ddb *DDB) GetItem(integrationID *string) (*IntegrationItem, error) {
 		return nil, &genericapi.AWSError{Err: err, Method: "Dynamodb.GetItem"}
 	}
 
-	var integration IntegrationItem
+	var integration Integration
 	if output.Item == nil {
 		return nil, nil
 	}

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -47,7 +47,7 @@ type Integration struct {
 }
 
 type IntegrationStatus struct {
-	ScanStatus        *string   `json:"scanStatus"`
-	EventStatus       *string   `json:"eventStatus"`
-	LastEventReceived time.Time `json:"lastEventReceived"`
+	ScanStatus        *string    `json:"scanStatus"`
+	EventStatus       *string    `json:"eventStatus"`
+	LastEventReceived *time.Time `json:"lastEventReceived"`
 }

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -20,8 +20,8 @@ package ddb
 
 import "time"
 
-// IntegrationItem represents an integration item as it is stored in DynamoDB.
-type IntegrationItem struct {
+// Integration represents an integration item as it is stored in DynamoDB.
+type Integration struct {
 	CreatedAtTime    *time.Time `json:"createdAtTime"`
 	CreatedBy        *string    `json:"createdBy"`
 	IntegrationID    *string    `json:"integrationId"`
@@ -35,9 +35,8 @@ type IntegrationItem struct {
 	LastScanEndTime      *time.Time `json:"lastScanEndTime"`
 	LastScanErrorMessage *string    `json:"lastScanErrorMessage"`
 	LastScanStartTime    *time.Time `json:"lastScanStartTime"`
-	ScanStatus           *string    `json:"scanStatus"`
-	EventStatus          *string    `json:"eventStatus"`
 	ScanIntervalMins     *int       `json:"scanIntervalMins"`
+	IntegrationStatus
 
 	S3Bucket          *string   `json:"s3Bucket"`
 	S3Prefix          *string   `json:"s3Prefix"`
@@ -45,4 +44,10 @@ type IntegrationItem struct {
 	LogTypes          []*string `json:"logTypes" dynamodbav:"logTypes,stringset"`
 	StackName         *string   `json:"stackName,omitempty"`
 	LogProcessingRole *string   `json:"logProcessingRole,omitempty"`
+}
+
+type IntegrationStatus struct {
+	ScanStatus        *string   `json:"scanStatus"`
+	EventStatus       *string   `json:"eventStatus"`
+	LastEventReceived time.Time `json:"lastEventReceived"`
 }

--- a/internal/core/source_api/ddb/scan.go
+++ b/internal/core/source_api/ddb/scan.go
@@ -28,7 +28,7 @@ import (
 
 // ScanIntegrations returns all enabled integrations based on type (if type is specified).
 // It performs a DDB scan of the entire table with a filter expression.
-func (ddb *DDB) ScanIntegrations(integrationType *string) ([]*IntegrationItem, error) {
+func (ddb *DDB) ScanIntegrations(integrationType *string) ([]*Integration, error) {
 	scanInput := &dynamodb.ScanInput{
 		TableName: aws.String(ddb.TableName),
 	}
@@ -48,7 +48,7 @@ func (ddb *DDB) ScanIntegrations(integrationType *string) ([]*IntegrationItem, e
 		return nil, errors.Wrap(err, "failed to scan table")
 	}
 
-	var integrations []*IntegrationItem
+	var integrations []*Integration
 	if err := dynamodbattribute.UnmarshalListOfMaps(output.Items, &integrations); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal scan results")
 	}

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -201,7 +201,7 @@ func getSourceInfo(s3Object *S3ObjectInfo) (result *models.SourceIntegration, er
 		}
 	}
 
-	//
+	// If the incoming notification maps to a known source, update the source information
 	if result != nil {
 		previousTime := lastEventReceived[*result.IntegrationID]
 		if previousTime.Add(statusUpdateFrequency).Before(now) {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -73,6 +73,11 @@ var (
 	//used to simplify mocking during testing
 	newCredentialsFunc = stscreds.NewCredentials
 	newS3ClientFunc    = getNewS3Client
+
+	// Map from integrationId -> last time an event was received
+	lastEventReceived = make(map[string]time.Time)
+	// How frequently to update the status
+	statusUpdateFrequency = 1 * time.Minute
 )
 
 func init() {
@@ -170,7 +175,7 @@ func getAwsCredentials(roleArn string) *credentials.Credentials {
 // Returns the source configuration for this S3 object.
 // It will return error if it encountered an issue retrieving the role.
 // It will return nil result if no source exists for this object.
-func getSourceInfo(s3Object *S3ObjectInfo) (*models.SourceIntegration, error) {
+func getSourceInfo(s3Object *S3ObjectInfo) (result *models.SourceIntegration, err error) {
 	now := time.Now() // No need to be UTC. We care about relative time
 	if sourceCache.cacheUpdateTime.Add(sourceCacheDuration).Before(now) {
 		// we need to update the cache
@@ -178,7 +183,7 @@ func getSourceInfo(s3Object *S3ObjectInfo) (*models.SourceIntegration, error) {
 			ListIntegrations: &models.ListIntegrationsInput{},
 		}
 		var output []*models.SourceIntegration
-		err := genericapi.Invoke(common.LambdaClient, sourceAPIFunctionName, input, &output)
+		err = genericapi.Invoke(common.LambdaClient, sourceAPIFunctionName, input, &output)
 		if err != nil {
 			return nil, err
 		}
@@ -190,11 +195,37 @@ func getSourceInfo(s3Object *S3ObjectInfo) (*models.SourceIntegration, error) {
 		integrationBucket, integrationPrefix := getSourceS3Info(source)
 		if aws.StringValue(integrationBucket) == s3Object.S3Bucket {
 			if strings.HasPrefix(s3Object.S3ObjectKey, aws.StringValue(integrationPrefix)) {
-				return source, nil
+				result = source
+				break
 			}
 		}
 	}
-	return nil, nil
+
+	//
+	if result != nil {
+		previousTime := lastEventReceived[*result.IntegrationID]
+		if previousTime.Add(statusUpdateFrequency).Before(now) {
+			updateIntegrationStatus(*result.IntegrationID, now)
+			lastEventReceived[*result.IntegrationID] = now
+		}
+	}
+
+	return result, nil
+}
+
+func updateIntegrationStatus(integrationID string, timestamp time.Time) {
+	input := &models.LambdaInput{
+		UpdateStatus: &models.UpdateStatusInput{
+			IntegrationID:     integrationID,
+			LastEventReceived: timestamp,
+		},
+	}
+	// We are setting the `output` parameter to `nil` since we don't care about the returned value
+	err := genericapi.Invoke(common.LambdaClient, sourceAPIFunctionName, input, nil)
+	// best effort - if we fail to update the status, just log a warning
+	if err != nil {
+		zap.L().Warn("failed to update status for integrationID", zap.String("integrationID", integrationID))
+	}
 }
 
 func getNewS3Client(region *string, creds *credentials.Credentials) (result s3iface.S3API) {

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -176,8 +176,8 @@ func getAwsCredentials(roleArn string) *credentials.Credentials {
 // It will return error if it encountered an issue retrieving the role.
 // It will return nil result if no source exists for this object.
 func getSourceInfo(s3Object *S3ObjectInfo) (result *models.SourceIntegration, err error) {
-	currentTime := time.Now() // No need to be UTC. We care about relative time
-	if currentTime.Sub(sourceCache.cacheUpdateTime) > sourceCacheDuration {
+	now := time.Now() // No need to be UTC. We care about relative time
+	if sourceCache.cacheUpdateTime.Add(sourceCacheDuration).Before(now) {
 		// we need to update the cache
 		input := &models.LambdaInput{
 			ListIntegrations: &models.ListIntegrationsInput{},
@@ -187,7 +187,7 @@ func getSourceInfo(s3Object *S3ObjectInfo) (result *models.SourceIntegration, er
 		if err != nil {
 			return nil, err
 		}
-		sourceCache.cacheUpdateTime = currentTime
+		sourceCache.cacheUpdateTime = now
 		sourceCache.sources = output
 	}
 
@@ -203,11 +203,11 @@ func getSourceInfo(s3Object *S3ObjectInfo) (result *models.SourceIntegration, er
 
 	// If the incoming notification maps to a known source, update the source information
 	if result != nil {
-		eventUpdateTime := lastEventReceived[*result.IntegrationID]
+		deadline := lastEventReceived[*result.IntegrationID].Add(statusUpdateFrequency)
 		// if more than 'statusUpdateFrequency' time has passed, update status
-		if currentTime.Sub(eventUpdateTime) > statusUpdateFrequency {
-			updateIntegrationStatus(*result.IntegrationID, currentTime)
-			lastEventReceived[*result.IntegrationID] = currentTime
+		if now.After(deadline) {
+			updateIntegrationStatus(*result.IntegrationID, now)
+			lastEventReceived[*result.IntegrationID] = now
 		}
 	}
 

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -131,6 +131,7 @@ func TestHandleUnsupportedFileType(t *testing.T) {
 			S3Bucket:          aws.String("mybucket"),
 			IntegrationType:   aws.String(models.IntegrationTypeAWS3),
 			LogProcessingRole: aws.String("arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix"),
+			IntegrationID:     aws.String("3e4b1734-e678-4581-b291-4b8a17621999"),
 		},
 	}
 
@@ -140,7 +141,10 @@ func TestHandleUnsupportedFileType(t *testing.T) {
 		Payload: marshaledResult,
 	}
 
+	// First invocation should be to get the list of available sources
 	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
+	// Second invocation would be to update the status
+	lambdaMock.On("Invoke", mock.Anything).Return(&lambda.InvokeOutput{}, nil).Once()
 	s3Mock.On("GetBucketLocation", mock.Anything).Return(
 		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
 


### PR DESCRIPTION
## Background

Current `Sources` page contains little information the current status of a source. 
While we are looking to provide more rich monitoring around a source status, adding a small piece of information as a stop-gap solution. 

With this solution, the log processor updates the "status" of the source with the timestamp of the most recently received event. The status will have 1 minute accuracy. 

## Changes

- Added new API method "UpdateStatus" to the panther-source-api Lambda.
- Updated log processor to invoke the source-api
- Shortening `ddb.IntegrationItem` to just `ddb.Integration`. The namespace `ddb` adds context that this is a resource related to DynamoDB. 
- Added "omitempty" to several fields returned by the UI. While we do this for most of our other APIs, it seemed we were not following this practice for `source-api`.

## Testing

- mage test:ci
- Deployed. ListIntegration operation now returns this: 

```
 {
    "awsAccountId": "415773754570",
    "createdAtTime": "2020-06-17T16:10:19.240641152Z",
    "createdBy": "00000000-0000-4000-8000-000000000000",
    "integrationId": "3734447d-5b26-444b-921b-acb5dbbf3d30",
    "integrationLabel": "panther-account-eu-west-1",
    "integrationType": "aws-s3",
    "s3Bucket": "panther-bootstrap-auditlogs-XXXXXXXX",
    "logTypes": [
      "AWS.ALB",
      "AWS.S3ServerAccess",
      "AWS.VPCFlow"
    ],
    "logProcessingRole": "arn:aws:iam::123456789012:role/PantherLogProcessingRole-panther-account-eu-west-1",
    "stackName": "panther-log-analysis-setup-panther-account-eu-west-1",
    "lastEventReceived": "2020-06-19T14:14:26.710855261Z"
  },
```
