### PR TITLE
Support updates to Custom::GuardDutyDestination resource

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -170,6 +170,7 @@ Resources:
                 - guardduty:Get*
                 - guardduty:List*
                 - guardduty:DeletePublishingDestination
+                - guardduty:UpdatePublishingDestination
               Resource: '*'
             - Effect: Allow
               Action:


### PR DESCRIPTION
## Background

When trying to upgrade one of our deployments to v1.5.0, I encountered this error:

> stack panther-onboard: Custom::GuardDutyDestination GuardDutyDestination UPDATE_FAILED: Failed to update resource. BadRequestException: The request failed because a publishingDestination already exists with the destinationType value provided in the request.

Here's what happened:

1. Because we added the `CustomResourceVersion` to most custom resources, CloudFormation triggered an update to the `Custom::GuardDutyDestination` resource, as intended
2. Our implementation of the custom resource used the same code path for both create and update, which leads to the error you see above
3. GuardDuty is disabled by default, so my release testing didn't catch it when I did an upgrade

## Changes

- Implement GuardDuty destination updates separately from creation

## Testing

- Deployed with GuardDuty disabled, then enabled, then with a new version (to trigger the update), then disabled again

## Migration
For existing deployments that have GuardDuty enabled, a simple workaround is to disable GuardDuty, deploy, then re-enable GuardDuty. (I've added this to the release notes.)

Because this setting is off by default and there is an easy workaround, I don't feel this is a critical bug fix that requires re-publishing the 1.5 release or creating a new release. But if the reviewers feel differently, let me know.