### PR TITLE
v1.5.0 Release

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -18,7 +18,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: IAM role for deploying Panther
 
 Metadata:
-  Version: v1.4.0
+  Version: v1.5.0
 
 Resources:
   DeploymentRole:
@@ -118,6 +118,7 @@ Resources:
               - lambda:*EventSourceMapping
               - lambda:List*
               - logs:*
+              - s3:ListAllMyBuckets
               - sns:List*
               - sqs:List*
               - states:CreateStateMachine

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -113,6 +113,7 @@ resource "aws_iam_policy" "deployment" {
           "lambda:*EventSourceMapping",
           "lambda:List*",
           "logs:*",
+          "s3:ListAllMyBuckets",
           "sns:List*",
           "sqs:List*",
           "states:CreateStateMachine",

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -539,19 +539,6 @@ Resources:
         AdvancedSecurityMode: ENFORCED
       UserPoolName: panther-users
 
-  AppClient:
-    Type: AWS::Cognito::UserPoolClient
-    Properties:
-      ClientName: Panther
-      GenerateSecret: false
-      RefreshTokenValidity: 1
-      UserPoolId: !Ref UserPool
-      PreventUserExistenceErrors: ENABLED
-      WriteAttributes:
-        - email
-        - given_name
-        - family_name
-
   ########## Dynamo ##########
   DynamoScalingRole:
     Type: AWS::IAM::Role
@@ -988,9 +975,6 @@ Outputs:
   UserPoolId:
     Description: Cognito user pool ID
     Value: !Ref UserPool
-  AppClientId:
-    Description: Cognito user pool client ID
-    Value: !Ref AppClient
 
   # Dynamo
   DynamoScalingRoleArn:

--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -293,6 +293,19 @@ Resources:
       ServiceToken: !GetAtt CustomResourceFunction.Arn
       UserPoolId: !Ref UserPoolId
 
+  AppClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      ClientName: Panther
+      GenerateSecret: false
+      RefreshTokenValidity: 1
+      UserPoolId: !Ref UserPoolId
+      PreventUserExistenceErrors: ENABLED
+      WriteAttributes:
+        - email
+        - given_name
+        - family_name
+
   AnalysisApi:
     Type: AWS::Serverless::Api
     Properties:
@@ -374,9 +387,13 @@ Resources:
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 
 Outputs:
+  AppClientId:
+    Description: Cognito user pool client ID
+    Value: !Ref AppClient
   PythonLayerVersionArn:
     Description: Python layer version
     Value: !If [CreatePythonLayer, !Ref PythonLayer, !Ref PythonLayerVersionArn]
+
   AnalysisApiId:
     Description: Analysis API Gateway ID
     Value: !Ref AnalysisApi

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -121,7 +121,7 @@ Parameters:
 Mappings:
   Constants:
     Panther:
-      Version: 1.4.0
+      Version: 1.5.0
 
 Conditions:
   RegistryProvided: !Not [!Equals [!Ref ImageRegistry, '']]
@@ -338,12 +338,12 @@ Resources:
 
   Web:
     Type: AWS::CloudFormation::Stack
-    DependsOn: [BootstrapGateway, Core] # custom-resources and users-api, respectively
+    DependsOn: Core # users-api
     Properties:
       TemplateURL: web_server.yml
       Parameters:
         AlarmTopicArn: !GetAtt Bootstrap.Outputs.AlarmTopicArn
-        AppClientId: !GetAtt Bootstrap.Outputs.AppClientId
+        AppClientId: !GetAtt BootstrapGateway.Outputs.AppClientId
         CertificateArn: !Ref CertificateArn
         CloudWatchLogRetentionDays: !Ref CloudWatchLogRetentionDays
         CustomResourceVersion: !FindInMap [Constants, Panther, Version]

--- a/docs/gitbook/quick-start.md
+++ b/docs/gitbook/quick-start.md
@@ -27,7 +27,7 @@ First, navigate to the AWS CloudFormation console and create a new stack.
 Use the following template URL to install the latest version in the us-east-1 region:
 
 ```
-https://panther-community-us-east-1.s3.amazonaws.com/v1.4.0/panther.yml
+https://panther-community-us-east-1.s3.amazonaws.com/v1.5.0/panther.yml
 ```
 
 The template URL is of the following form:
@@ -68,7 +68,7 @@ Resources:
   Panther:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://panther-community-${AWS::Region}.s3.amazonaws.com/v1.4.0/panther.yml
+      TemplateURL: !Sub https://panther-community-${AWS::Region}.s3.amazonaws.com/v1.5.0/panther.yml
       Parameters:
         CompanyDisplayName: AwesomeCo
         FirstUserEmail: user@example.com
@@ -87,7 +87,7 @@ aws cloudformation deploy --template-file template.yml --stack-name panther --ca
 ```hcl
 resource "aws_cloudformation_stack" "panther" {
   name = "panther"
-  template_url = "https://panther-community-<REGION>.s3.amazonaws.com/v1.4.0/panther.yml"
+  template_url = "https://panther-community-<REGION>.s3.amazonaws.com/v1.5.0/panther.yml"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters = {
     CompanyDisplayName = "AwesomeCo"

--- a/internal/core/organization_api/api/get_settings.go
+++ b/internal/core/organization_api/api/get_settings.go
@@ -22,5 +22,5 @@ import "github.com/panther-labs/panther/api/lambda/organization/models"
 
 // GetSettings retrieves account settings.
 func (API) GetSettings(_ *models.GetSettingsInput) (*models.GeneralSettings, error) {
-	return orgTable.Get()
+	return orgTable.GetGeneralSettings()
 }

--- a/internal/core/organization_api/api/update_settings.go
+++ b/internal/core/organization_api/api/update_settings.go
@@ -24,5 +24,5 @@ import (
 
 // UpdateSettings updates account settings.
 func (API) UpdateSettings(input *models.UpdateSettingsInput) (*models.GeneralSettings, error) {
-	return orgTable.Update(input)
+	return orgTable.UpdateGeneralSettings(input)
 }

--- a/internal/core/organization_api/table/get.go
+++ b/internal/core/organization_api/table/get.go
@@ -21,15 +21,12 @@ package table
 import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/organization/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-// Get retrieves account details from the table.
-func (table *OrganizationsTable) Get() (*models.GeneralSettings, error) {
-	zap.L().Debug("retrieving general settings from dynamo")
+func (table *OrganizationsTable) GetGeneralSettings() (*models.GeneralSettings, error) {
 	response, err := table.client.GetItem(&dynamodb.GetItemInput{Key: settingsKey, TableName: table.Name})
 	if err != nil {
 		return nil, &genericapi.AWSError{Method: "dynamodb.GetItem", Err: err}

--- a/internal/core/organization_api/table/get_test.go
+++ b/internal/core/organization_api/table/get_test.go
@@ -42,7 +42,7 @@ func TestGetItemAwsError(t *testing.T) {
 		(*dynamodb.GetItemOutput)(nil), errors.New("service unavailable"))
 	table := &OrganizationsTable{client: mockClient, Name: aws.String("test-table")}
 
-	result, err := table.Get()
+	result, err := table.GetGeneralSettings()
 	mockClient.AssertExpectations(t)
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -60,7 +60,7 @@ func TestGetItemUnmarshalError(t *testing.T) {
 	mockClient.On("GetItem", mock.Anything).Return(output, nil)
 	table := &OrganizationsTable{client: mockClient, Name: aws.String("test-table")}
 
-	result, err := table.Get()
+	result, err := table.GetGeneralSettings()
 	mockClient.AssertExpectations(t)
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -80,7 +80,7 @@ func TestGetItem(t *testing.T) {
 	mockClient.On("GetItem", expectedInput).Return(output, nil)
 	table := &OrganizationsTable{client: mockClient, Name: aws.String("test-table")}
 
-	_, err := table.Get()
+	_, err := table.GetGeneralSettings()
 	mockClient.AssertExpectations(t)
 	require.NoError(t, err)
 }

--- a/internal/core/organization_api/table/table.go
+++ b/internal/core/organization_api/table/table.go
@@ -33,8 +33,8 @@ var settingsKey = DynamoItem{"id": {S: aws.String("generalSettings")}}
 
 // API defines the interface for the table which can be used for mocking.
 type API interface {
-	Get() (*models.GeneralSettings, error)
-	Update(settings *models.GeneralSettings) (*models.GeneralSettings, error)
+	GetGeneralSettings() (*models.GeneralSettings, error)
+	UpdateGeneralSettings(*models.GeneralSettings) (*models.GeneralSettings, error)
 }
 
 // OrganizationsTable encapsulates a connection to the Dynamo table.

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -240,7 +240,7 @@ func deploySingleStack(stack string) error {
 		return deployDashboardStack(bucket)
 	case frontendStack:
 		setFirstUser(getSettings())
-		return deployFrontend(getAccountID(), stackOutputs(bootstrapStack), getSettings())
+		return deployFrontend(getAccountID(), stackOutputs(bootstrapStack, gatewayStack), getSettings())
 	case logAnalysisStack:
 		build.API()
 		build.Lambda()

--- a/tools/mage/teardown.go
+++ b/tools/mage/teardown.go
@@ -169,7 +169,7 @@ func destroyPantherBuckets() {
 	client := s3.New(awsSession)
 	response, err := client.ListBuckets(&s3.ListBucketsInput{})
 	if err != nil {
-		logger.Fatal(err)
+		logger.Fatalf("failed to list S3 buckets: %v", err)
 	}
 
 	for _, bucket := range response.Buckets {


### PR DESCRIPTION
## Background

This will be the v1.5.0 release tag once merged

## Changes

- Add `s3:ListAllMyBuckets` permission to the deployment role - this is required for `mage teardown`
- Bump version in docs and master template to v1.5.0
- Backport some restructuring from https://github.com/panther-labs/panther-enterprise/pull/264 for easier merging

## Testing

- Full release testing ongoing
- Paid special attention to new alerts page, adding multiple globals, reset password, and upgrading a deployment with the pre-packaged template