### PR TITLE
Log Source Table to display "lastEventReceived" for each source

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -368,6 +368,7 @@ type S3LogIntegration {
   integrationId: ID!
   integrationType: String!
   integrationLabel: String!
+  lastEventReceived: AWSDateTime
   s3Bucket: String!
   s3Prefix: String
   kmsKey: String

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -368,7 +368,7 @@ type S3LogIntegration {
   integrationId: ID!
   integrationType: String!
   integrationLabel: String!
-  lastEventReceived: AWSTimestamp
+  lastEventReceived: AWSDateTime
   s3Bucket: String!
   s3Prefix: String
   kmsKey: String

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -368,7 +368,7 @@ type S3LogIntegration {
   integrationId: ID!
   integrationType: String!
   integrationLabel: String!
-  lastEventReceived: AWSDateTime
+  lastEventReceived: AWSTimestamp
   s3Bucket: String!
   s3Prefix: String
   kmsKey: String

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -29,8 +29,8 @@ export type Scalars = {
   Float: number;
   AWSDateTime: string;
   AWSJSON: string;
-  AWSTimestamp: number;
   AWSEmail: string;
+  AWSTimestamp: number;
 };
 
 export enum AccountTypeEnum {
@@ -963,7 +963,7 @@ export type S3LogIntegration = {
   integrationId: Scalars['ID'];
   integrationType: Scalars['String'];
   integrationLabel: Scalars['String'];
-  lastEventReceived?: Maybe<Scalars['AWSTimestamp']>;
+  lastEventReceived?: Maybe<Scalars['AWSDateTime']>;
   s3Bucket: Scalars['String'];
   s3Prefix?: Maybe<Scalars['String']>;
   kmsKey?: Maybe<Scalars['String']>;
@@ -1263,7 +1263,6 @@ export type ResolversTypes = {
   GetComplianceIntegrationTemplateInput: GetComplianceIntegrationTemplateInput;
   IntegrationTemplate: ResolverTypeWrapper<IntegrationTemplate>;
   S3LogIntegration: ResolverTypeWrapper<S3LogIntegration>;
-  AWSTimestamp: ResolverTypeWrapper<Scalars['AWSTimestamp']>;
   S3LogIntegrationHealth: ResolverTypeWrapper<S3LogIntegrationHealth>;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   GetResourceInput: GetResourceInput;
@@ -1305,6 +1304,7 @@ export type ResolversTypes = {
   ListGlobalPythonModulesResponse: ResolverTypeWrapper<ListGlobalPythonModulesResponse>;
   User: ResolverTypeWrapper<User>;
   AWSEmail: ResolverTypeWrapper<Scalars['AWSEmail']>;
+  AWSTimestamp: ResolverTypeWrapper<Scalars['AWSTimestamp']>;
   Mutation: ResolverTypeWrapper<{}>;
   DestinationInput: DestinationInput;
   DestinationConfigInput: DestinationConfigInput;
@@ -1387,7 +1387,6 @@ export type ResolversParentTypes = {
   GetComplianceIntegrationTemplateInput: GetComplianceIntegrationTemplateInput;
   IntegrationTemplate: IntegrationTemplate;
   S3LogIntegration: S3LogIntegration;
-  AWSTimestamp: Scalars['AWSTimestamp'];
   S3LogIntegrationHealth: S3LogIntegrationHealth;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   GetResourceInput: GetResourceInput;
@@ -1429,6 +1428,7 @@ export type ResolversParentTypes = {
   ListGlobalPythonModulesResponse: ListGlobalPythonModulesResponse;
   User: User;
   AWSEmail: Scalars['AWSEmail'];
+  AWSTimestamp: Scalars['AWSTimestamp'];
   Mutation: {};
   DestinationInput: DestinationInput;
   DestinationConfigInput: DestinationConfigInput;
@@ -2306,7 +2306,7 @@ export type S3LogIntegrationResolvers<
   integrationId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   integrationType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   integrationLabel?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  lastEventReceived?: Resolver<Maybe<ResolversTypes['AWSTimestamp']>, ParentType, ContextType>;
+  lastEventReceived?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
   s3Bucket?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   s3Prefix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   kmsKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -963,6 +963,7 @@ export type S3LogIntegration = {
   integrationId: Scalars['ID'];
   integrationType: Scalars['String'];
   integrationLabel: Scalars['String'];
+  lastEventReceived?: Maybe<Scalars['AWSDateTime']>;
   s3Bucket: Scalars['String'];
   s3Prefix?: Maybe<Scalars['String']>;
   kmsKey?: Maybe<Scalars['String']>;
@@ -2305,6 +2306,7 @@ export type S3LogIntegrationResolvers<
   integrationId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   integrationType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   integrationLabel?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  lastEventReceived?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
   s3Bucket?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   s3Prefix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   kmsKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -29,8 +29,8 @@ export type Scalars = {
   Float: number;
   AWSDateTime: string;
   AWSJSON: string;
-  AWSEmail: string;
   AWSTimestamp: number;
+  AWSEmail: string;
 };
 
 export enum AccountTypeEnum {
@@ -963,7 +963,7 @@ export type S3LogIntegration = {
   integrationId: Scalars['ID'];
   integrationType: Scalars['String'];
   integrationLabel: Scalars['String'];
-  lastEventReceived?: Maybe<Scalars['AWSDateTime']>;
+  lastEventReceived?: Maybe<Scalars['AWSTimestamp']>;
   s3Bucket: Scalars['String'];
   s3Prefix?: Maybe<Scalars['String']>;
   kmsKey?: Maybe<Scalars['String']>;
@@ -1263,6 +1263,7 @@ export type ResolversTypes = {
   GetComplianceIntegrationTemplateInput: GetComplianceIntegrationTemplateInput;
   IntegrationTemplate: ResolverTypeWrapper<IntegrationTemplate>;
   S3LogIntegration: ResolverTypeWrapper<S3LogIntegration>;
+  AWSTimestamp: ResolverTypeWrapper<Scalars['AWSTimestamp']>;
   S3LogIntegrationHealth: ResolverTypeWrapper<S3LogIntegrationHealth>;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   GetResourceInput: GetResourceInput;
@@ -1304,7 +1305,6 @@ export type ResolversTypes = {
   ListGlobalPythonModulesResponse: ResolverTypeWrapper<ListGlobalPythonModulesResponse>;
   User: ResolverTypeWrapper<User>;
   AWSEmail: ResolverTypeWrapper<Scalars['AWSEmail']>;
-  AWSTimestamp: ResolverTypeWrapper<Scalars['AWSTimestamp']>;
   Mutation: ResolverTypeWrapper<{}>;
   DestinationInput: DestinationInput;
   DestinationConfigInput: DestinationConfigInput;
@@ -1387,6 +1387,7 @@ export type ResolversParentTypes = {
   GetComplianceIntegrationTemplateInput: GetComplianceIntegrationTemplateInput;
   IntegrationTemplate: IntegrationTemplate;
   S3LogIntegration: S3LogIntegration;
+  AWSTimestamp: Scalars['AWSTimestamp'];
   S3LogIntegrationHealth: S3LogIntegrationHealth;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   GetResourceInput: GetResourceInput;
@@ -1428,7 +1429,6 @@ export type ResolversParentTypes = {
   ListGlobalPythonModulesResponse: ListGlobalPythonModulesResponse;
   User: User;
   AWSEmail: Scalars['AWSEmail'];
-  AWSTimestamp: Scalars['AWSTimestamp'];
   Mutation: {};
   DestinationInput: DestinationInput;
   DestinationConfigInput: DestinationConfigInput;
@@ -2306,7 +2306,7 @@ export type S3LogIntegrationResolvers<
   integrationId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   integrationType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   integrationLabel?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  lastEventReceived?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
+  lastEventReceived?: Resolver<Maybe<ResolversTypes['AWSTimestamp']>, ParentType, ContextType>;
   s3Bucket?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   s3Prefix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   kmsKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -31,6 +31,7 @@ export type S3LogIntegrationDetails = Pick<
   | 'createdAtTime'
   | 'createdBy'
   | 'awsAccountId'
+  | 'lastEventReceived'
   | 'kmsKey'
   | 's3Bucket'
   | 's3Prefix'
@@ -52,6 +53,7 @@ export const S3LogIntegrationDetails = gql`
     createdAtTime
     createdBy
     awsAccountId
+    lastEventReceived
     kmsKey
     s3Bucket
     s3Prefix

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
@@ -5,6 +5,7 @@ fragment S3LogIntegrationDetails on S3LogIntegration {
   createdAtTime
   createdBy
   awsAccountId
+  lastEventReceived
   kmsKey
   s3Bucket
   s3Prefix

--- a/web/src/pages/ListLogSources/LogSourceTable/LogSourceTable.tsx
+++ b/web/src/pages/ListLogSources/LogSourceTable/LogSourceTable.tsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import { Box, Flex, Label, Table } from 'pouncejs';
 import { ListLogSources } from 'Pages/ListLogSources';
+import { formatDatetime } from 'Helpers/utils';
 import LogSourceHealthIcon from './LogSourceHealthIcon';
 import LogSourceTableRowOptionsProps from './LogSourceTableRowOptions';
 
@@ -57,7 +58,9 @@ const LogSourceTable: React.FC<LogSourceTableProps> = ({ sources }) => {
             </Table.Cell>
             <Table.Cell>{source.s3Bucket}</Table.Cell>
             <Table.Cell>{source.s3Prefix || 'None'}</Table.Cell>
-            <Table.Cell>{source.lastEventReceived || 'N/A'}</Table.Cell>
+            <Table.Cell>
+              {source.lastEventReceived ? formatDatetime(source.lastEventReceived) : 'N/A'}
+            </Table.Cell>
             <Table.Cell>
               <Flex justify="center">
                 <LogSourceHealthIcon logSourceHealth={source.health} />

--- a/web/src/pages/ListLogSources/LogSourceTable/LogSourceTable.tsx
+++ b/web/src/pages/ListLogSources/LogSourceTable/LogSourceTable.tsx
@@ -18,6 +18,7 @@
 
 import React from 'react';
 import { Box, Flex, Label, Table } from 'pouncejs';
+import dayjs from 'dayjs';
 import { ListLogSources } from 'Pages/ListLogSources';
 import LogSourceHealthIcon from './LogSourceHealthIcon';
 import LogSourceTableRowOptionsProps from './LogSourceTableRowOptions';
@@ -37,6 +38,7 @@ const LogSourceTable: React.FC<LogSourceTableProps> = ({ sources }) => {
           <Table.HeaderCell>Log Types</Table.HeaderCell>
           <Table.HeaderCell>S3 Bucket</Table.HeaderCell>
           <Table.HeaderCell>S3 Objects Prefix</Table.HeaderCell>
+          <Table.HeaderCell>Last Received Event</Table.HeaderCell>
           <Table.HeaderCell align="center">Healthy</Table.HeaderCell>
           <Table.HeaderCell />
         </Table.Row>
@@ -56,6 +58,12 @@ const LogSourceTable: React.FC<LogSourceTableProps> = ({ sources }) => {
             </Table.Cell>
             <Table.Cell>{source.s3Bucket}</Table.Cell>
             <Table.Cell>{source.s3Prefix || 'None'}</Table.Cell>
+            <Table.Cell>{source.lastEventReceived || 'N/A'}</Table.Cell>
+            <Table.Cell>
+              {source.lastEventReceived
+                ? dayjs(source.lastEventReceived * 1000).format('MM/DD/YYYY, HH:mm G[M]TZZ')
+                : 'N/A'}
+            </Table.Cell>
             <Table.Cell>
               <Flex justify="center">
                 <LogSourceHealthIcon logSourceHealth={source.health} />

--- a/web/src/pages/ListLogSources/LogSourceTable/LogSourceTable.tsx
+++ b/web/src/pages/ListLogSources/LogSourceTable/LogSourceTable.tsx
@@ -18,7 +18,6 @@
 
 import React from 'react';
 import { Box, Flex, Label, Table } from 'pouncejs';
-import dayjs from 'dayjs';
 import { ListLogSources } from 'Pages/ListLogSources';
 import LogSourceHealthIcon from './LogSourceHealthIcon';
 import LogSourceTableRowOptionsProps from './LogSourceTableRowOptions';
@@ -59,11 +58,6 @@ const LogSourceTable: React.FC<LogSourceTableProps> = ({ sources }) => {
             <Table.Cell>{source.s3Bucket}</Table.Cell>
             <Table.Cell>{source.s3Prefix || 'None'}</Table.Cell>
             <Table.Cell>{source.lastEventReceived || 'N/A'}</Table.Cell>
-            <Table.Cell>
-              {source.lastEventReceived
-                ? dayjs(source.lastEventReceived * 1000).format('MM/DD/YYYY, HH:mm G[M]TZZ')
-                : 'N/A'}
-            </Table.Cell>
             <Table.Cell>
               <Flex justify="center">
                 <LogSourceHealthIcon logSourceHealth={source.health} />


### PR DESCRIPTION
## Background

We want to show to users when was the latest event received for each integration. The purpose of that is to primarily understand if an integration is active (or recently active) and not just "healthy". The backend functionality for this is implemented on #1054. This PR introduces the changes needed to display that field in UI.

Note: Ignore backend changes on this PR, they should be handle on #1054 

Closes #1055 

## Changes

- Added `lastEventReceived` field to `S3LogIntegration`
- Updated `LogSourceTable` to display field

## Testing

- Locally
- Deployed env

![Screenshot 2020-06-25 at 9 09 38 AM](https://user-images.githubusercontent.com/14179917/85665033-9ef5ac80-b6c3-11ea-8934-c79a2278ba3c.png)
