### PR TITLE
Fixing classifier behavior

### DIFF
--- a/internal/log_analysis/log_processor/classification/classifier.go
+++ b/internal/log_analysis/log_processor/classification/classifier.go
@@ -78,18 +78,12 @@ func (c *Classifier) ParserStats() map[string]*ParserStats {
 func safeLogParse(logType string, parser parsers.Interface, log string) (results []*parsers.Result, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.New("parser panic")
+			err = errors.Errorf("parser %q panic: %v", logType, r)
 			results = nil
-			zap.L().Debug("parser panic",
-				zap.String("parser", logType),
-				zap.Error(err))
 		}
 	}()
 	results, err = parser.ParseLog(log)
 	if err != nil {
-		zap.L().Debug("parser failed",
-			zap.String("parser", logType),
-			zap.Error(err))
 		return nil, err
 	}
 	return results, nil
@@ -137,7 +131,7 @@ func (c *Classifier) Classify(log string) *ClassifierResult {
 
 		// Parser failed to parse event
 		if err != nil {
-			zap.L().Debug("failed to parse event", zap.String("expectedLogType", logType))
+			zap.L().Debug("failed to parse event", zap.String("expectedLogType", logType), zap.Error(err))
 			// Removing parser from queue
 			popped = append(popped, heap.Pop(c.parsers))
 			// Increasing penalty of the parser

--- a/internal/log_analysis/log_processor/classification/classifier.go
+++ b/internal/log_analysis/log_processor/classification/classifier.go
@@ -20,11 +20,9 @@ package classification
 
 import (
 	"container/heap"
-	"runtime/debug"
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -77,27 +75,24 @@ func (c *Classifier) ParserStats() map[string]*ParserStats {
 }
 
 // catch panics from parsers, log and continue
-func safeLogParse(logType string, parser parsers.Interface, log string) (results []*parsers.Result) {
+func safeLogParse(logType string, parser parsers.Interface, log string) (results []*parsers.Result, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			err = errors.New("parser panic")
+			results = nil
 			zap.L().Debug("parser panic",
 				zap.String("parser", logType),
-				zap.Error(errors.Errorf("%v", r)),
-				zap.String("stacktrace", string(debug.Stack())))
-			results = nil // return indicator that parse failed
+				zap.Error(err))
 		}
 	}()
-	results, err := parser.ParseLog(log)
+	results, err = parser.ParseLog(log)
 	if err != nil {
 		zap.L().Debug("parser failed",
 			zap.String("parser", logType),
 			zap.Error(err))
-		return nil
+		return nil, err
 	}
-	if len(results) == 0 {
-		return nil
-	}
-	return results
+	return results, nil
 }
 
 // Classify attempts to classify the provided log line
@@ -137,11 +132,11 @@ func (c *Classifier) Classify(log string) *ClassifierResult {
 
 		startParseTime := time.Now().UTC()
 		logType := currentItem.logType
-		parsedEvents := safeLogParse(logType, currentItem.parser, log)
+		parsedEvents, err := safeLogParse(logType, currentItem.parser, log)
 		endParseTime := time.Now().UTC()
 
 		// Parser failed to parse event
-		if parsedEvents == nil {
+		if err != nil {
 			zap.L().Debug("failed to parse event", zap.String("expectedLogType", logType))
 			// Removing parser from queue
 			popped = append(popped, heap.Pop(c.parsers))
@@ -155,7 +150,7 @@ func (c *Classifier) Classify(log string) *ClassifierResult {
 		// Since the parsing was successful, remove all penalty from the parser
 		// The parser will be higher priority in the queue
 		currentItem.penalty = 0
-		result.LogType = aws.String(logType)
+		result.LogType = &logType
 		result.Events = parsedEvents
 
 		// update per-parser stats

--- a/internal/log_analysis/log_processor/classification/classifier_test.go
+++ b/internal/log_analysis/log_processor/classification/classifier_test.go
@@ -164,6 +164,41 @@ func TestClassifyParserPanic(t *testing.T) {
 	panicParser.AssertNumberOfCalls(t, "Parse", 1)
 }
 
+func TestClassifyParserReturningEmptyResults(t *testing.T) {
+	// uncomment to see the logs produced
+	/*
+		logger := zap.NewExample()
+		defer logger.Sync()
+		undo := zap.ReplaceGlobals(logger)
+		defer undo()
+	*/
+
+	parser := &testutil.MockParser{}
+	parser.On("Parse", mock.Anything).Return([]*parsers.Result{}, nil).Once()
+	classifier := NewClassifier(map[string]parsers.Interface{
+		"parser": parser,
+	})
+
+	logLine := "log of death"
+
+	expectedStats := &ClassifierStats{
+		BytesProcessedCount:         uint64(len(logLine)),
+		LogLineCount:                1,
+		EventCount:                  0,
+		SuccessfullyClassifiedCount: 1,
+		ClassificationFailureCount:  0,
+	}
+
+	result := classifier.Classify(logLine)
+
+	// skipping specifically validating the times
+	expectedStats.ClassifyTimeMicroseconds = classifier.Stats().ClassifyTimeMicroseconds
+	require.Equal(t, expectedStats, classifier.Stats())
+
+	require.Equal(t, &ClassifierResult{Events: []*parsers.Result{}, LogType: box.String("parser")}, result)
+	parser.AssertExpectations(t)
+}
+
 func TestClassifyNoLogline(t *testing.T) {
 	testSkipClassify("", t)
 }

--- a/internal/log_analysis/log_processor/classification/classifier_test.go
+++ b/internal/log_analysis/log_processor/classification/classifier_test.go
@@ -165,14 +165,6 @@ func TestClassifyParserPanic(t *testing.T) {
 }
 
 func TestClassifyParserReturningEmptyResults(t *testing.T) {
-	// uncomment to see the logs produced
-	/*
-		logger := zap.NewExample()
-		defer logger.Sync()
-		undo := zap.ReplaceGlobals(logger)
-		defer undo()
-	*/
-
 	parser := &testutil.MockParser{}
 	parser.On("Parse", mock.Anything).Return([]*parsers.Result{}, nil).Once()
 	classifier := NewClassifier(map[string]parsers.Interface{

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow.go
@@ -139,8 +139,8 @@ func (p *VPCFlowParser) Parse(log string) ([]*parsers.PantherLog, error) {
 		return nil, errors.New("log is not CSV")
 	}
 	if p.columnMap == nil { // must be first log line in file
-		if p.isVpcFlowHeader(log) { // if this is a header, return success but no events and setup p.columnMap
-			return []*parsers.PantherLog{}, nil
+		if p.inspectVpcFlowLogHeader(log) { // if this is a header, return success but no events and setup p.columnMap
+			return nil, nil
 		}
 		return nil, errors.New("invalid header")
 	}
@@ -166,7 +166,8 @@ func (p *VPCFlowParser) LogType() string {
 	return TypeVPCFlow
 }
 
-func (p *VPCFlowParser) isVpcFlowHeader(log string) bool {
+// Returns true if the file is a VPC FL header
+func (p *VPCFlowParser) inspectVpcFlowLogHeader(log string) bool {
 	headers := strings.Split(log, " ")
 	matchCount := 0
 	for _, header := range headers {

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow_test.go
@@ -145,8 +145,7 @@ func checkVPCFlowLog(t *testing.T, header, log string, expectedEvent *VPCFlow) {
 	expectedEvent.SetEvent(expectedEvent)
 	parser := (&VPCFlowParser{}).New() // important to call New() to initialize reader
 	noevents, noerr := parser.Parse(header)
-	require.Empty(t, noevents, "Header parsing should not return events")
-	require.NotNil(t, noevents, "Header parsing should return empty events")
+	require.Nil(t, noevents, "Header parsing should return nil events")
 	require.NoError(t, noerr, "Header parsing should not return an error")
 	events, err := parser.Parse(log)
 	testutil.EqualPantherLog(t, expectedEvent.Log(), events, err)

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/access.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/access.go
@@ -64,8 +64,8 @@ func (p *AccessParser) Parse(log string) ([]*parsers.PantherLog, error) {
 		// All subsequent lines describing event headers and body should be skipped without an error if we have managed
 		// to match at least one log line previously.
 		if p.rxMatchedOnce {
-			// Return empty result and no error
-			return []*parsers.PantherLog{}, nil
+			// Return nil result and no error
+			return nil, nil
 		}
 		// No lines were previously matched, the file is not a Juniper.Access log file.
 		return nil, errors.New("invalid log line")

--- a/internal/log_analysis/log_processor/parsers/testutil/testutil.go
+++ b/internal/log_analysis/log_processor/parsers/testutil/testutil.go
@@ -169,7 +169,6 @@ func CheckPantherMultiline(t *testing.T, logs string, parser parsers.LogParser, 
 
 		results, err := p.Parse(log)
 		require.NoError(t, err)
-		require.NotNil(t, results)
 		actual = append(actual, results...)
 	}
 	require.Equal(t, len(expect), len(actual))


### PR DESCRIPTION
## Background

Changed classifier so that it considers a parser invocation failed only if parser returned an error. 
If a parser returns no error and empty result, we consider the parsing successful (parser matched the event), just there was no output event. This can happen in case of e.g. CSV files when processing header lines. 

## Changes

- Modified classifier to treat empty result as an acceptable result. 
- After chat with @alxarch  Changed parsers to return `nil, nil` in cases where a log line is matched but no event is returned. Ι basically searched the parser package, it seems that the only parsers that had to deal with such a scenario where the VPC FL parsers and Juniper Access logs. 

## Testing

- unit tests
- Deployed and verified in my account (before this change we were getting warnings for VPC FL files)
