### PR TITLE
Add GSuite application instructions

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -54,7 +54,7 @@
     * [AWS Root Access Key Created](log-analysis/rules/aws-cis/aws-root-access-key-created.md)
     * [AWS Root Console Login](log-analysis/rules/aws-cis/aws-root-console-login.md)
     * [AWS Root Password Changed](log-analysis/rules/aws-cis/aws-root-password-changed.md)
-* [Supported Log Schemas]()
+* [Supported Logs]()
   * [Apache](log-analysis/log-processing/supported-logs/Apache.md)
   * [AWS](log-analysis/log-processing/supported-logs/AWS.md)
   * [Cisco Umbrella](log-analysis/log-processing/supported-logs/CiscoUmbrella.md)

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -54,7 +54,7 @@
     * [AWS Root Access Key Created](log-analysis/rules/aws-cis/aws-root-access-key-created.md)
     * [AWS Root Console Login](log-analysis/rules/aws-cis/aws-root-console-login.md)
     * [AWS Root Password Changed](log-analysis/rules/aws-cis/aws-root-password-changed.md)
-* [Supported Logs]()
+* [Supported Log Schemas]()
   * [Apache](log-analysis/log-processing/supported-logs/Apache.md)
   * [AWS](log-analysis/log-processing/supported-logs/AWS.md)
   * [Cisco Umbrella](log-analysis/log-processing/supported-logs/CiscoUmbrella.md)
@@ -70,6 +70,8 @@
   * [Suricata](log-analysis/log-processing/supported-logs/Suricata.md)
   * [Syslog](log-analysis/log-processing/supported-logs/Syslog.md)
   * [Zeek](log-analysis/log-processing/supported-logs/Zeek.md)
+* [SaaS logs setup]()
+  * [GSuite](log-analysis/log-processing/log-setup/gsuite.md)
 * [Standard Fields](log-analysis/panther-fields.md)
 
 ## Cloud Security

--- a/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
@@ -1,0 +1,37 @@
+# GSuite
+
+In order for Panther to be able to access the Report logs of your organization, you will need to create a new GSuite application with permissions to access Reports of your organization. 
+Panther will use the credentials of this application in order to pull the logs periodically (every 1 minute).
+
+## Setting up a GSuite application
+{% hint style="info" %}
+The steps below can only be performed if your GSuite user has permissions to see your organization's Reports. If your user doesn't have such permissions, 
+you can follow the steps [here](https://support.google.com/a/answer/2406043) in order to create a new role with Permissions access and assign your user this role. 
+{% endhint %}
+
+
+#### Create a Google API project
+1. Go to [Google API Console](https://console.developers.google.com/project)
+1. Click **Create Project**
+1. Enter a project name e.g. `Panther`
+1. Click **Create**. It will take a few seconds to create the project. Once created, click **View**
+
+#### Enable access
+1. Select the option to **Enable APIs**
+1. Select the **Admin SDK** and click **Enable**
+1. Select **Credentials** and **Configure Consent Screen**
+1. Click on **Internal** and **Create**
+1. Enter an **Application Name** e.g. `Panther` and click **Save**
+
+#### Create Credentials
+1. Click on **Create Credentials** -> **OAuth client ID**
+1. Select **Desktop app** as **Application Type** . You can give it a name e.g. `Panther`
+1. Click on **Create**
+
+Keep note of the ClientID and Client Secret! You will need to provide them to Panther in order for Panther to pull your reports.
+Note that you will still have to authorize Panther to pull your logs using a standard OAuth flow. Panther UI will guide you through the steps.  
+
+
+
+ 
+ 

--- a/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
@@ -29,9 +29,4 @@ you can follow the steps [here](https://support.google.com/a/answer/2406043) in 
 1. Click on **Create**
 
 Keep note of the ClientID and Client Secret! You will need to provide them to Panther in order for Panther to pull your reports.
-Note that you will still have to authorize Panther to pull your logs using a standard OAuth flow. Panther UI will guide you through the steps.  
-
-
-
- 
- 
+Note that you will still have to authorize Panther to pull your logs using a standard OAuth flow. Panther UI will guide you through the steps.

--- a/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
@@ -1,12 +1,12 @@
 # GSuite
 
-In order for Panther to be able to access the Report logs of your organization, you will need to create a new GSuite application with permissions to access Reports of your organization. 
-Panther will use the credentials of this application in order to pull the logs periodically (every 1 minute).
+In order for Panther to be able to access the Reports of your organization, you will need to create a new GSuite application with the necessary permissions. 
+Panther will use this application to pull the logs periodically (every 1 minute).
 
 ## Setting up a GSuite application
 {% hint style="info" %}
 The steps below can only be performed if your GSuite user has permissions to see your organization's Reports. If your user doesn't have such permissions, 
-you can follow the steps [here](https://support.google.com/a/answer/2406043) in order to create a new role with Permissions access and assign your user this role. 
+you can follow the steps [here](https://support.google.com/a/answer/2406043) in order to create a new role with Reports access and assign the role to your user. 
 {% endhint %}
 
 

--- a/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/gsuite.md
@@ -1,32 +1,36 @@
-# GSuite
+# G Suite Setup
 
-In order for Panther to be able to access the Reports of your organization, you will need to create a new GSuite application with the necessary permissions. 
+In order for Panther to be able to access the Reports of your organization, you will need to create a new G Suite application with the necessary permissions. 
 Panther will use this application to pull the logs periodically (every 1 minute).
 
-## Setting up a GSuite application
+## Setting up a G Suite application
+
 {% hint style="info" %}
-The steps below can only be performed if your GSuite user has permissions to see your organization's Reports. If your user doesn't have such permissions, 
+The steps below can only be performed if your G Suite user has permissions to see your organization's Reports. If your user doesn't have such permissions, 
 you can follow the steps [here](https://support.google.com/a/answer/2406043) in order to create a new role with Reports access and assign the role to your user. 
 {% endhint %}
 
 
-#### Create a Google API project
+### Create a Google API project
 1. Go to [Google API Console](https://console.developers.google.com/project)
 1. Click **Create Project**
 1. Enter a project name e.g. `Panther`
-1. Click **Create**. It will take a few seconds to create the project. Once created, click **View**
+1. Click **Create**. It will take a few seconds to create the project. Once created, you will get an on-screen notification. 
+ You can click **View** to see the details of the project. 
 
-#### Enable access
+### Enable access
 1. Select the option to **Enable APIs**
 1. Select the **Admin SDK** and click **Enable**
 1. Select **Credentials** and **Configure Consent Screen**
 1. Click on **Internal** and **Create**
 1. Enter an **Application Name** e.g. `Panther` and click **Save**
 
-#### Create Credentials
+### Create Credentials
 1. Click on **Create Credentials** -> **OAuth client ID**
 1. Select **Desktop app** as **Application Type** . You can give it a name e.g. `Panther`
 1. Click on **Create**
 
+{% hint style="info" %}
 Keep note of the ClientID and Client Secret! You will need to provide them to Panther in order for Panther to pull your reports.
 Note that you will still have to authorize Panther to pull your logs using a standard OAuth flow. Panther UI will guide you through the steps.
+{% endhint %}


### PR DESCRIPTION
## Background

Adding instructions on how to create GSuite application that Panther can use to pull logs

The UI will point to this documentation as part of the GSuite logs onboarding. Feedback/recommendation about the text the structured are more than welcomed!
