### PR TITLE
Reducing retries for log processor messages

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -344,7 +344,7 @@ Resources:
       VisibilityTimeout: !FindInMap [Functions, LogProcessor, Timeout]
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt LogProcessorDLQ.Arn
-        maxReceiveCount: 10
+        maxReceiveCount: 4 # Retry for 4 x 15' timeout = 60'
 
   LogProcessorQueueAlarms:
     Type: Custom::SQSAlarms


### PR DESCRIPTION
## Background

Fixes https://github.com/panther-labs/panther/issues/961

## Changes

- Reducing retries for log processor messages to 4. If that threshold is breached, the message will move to the DLQ. 

Given that the visibility timeout is 15', this means we will retry for 1hr until giving up. When giving up, the message will go to the DLQ. 

An "absolutely correct" number of retries is hard to hit. Too few and people will have to be paged/notified for the slightest issue, too high can lead to "pointless" retrying. 
I think retrying for 1hr is reasonable for our scenarios, but we can always adjust in the future. 

## Testing

- Mage test:ci
