### PR TITLE
Changing API for sources-api to return null when a timestamp is not configured

### DIFF
--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -29,16 +29,16 @@ type SourceIntegration struct {
 
 // SourceIntegrationStatus provides information about the status of a source
 type SourceIntegrationStatus struct {
-	ScanStatus        string    `json:"scanStatus,omitempty"`
-	EventStatus       string    `json:"eventStatus,omitempty"`
-	LastEventReceived time.Time `json:"lastEventReceived,omitempty"`
+	ScanStatus        string     `json:"scanStatus,omitempty"`
+	EventStatus       string     `json:"eventStatus,omitempty"`
+	LastEventReceived *time.Time `json:"lastEventReceived,omitempty"`
 }
 
 // SourceIntegrationScanInformation is detail about the last snapshot.
 type SourceIntegrationScanInformation struct {
-	LastScanEndTime      time.Time `json:"lastScanEndTime,omitempty"`
-	LastScanErrorMessage string    `json:"lastScanErrorMessage,omitempty"`
-	LastScanStartTime    time.Time `json:"lastScanStartTime,omitempty"`
+	LastScanStartTime    *time.Time `json:"lastScanStartTime,omitempty"`
+	LastScanEndTime      *time.Time `json:"lastScanEndTime,omitempty"`
+	LastScanErrorMessage string     `json:"lastScanErrorMessage,omitempty"`
 }
 
 // SourceIntegrationMetadata is general settings and metadata for an integration.

--- a/internal/compliance/snapshot_scheduler/scheduler/schedule.go
+++ b/internal/compliance/snapshot_scheduler/scheduler/schedule.go
@@ -102,10 +102,10 @@ func scanIsNotOngoing(integration *models.SourceIntegration) bool {
 
 // scanIntervalElapsed determines if a new scan needs to be started based on the configured interval.
 func scanIntervalElapsed(integration *models.SourceIntegration) bool {
-	if integration.LastScanEndTime.IsZero() {
+	if integration.LastScanEndTime == nil {
 		return true
 	}
 
 	intervalMins := time.Duration(integration.ScanIntervalMins) * time.Minute
-	return time.Since(integration.LastScanEndTime) >= intervalMins
+	return time.Since(*integration.LastScanEndTime) >= intervalMins
 }

--- a/internal/compliance/snapshot_scheduler/scheduler/schedule_test.go
+++ b/internal/compliance/snapshot_scheduler/scheduler/schedule_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/pkg/box"
 )
 
 //
@@ -102,8 +103,8 @@ var (
 				ScanStatus: models.StatusOK,
 			},
 			SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-				LastScanEndTime:   time.Now().Add(time.Duration(-15) * time.Minute),
-				LastScanStartTime: time.Now().Add(time.Duration(-20) * time.Minute),
+				LastScanEndTime:   box.Time(time.Now().Add(time.Duration(-15) * time.Minute)),
+				LastScanStartTime: box.Time(time.Now().Add(time.Duration(-20) * time.Minute)),
 			},
 		},
 		{
@@ -117,8 +118,8 @@ var (
 				ScanStatus: models.StatusOK,
 			},
 			SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-				LastScanEndTime:   time.Now().Add(time.Duration(-35) * time.Minute),
-				LastScanStartTime: time.Now().Add(time.Duration(-40) * time.Minute),
+				LastScanEndTime:   box.Time(time.Now().Add(time.Duration(-35) * time.Minute)),
+				LastScanStartTime: box.Time(time.Now().Add(time.Duration(-40) * time.Minute)),
 			},
 		},
 		// A new integration that was recently added that has never been scanned.
@@ -142,7 +143,7 @@ var (
 				ScanStatus: models.StatusScanning,
 			},
 			SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-				LastScanStartTime: time.Now().Add(time.Duration(-20) * time.Minute),
+				LastScanStartTime: box.Time(time.Now().Add(time.Duration(-20) * time.Minute)),
 			},
 		},
 		// An integration with a scan in progress, stuck.
@@ -157,9 +158,9 @@ var (
 				ScanStatus: models.StatusScanning,
 			},
 			SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-				LastScanStartTime: time.Now().Add(time.Duration(-65) * time.Minute),
+				LastScanStartTime: box.Time(time.Now().Add(time.Duration(-65) * time.Minute)),
 				// Last time it scanned was a day ago.
-				LastScanEndTime: time.Now().Add(time.Duration(-24) * time.Hour),
+				LastScanEndTime: box.Time(time.Now().Add(time.Duration(-24) * time.Hour)),
 			},
 		},
 	}
@@ -206,7 +207,7 @@ func TestScanIntervalElapsed(t *testing.T) {
 			ScanIntervalMins: 30,
 		},
 		SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-			LastScanEndTime: time.Now().Add(time.Duration(-60) * time.Minute),
+			LastScanEndTime: box.Time(time.Now().Add(time.Duration(-60) * time.Minute)),
 		},
 	}))
 }
@@ -217,7 +218,7 @@ func TestNewScanNotNeeded(t *testing.T) {
 			ScanIntervalMins: 30,
 		},
 		SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-			LastScanEndTime: time.Now().Add(time.Duration(-15) * time.Minute),
+			LastScanEndTime: box.Time(time.Now().Add(time.Duration(-15) * time.Minute)),
 		},
 	}))
 }

--- a/internal/core/source_api/api/list_integrations_test.go
+++ b/internal/core/source_api/api/list_integrations_test.go
@@ -74,8 +74,8 @@ func TestListIntegrations(t *testing.T) {
 			EventStatus: models.StatusOK,
 		},
 		SourceIntegrationScanInformation: models.SourceIntegrationScanInformation{
-			LastScanEndTime:   lastScanEndTime,
-			LastScanStartTime: lastScanStartTime,
+			LastScanEndTime:   &lastScanEndTime,
+			LastScanStartTime: &lastScanStartTime,
 		},
 	}
 	out, err := apiTest.ListIntegrations(&models.ListIntegrationsInput{})

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -106,7 +106,7 @@ func (API) UpdateIntegrationLastScanStart(input *models.UpdateIntegrationLastSca
 		return err
 	}
 
-	existingIntegration.LastScanStartTime = input.LastScanStartTime
+	existingIntegration.LastScanStartTime = &input.LastScanStartTime
 	existingIntegration.ScanStatus = input.ScanStatus
 	err = dynamoClient.PutItem(existingIntegration)
 	if err != nil {
@@ -122,7 +122,7 @@ func (API) UpdateIntegrationLastScanEnd(input *models.UpdateIntegrationLastScanE
 		return err
 	}
 
-	existingIntegration.LastScanEndTime = input.LastScanEndTime
+	existingIntegration.LastScanEndTime = &input.LastScanEndTime
 	existingIntegration.LastScanErrorMessage = input.LastScanErrorMessage
 	existingIntegration.ScanStatus = input.ScanStatus
 	err = dynamoClient.PutItem(existingIntegration)

--- a/internal/core/source_api/api/update_status.go
+++ b/internal/core/source_api/api/update_status.go
@@ -33,7 +33,7 @@ var (
 // It updates the status of an integration
 func (api API) UpdateStatus(input *models.UpdateStatusInput) error {
 	status := ddb.IntegrationStatus{
-		LastEventReceived: input.LastEventReceived,
+		LastEventReceived: &input.LastEventReceived,
 	}
 	err := dynamoClient.UpdateStatus(input.IntegrationID, status)
 	if err != nil {

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -22,32 +22,32 @@ import "time"
 
 // Integration represents an integration item as it is stored in DynamoDB.
 type Integration struct {
-	CreatedAtTime    time.Time `json:"createdAtTime"`
-	CreatedBy        string    `json:"createdBy"`
-	IntegrationID    string    `json:"integrationId"`
-	IntegrationLabel string    `json:"integrationLabel"`
-	IntegrationType  string    `json:"integrationType"`
+	CreatedAtTime    time.Time `json:"createdAtTime,omitempty"`
+	CreatedBy        string    `json:"createdBy,omitempty"`
+	IntegrationID    string    `json:"integrationId,omitempty"`
+	IntegrationLabel string    `json:"integrationLabel,omitempty"`
+	IntegrationType  string    `json:"integrationType,omitempty"`
 
-	AWSAccountID       string `json:"awsAccountId"`
-	RemediationEnabled *bool  `json:"remediationEnabled"`
-	CWEEnabled         *bool  `json:"cweEnabled"`
+	AWSAccountID       string `json:"awsAccountId,omitempty"`
+	RemediationEnabled *bool  `json:"remediationEnabled,omitempty"`
+	CWEEnabled         *bool  `json:"cweEnabled,omitempty"`
 
-	LastScanStartTime    *time.Time `json:"lastScanStartTime"`
-	LastScanEndTime      *time.Time `json:"lastScanEndTime"`
-	LastScanErrorMessage string     `json:"lastScanErrorMessage"`
-	ScanIntervalMins     int        `json:"scanIntervalMins"`
+	LastScanStartTime    *time.Time `json:"lastScanStartTime,omitempty"`
+	LastScanEndTime      *time.Time `json:"lastScanEndTime,omitempty"`
+	LastScanErrorMessage string     `json:"lastScanErrorMessage,omitempty"`
+	ScanIntervalMins     int        `json:"scanIntervalMins,omitempty"`
 	IntegrationStatus
 
-	S3Bucket          string   `json:"s3Bucket"`
-	S3Prefix          string   `json:"s3Prefix"`
-	KmsKey            string   `json:"kmsKey"`
-	LogTypes          []string `json:"logTypes" dynamodbav:"logTypes,stringset"`
-	StackName         string   `json:"stackName"`
-	LogProcessingRole string   `json:"logProcessingRole"`
+	S3Bucket          string   `json:"s3Bucket,omitempty"`
+	S3Prefix          string   `json:"s3Prefix,omitempty"`
+	KmsKey            string   `json:"kmsKey,omitempty"`
+	LogTypes          []string `json:"logTypes,omitempty" dynamodbav:"logTypes,stringset"`
+	StackName         string   `json:"stackName,omitempty"`
+	LogProcessingRole string   `json:"logProcessingRole,omitempty"`
 }
 
 type IntegrationStatus struct {
-	ScanStatus        string     `json:"scanStatus"`
-	EventStatus       string     `json:"eventStatus"`
-	LastEventReceived *time.Time `json:"lastEventReceived"`
+	ScanStatus        string     `json:"scanStatus,omitempty"`
+	EventStatus       string     `json:"eventStatus,omitempty"`
+	LastEventReceived *time.Time `json:"lastEventReceived,omitempty"`
 }

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -32,10 +32,10 @@ type Integration struct {
 	RemediationEnabled *bool  `json:"remediationEnabled"`
 	CWEEnabled         *bool  `json:"cweEnabled"`
 
-	LastScanEndTime      time.Time `json:"lastScanEndTime"`
-	LastScanErrorMessage string    `json:"lastScanErrorMessage"`
-	LastScanStartTime    time.Time `json:"lastScanStartTime"`
-	ScanIntervalMins     int       `json:"scanIntervalMins"`
+	LastScanStartTime    *time.Time `json:"lastScanStartTime"`
+	LastScanEndTime      *time.Time `json:"lastScanEndTime"`
+	LastScanErrorMessage string     `json:"lastScanErrorMessage"`
+	ScanIntervalMins     int        `json:"scanIntervalMins"`
 	IntegrationStatus
 
 	S3Bucket          string   `json:"s3Bucket"`
@@ -47,7 +47,7 @@ type Integration struct {
 }
 
 type IntegrationStatus struct {
-	ScanStatus        string    `json:"scanStatus"`
-	EventStatus       string    `json:"eventStatus"`
-	LastEventReceived time.Time `json:"lastEventReceived"`
+	ScanStatus        string     `json:"scanStatus"`
+	EventStatus       string     `json:"eventStatus"`
+	LastEventReceived *time.Time `json:"lastEventReceived"`
 }


### PR DESCRIPTION
## Background

Changing API for sources-api to return null when a timestamp is not configured. Current API was returning `0001-01-01T00:00:00Z` when a timestamp was not configured (this is zero time for Golang's `time.Time`). 
However the above default value doesn't make sense for other languages, it is Go specific. 
Given that the APIs are also used by the frontend, it makes sense that optional `time.Time` fields are defined as pointers, so that they are omitted when they are serialized. 

## Changes

- Changed optional time fields from source-api to be `*time.Time`

## Testing

- `mage test:ci`
- Deployed and verified behavior. 
