### PR TITLE
Move VPC flow logs to bootstrap stack

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -615,6 +615,16 @@ Resources:
       EnableDnsHostnames: true
       CidrBlock: !FindInMap [SubnetConfig, VPC, CIDR]
 
+  FlowLogs:
+    DependsOn: AuditLogsBucketPolicy
+    Type: AWS::EC2::FlowLog
+    Properties:
+      LogDestination: !Sub ${AuditLogs.Arn}/${VPC}/
+      LogDestinationType: s3
+      ResourceId: !Ref VPC
+      ResourceType: VPC
+      TrafficType: ALL
+
   # We define a public subnet so that we can access our web server from a public IP. The empty
   # string in !GetAZs is equivalent to AWS::Region
   PublicSubnetOne:
@@ -932,9 +942,6 @@ Outputs:
     Value: !Ref Source
 
   # Networking + elb
-  VpcId:
-    Description: Web VPC ID
-    Value: !Ref VPC
   SubnetOneId:
     Description: Public subnet one
     Value: !Ref PublicSubnetOne

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -326,7 +326,6 @@ Resources:
         EnableCloudTrail: !Ref EnableCloudTrail
         EnableGuardDuty: !Ref EnableGuardDuty
         EnableS3AccessLogs: !Ref EnableS3AccessLogs
-        VpcId: !GetAtt Bootstrap.Outputs.VpcId
       Tags:
         - Key: Application
           Value: Panther

--- a/deployments/onboard.yml
+++ b/deployments/onboard.yml
@@ -41,9 +41,6 @@ Parameters:
     Type: String
     Description: Enable S3 access logging for all Panther buckets
     AllowedValues: [true, false]
-  VpcId:
-    Type: String
-    Description: Web VPC ID
 
 Conditions:
   EnableCloudTrail: !Equals [!Ref EnableCloudTrail, true]
@@ -131,16 +128,6 @@ Resources:
         DestinationArn: !Sub arn:${AWS::Partition}:s3:::${AuditLogsBucket}
         KmsKeyArn: !GetAtt GuardDutyEncryptionKey.Arn
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
-
-  # Panther monitors itself, the AuditLogsBucket is processed by the log processor
-  FlowLogs:
-    Type: AWS::EC2::FlowLog
-    Properties:
-      LogDestination: !Sub arn:${AWS::Partition}:s3:::${AuditLogsBucket}
-      LogDestinationType: s3
-      ResourceId: !Ref VpcId
-      ResourceType: VPC
-      TrafficType: ALL
 
   # Configure SNS Topic to receive bucket notifications
   # This topic is used to notify the log processor queue whenever new data is written to the auditing bucket.

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -517,7 +517,6 @@ func deployOnboardStack(settings *config.PantherConfig, outputs map[string]strin
 			"EnableCloudTrail":      strconv.FormatBool(settings.Setup.EnableCloudTrail),
 			"EnableGuardDuty":       strconv.FormatBool(settings.Setup.EnableGuardDuty),
 			"EnableS3AccessLogs":    strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
-			"VpcId":                 outputs["VpcId"],
 		})
 	} else {
 		// Delete the onboard stack if OnboardSelf was toggled off


### PR DESCRIPTION
## Background

VPC flow logs moved from the bootstrap stack to the onboard stack when preparing the pre-packaged deployment because of a SAR compatibility issue. Our hosted deployments generally do not enable self-onboarding, meaning the entire onboard stack, including VPC flow logs, does not exist in those environments.

VPC flow logs are similar to S3 access logs - they are enabled on each resource, not account-wide like CloudTrail/GuardDuty. Like S3 access logs, VPC flow logs should always be enabled if possible, even if they aren't being ingested by the Panther deployment in the same account.

## Changes

- Move FlowLogs resource from onboard into bootstrap stack (SAR compatibility is no longer a concern)

The configuration can't just be copied exactly without a migration:

```
11:43:31	INFO	deploy: update CloudFormation stack panther-bootstrap
11:44:08	ERROR	stack panther-bootstrap: AWS::EC2::FlowLog FlowLogs CREATE_FAILED: Error. There is an existing Flow Log with the same configuration and log destination. (Service: Ec2, Status Code: 400, Request ID: cbfb08c1-ca97-4daa-9ec3-a604e8428c41, Extended Request ID: null)
```

Rather than writing a migration (which would require a new custom resource), I just changed the S3 target to include the VPC id as a top level folder when writing the logs. This is how S3 access logs work as well, and I'd argue it's a better configuration than writing logs to the root of the bucket anyway.

During the v1.4.0 => v1.5.0 migration, then, there will briefly be two different flow logs configured on the same Panther VPC - one which writes to the bucket root, one which writes under a folder.

## Testing

- Upgraded existing deployment
