### PR TITLE
Custom resource and IAM bug fixes

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -121,21 +121,28 @@ Resources:
           Statement:
             - Effect: Allow
               Action:
+                - acm:ImportCertificate
+                - athena:GetQuery*
+                - athena:StartQueryExecution
+                - athena:StopQueryExecution
+                - athena:UpdateWorkGroup
+                - guardduty:Create*
+                - guardduty:DeletePublishingDestination
+                - guardduty:Get*
+                - guardduty:List*
+                - guardduty:UpdatePublishingDestination
+                - kms:ListAliases # required for GuardDuty
+                - lambda:ListLayerVersions
+              Resource: '*'
+            - Effect: Allow
+              Action:
                 - acm:AddTagsToCertificate
                 - acm:DeleteCertificate
-                - acm:ImportCertificate
                 - acm:RemoveTagsFromCertificate
               # ACM certificate IDs are random and at the time of writing, DeleteCertificate does
               # not support using resource tags as a condition.
               # So this is as narrow as this resource can get:
               Resource: !Sub arn:${AWS::Partition}:acm:${AWS::Region}:${AWS::AccountId}:certificate/*
-            - Effect: Allow
-              Action:
-                - athena:UpdateWorkGroup
-                - athena:StartQueryExecution
-                - athena:StopQueryExecution
-                - athena:GetQuery*
-              Resource: '*'
             - Effect: Allow
               Action:
                 - cloudwatch:PutMetricAlarm
@@ -166,14 +173,6 @@ Resources:
                 - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/panther*
             - Effect: Allow
               Action:
-                - guardduty:Create*
-                - guardduty:Get*
-                - guardduty:List*
-                - guardduty:DeletePublishingDestination
-                - guardduty:UpdatePublishingDestination
-              Resource: '*'
-            - Effect: Allow
-              Action:
                 - iam:DeleteServerCertificate
                 - iam:UploadServerCertificate
               Resource:
@@ -185,18 +184,10 @@ Resources:
               Action: iam:PassRole
               Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/Panther*
             - Effect: Allow
-              Action: kms:ListAliases # required for GuardDuty
-              Resource: '*'
-            - Effect: Allow
-              Action:
-                - lambda:GetFunction
+              Action: lambda:GetFunction
               Resource:
                 - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-policy-engine
                 - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-rules-engine
-            - Effect: Allow
-              Action:
-                - lambda:ListLayerVersions
-              Resource: '*'
             - Effect: Allow
               Action: lambda:InvokeFunction
               Resource:
@@ -207,9 +198,6 @@ Resources:
             - Effect: Allow
               Action: lambda:DeleteLayerVersion
               Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:panther-engine-globals:*
-            - Effect: Allow
-              Action: lambda:ListLayerVersions
-              Resource: '*'
             - Effect: Allow
               Action:
                 - logs:DeleteMetricFilter

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -168,12 +168,9 @@ Resources:
               Action:
                 - cognito-idp:AdminCreateUser
                 - cognito-idp:AdminDeleteUser
-                - cognito-idp:AdminDisableUser
-                - cognito-idp:AdminEnableUser
                 - cognito-idp:AdminGetUser
                 - cognito-idp:AdminResetUserPassword
                 - cognito-idp:AdminUpdateUserAttributes
-                - cognito-idp:GetUser
                 - cognito-idp:ListUsers
               Resource: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}
 

--- a/internal/core/custom_resources/resources/alarms_elb.go
+++ b/internal/core/custom_resources/resources/alarms_elb.go
@@ -63,8 +63,10 @@ func customElbAlarms(_ context.Context, event cfn.Event) (string, map[string]int
 		}
 
 		// Migration: In v1.5.0, the client error alarms were removed
-		if err := deleteMetricAlarms(event.PhysicalResourceID, elbTargetClientErrorAlarm, elbClientErrorAlarm); err != nil {
-			zap.L().Error("failed to remove deprecated alarm", zap.Error(err))
+		if event.RequestType == cfn.RequestUpdate {
+			if err := deleteMetricAlarms(event.PhysicalResourceID, elbTargetClientErrorAlarm, elbClientErrorAlarm); err != nil {
+				zap.L().Error("failed to remove deprecated alarm", zap.Error(err))
+			}
 		}
 
 		return physicalID, nil, nil


### PR DESCRIPTION
## Background

Backporting some bug fixes and refactoring from https://github.com/panther-labs/panther-enterprise/pull/305

## Changes

- acm:ImportCertificate apparently requires '*' as the IAM resource permission when importing from a file - the custom-resources Lambda was logging a "not authorized" warning and falling back to IAM
- the elb alarm removal intended as a migration triggers on every create as well as every update, which meant that a fresh deployment was logging a warning trying to delete an "invalid physical ID". Fixed to only run on updates
- Removed unnecessary IAM permissions from `users-api` and consolidated IAM permissions for `custom-resources`
- Slightly restructured Cognito trigger handling to match enterprise code

## Testing

- `mage test:ci`
