### PR TITLE
Rebuild global layer when modified from web UI

### DIFF
--- a/internal/core/analysis_api/handlers/bulk_upload.go
+++ b/internal/core/analysis_api/handlers/bulk_upload.go
@@ -137,7 +137,7 @@ func BulkUpload(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyR
 
 	// If at least one global was created or modified, rebuild the global layer
 	if aws.Int64Value(counts.TotalGlobals) > 0 {
-		err = updateLayer(typeGlobal)
+		err = updateLayer()
 		if err != nil {
 			return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 		}

--- a/internal/core/analysis_api/handlers/create_global.go
+++ b/internal/core/analysis_api/handlers/create_global.go
@@ -51,7 +51,7 @@ func CreateGlobal(request *events.APIGatewayProxyRequest) *events.APIGatewayProx
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 
-	if err = updateLayer(typeGlobal); err != nil {
+	if err = updateLayer(); err != nil {
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 

--- a/internal/core/analysis_api/handlers/delete_global.go
+++ b/internal/core/analysis_api/handlers/delete_global.go
@@ -46,7 +46,7 @@ func DeleteGlobal(request *events.APIGatewayProxyRequest) *events.APIGatewayProx
 	if err = dynamoBatchDelete(input); err != nil {
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
-	if err = updateLayer(typeGlobal); err != nil {
+	if err = updateLayer(); err != nil {
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 	if err = s3BatchDelete(input); err != nil {

--- a/internal/core/analysis_api/handlers/modify_global.go
+++ b/internal/core/analysis_api/handlers/modify_global.go
@@ -51,7 +51,7 @@ func ModifyGlobal(request *events.APIGatewayProxyRequest) *events.APIGatewayProx
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 
-	if err = updateLayer(typeGlobal); err != nil {
+	if err = updateLayer(); err != nil {
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 

--- a/internal/core/analysis_api/handlers/modify_global.go
+++ b/internal/core/analysis_api/handlers/modify_global.go
@@ -51,5 +51,9 @@ func ModifyGlobal(request *events.APIGatewayProxyRequest) *events.APIGatewayProx
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 
+	if err = updateLayer(typeGlobal); err != nil {
+		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
+	}
+
 	return gatewayapi.MarshalResponse(item.Global(), http.StatusOK)
 }

--- a/internal/core/analysis_api/handlers/sqs.go
+++ b/internal/core/analysis_api/handlers/sqs.go
@@ -48,7 +48,7 @@ func queuePolicy(policy *tableItem) error {
 //
 // Currently only the global type is supported, but in the future we may support other types as
 // well.
-func updateLayer(_ string) error {
+func updateLayer() error {
 	_, err := sqsClient.SendMessage(&sqs.SendMessageInput{
 		MessageBody: aws.String(typeGlobal),
 		QueueUrl:    aws.String(env.LayerManagerQueueURL),

--- a/internal/core/analysis_api/handlers/sqs.go
+++ b/internal/core/analysis_api/handlers/sqs.go
@@ -43,10 +43,14 @@ func queuePolicy(policy *tableItem) error {
 	return err
 }
 
-// updateLayer sends a message to the layer manager lambda indicating a layer of a certain type needs to be re-built
-func updateLayer(analysisType string) error {
+// updateLayer sends a message to the layer manager lambda indicating a layer of a certain type
+// needs to be re-built
+//
+// Currently only the global type is supported, but in the future we may support other types as
+// well.
+func updateLayer(_ string) error {
 	_, err := sqsClient.SendMessage(&sqs.SendMessageInput{
-		MessageBody: aws.String(analysisType),
+		MessageBody: aws.String(typeGlobal),
 		QueueUrl:    aws.String(env.LayerManagerQueueURL),
 	})
 	return err


### PR DESCRIPTION
## Background

When we added support for multiple globals we moved the `rebuild global layer` API call out of the `WriteItem` helper that all the analysis-api endpoints rely on to write to dynamo and into the API endpoints directly. But we forgot to do this for the `ModifyGlobal` endpoint. This meant that the global layer was only rebuilt when new globals were created, globals were deleted, or a global was uploaded via the bulk upload endpoint. Modifying a single global (e.g. via the web UI) did not actually rebuild the global layer. This fixes that.

## Changes

- Rebuild the global layer after a global is modified via the web UI

## Testing

- Deploying into dev account now to verify
