### PR TITLE
Add firehose permissions to deployment role

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -151,8 +151,7 @@ Resources:
             Resource: !Sub arn:${AWS::Partition}:execute-api:*:${AWS::AccountId}:*
           - Effect: Allow
             Action: firehose:*
-            Resource:
-              - !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/panther-*
+            Resource: !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/panther-*
           - Effect: Allow
             Action: iam:*
             Resource:

--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -150,6 +150,10 @@ Resources:
             Action: execute-api:Invoke
             Resource: !Sub arn:${AWS::Partition}:execute-api:*:${AWS::AccountId}:*
           - Effect: Allow
+            Action: firehose:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/panther-*
+          - Effect: Allow
             Action: iam:*
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/AWSServiceRole*

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -160,6 +160,11 @@ resource "aws_iam_policy" "deployment" {
       },
       {
         Effect : "Allow",
+        Action : "firehose:*",
+        Resource : "arn:${var.aws_partition}:firehose:*:${var.aws_account_id}:deliverystream/panther-*"
+      },
+      {
+        Effect : "Allow",
         Action : "iam:*",
         Resource : [
           "arn:${var.aws_partition}:iam::${var.aws_account_id}:role/AWSServiceRole*",


### PR DESCRIPTION
## Background

When testing panther-enterprise v1.5.0, I found the deployment role was missing `firehose:*` permissions for the event bridge delivery stream.

We added that permission in the enterprise repo, but not here in the community edition. We only have one deployment role template, and the one that we had published to S3 does not work for enterprise.

## Changes

- Add `firehose:*` permission for `panther-*` delivery streams to the deployment role

## Testing

- Enterprise deployment with this role
- Copied template from community into enterprise to ensure there were no other differences

I'm not going to move the v1.5.0 git tag, but I did overwrite the v1.5.0 S3 template in the public bucket.
