### PR TITLE
Prevent persistence after user deletion

### DIFF
--- a/api/lambda/users/models/api.go
+++ b/api/lambda/users/models/api.go
@@ -67,6 +67,9 @@ type GetUserOutput = User
 
 // InviteUserInput creates a new user with minimal permissions and sends them an invite.
 type InviteUserInput struct {
+	// Which Panther user is making this request?
+	RequesterID *string `json:"requesterId" validate:"required,uuid4"`
+
 	GivenName  *string `json:"givenName" validate:"required,min=1,excludesall='<>&\""`
 	FamilyName *string `json:"familyName" validate:"required,min=1,excludesall='<>&\""`
 	Email      *string `json:"email" validate:"required,email"`
@@ -115,13 +118,16 @@ type ListUsersInput struct {
 //    ]
 // }
 type ListUsersOutput struct {
-	Users []*User `json:"users"`
+	Users []User `json:"users"`
 }
 
 // RemoveUserInput deletes a user.
 //
 // This will fail if the user is the only one with UserModify permissions.
 type RemoveUserInput struct {
+	// Which Panther user is making this request?
+	RequesterID *string `json:"requesterId" validate:"required,uuid4"`
+
 	ID *string `json:"id" validate:"required,uuid4"`
 }
 
@@ -132,6 +138,9 @@ type RemoveUserOutput struct {
 
 // ResetUserPasswordInput resets the password for a user.
 type ResetUserPasswordInput struct {
+	// Which Panther user is making this request?
+	RequesterID *string `json:"requesterId" validate:"required,uuid4"`
+
 	ID *string `json:"id" validate:"required,uuid4"`
 }
 
@@ -142,6 +151,9 @@ type ResetUserPasswordOutput struct {
 
 // UpdateUserInput updates user details.
 type UpdateUserInput struct {
+	// Which Panther user is making this request?
+	RequesterID *string `json:"requesterId" validate:"required,uuid4"`
+
 	ID *string `json:"id" validate:"required,uuid4"`
 
 	// At least one of the following must be specified:

--- a/api/lambda/users/models/validator_test.go
+++ b/api/lambda/users/models/validator_test.go
@@ -40,15 +40,17 @@ func TestUpdateUserBlankField(t *testing.T) {
 
 func TestUpdateUserOneField(t *testing.T) {
 	assert.NoError(t, Validator().Struct(&UpdateUserInput{
-		ID:        mockID,
-		GivenName: aws.String("panther"),
+		RequesterID: mockID,
+		ID:          mockID,
+		GivenName:   aws.String("panther"),
 	}))
 }
 
 func TestUpdateUserAllFields(t *testing.T) {
 	assert.NoError(t, Validator().Struct(&UpdateUserInput{
-		ID:         mockID,
-		GivenName:  aws.String("given-name"),
-		FamilyName: aws.String("family-name"),
+		RequesterID: mockID,
+		ID:          mockID,
+		GivenName:   aws.String("given-name"),
+		FamilyName:  aws.String("family-name"),
 	}))
 }

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -200,6 +200,7 @@ Resources:
           "operation": "Invoke",
           "payload": $util.toJson({
             "resetUserPassword": {
+              "requesterId": $ctx.identity.sub,
               "id": $ctx.args.id
             }
           })
@@ -219,6 +220,8 @@ Resources:
       FieldName: updateUser
       DataSourceName: !GetAtt UsersAPILambdaDataSource.Name
       RequestMappingTemplate: |
+        #set ($input = $ctx.args.input)
+        $util.qr($input.put("requesterId", $ctx.identity.sub))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",
@@ -246,6 +249,7 @@ Resources:
           "operation": "Invoke",
           "payload": $util.toJson({
             "removeUser": {
+              "requesterId": $ctx.identity.sub,
               "id": $ctx.args.id
             }
           })
@@ -288,6 +292,7 @@ Resources:
       DataSourceName: !GetAtt UsersAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
+        $util.qr($input.put("requesterId", $ctx.identity.sub))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -171,6 +171,7 @@ Resources:
                 - cognito-idp:AdminGetUser
                 - cognito-idp:AdminResetUserPassword
                 - cognito-idp:AdminUpdateUserAttributes
+                - cognito-idp:AdminUserGlobalSignOut
                 - cognito-idp:ListUsers
               Resource: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}
 

--- a/internal/core/custom_resources/resources/panther_user.go
+++ b/internal/core/custom_resources/resources/panther_user.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-lambda-go/cfn"
+	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
@@ -78,9 +79,10 @@ func customPantherUser(_ context.Context, event cfn.Event) (string, map[string]i
 func inviteUser(props PantherUserProperties) (string, error) {
 	input := models.LambdaInput{
 		InviteUser: &models.InviteUserInput{
-			GivenName:  &props.GivenName,
-			FamilyName: &props.FamilyName,
-			Email:      &props.Email,
+			RequesterID: aws.String(systemUserID),
+			GivenName:   &props.GivenName,
+			FamilyName:  &props.FamilyName,
+			Email:       &props.Email,
 		},
 	}
 	var output models.InviteUserOutput
@@ -95,10 +97,11 @@ func inviteUser(props PantherUserProperties) (string, error) {
 func updateUser(userID string, props PantherUserProperties) error {
 	input := models.LambdaInput{
 		UpdateUser: &models.UpdateUserInput{
-			ID:         &userID,
-			GivenName:  &props.GivenName,
-			FamilyName: &props.FamilyName,
-			Email:      &props.Email,
+			RequesterID: aws.String(systemUserID),
+			ID:          &userID,
+			GivenName:   &props.GivenName,
+			FamilyName:  &props.FamilyName,
+			Email:       &props.Email,
 		},
 	}
 	return genericapi.Invoke(lambdaClient, "panther-users-api", &input, nil)
@@ -106,7 +109,10 @@ func updateUser(userID string, props PantherUserProperties) error {
 
 func deleteUser(userID string) error {
 	input := models.LambdaInput{
-		RemoveUser: &models.RemoveUserInput{ID: &userID},
+		RemoveUser: &models.RemoveUserInput{
+			RequesterID: aws.String(systemUserID),
+			ID:          &userID,
+		},
 	}
 	return genericapi.Invoke(lambdaClient, "panther-users-api", &input, nil)
 }

--- a/internal/core/users_api/api/api.go
+++ b/internal/core/users_api/api/api.go
@@ -31,6 +31,9 @@ import (
 // The API has receiver methods for each of the handlers.
 type API struct{}
 
+// RequesterID when the backend is requesting users-api operations, e.g. first deployment.
+const systemUserID = "00000000-0000-4000-8000-000000000000"
+
 var (
 	awsSession               = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(10)))
 	appDomainURL             = os.Getenv("APP_DOMAIN_URL")

--- a/internal/core/users_api/api/invite_user_test.go
+++ b/internal/core/users_api/api/invite_user_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 var inviteInput = &models.InviteUserInput{
-	GivenName:  aws.String("Joe"),
-	Email:      aws.String("joe.blow@panther.io"),
-	FamilyName: aws.String("Blow"),
+	RequesterID: aws.String(systemUserID),
+	GivenName:   aws.String("Joe"),
+	Email:       aws.String("joe.blow@panther.io"),
+	FamilyName:  aws.String("Blow"),
 }
 var userID = aws.String("1234-5678-9012")
 

--- a/internal/core/users_api/api/list_users_test.go
+++ b/internal/core/users_api/api/list_users_test.go
@@ -34,7 +34,7 @@ func TestListUsersGatewayErr(t *testing.T) {
 	mockGateway := &cognito.MockUserGateway{}
 	userGateway = mockGateway
 	mockGateway.On("ListUsers", &models.ListUsersInput{}).Return(
-		([]*models.User)(nil), &genericapi.AWSError{})
+		([]models.User)(nil), &genericapi.AWSError{})
 
 	result, err := (API{}).ListUsers(&models.ListUsersInput{})
 	assert.Nil(t, result)
@@ -45,7 +45,7 @@ func TestListUsersGatewayErr(t *testing.T) {
 func TestListUsers(t *testing.T) {
 	mockGateway := &cognito.MockUserGateway{}
 	userGateway = mockGateway
-	users := []*models.User{{ID: aws.String("test-user-id")}}
+	users := []models.User{{ID: aws.String("test-user-id")}}
 	mockGateway.On("ListUsers", &models.ListUsersInput{}).Return(users, nil)
 
 	result, err := (API{}).ListUsers(&models.ListUsersInput{})

--- a/internal/core/users_api/api/remove_user.go
+++ b/internal/core/users_api/api/remove_user.go
@@ -25,6 +25,10 @@ import (
 
 // RemoveUser deletes a user from cognito.
 func (API) RemoveUser(input *models.RemoveUserInput) (*models.RemoveUserOutput, error) {
+	if err := validateRequester(input.RequesterID); err != nil {
+		return nil, err
+	}
+
 	users, err := userGateway.ListUsers(&models.ListUsersInput{})
 	if err != nil {
 		return nil, err

--- a/internal/core/users_api/api/remove_user_test.go
+++ b/internal/core/users_api/api/remove_user_test.go
@@ -36,7 +36,7 @@ func TestRemoveUser(t *testing.T) {
 	mockGateway := &cognito.MockUserGateway{}
 	userGateway = mockGateway
 	mockGateway.On("ListUsers", &models.ListUsersInput{}).Return(
-		[]*models.User{
+		[]models.User{
 			{ID: userID},
 			{ID: otherUserID},
 		},
@@ -45,7 +45,10 @@ func TestRemoveUser(t *testing.T) {
 
 	mockGateway.On("DeleteUser", userID).Return(nil)
 
-	result, err := API{}.RemoveUser(&models.RemoveUserInput{ID: userID})
+	result, err := API{}.RemoveUser(&models.RemoveUserInput{
+		RequesterID: aws.String(systemUserID),
+		ID:          userID,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, &models.RemoveUserOutput{ID: userID}, result)
 	mockGateway.AssertExpectations(t)

--- a/internal/core/users_api/api/reset_user_password.go
+++ b/internal/core/users_api/api/reset_user_password.go
@@ -24,6 +24,10 @@ import (
 
 // ResetUserPassword resets a user password.
 func (API) ResetUserPassword(input *models.ResetUserPasswordInput) (*models.ResetUserPasswordOutput, error) {
+	if err := validateRequester(input.RequesterID); err != nil {
+		return nil, err
+	}
+
 	// Resetting a password will cause cognito to trigger the custom email message, which
 	// will invoke this same Lambda function (cognito_trigger.go).
 	if err := userGateway.ResetUserPassword(input.ID); err != nil {

--- a/internal/core/users_api/api/reset_user_password_test.go
+++ b/internal/core/users_api/api/reset_user_password_test.go
@@ -36,7 +36,10 @@ func TestResetUserPasswordGatewayErr(t *testing.T) {
 	userID := aws.String("test-id")
 	mockGateway.On("ResetUserPassword", userID).Return(&genericapi.AWSError{})
 
-	result, err := (API{}).ResetUserPassword(&models.ResetUserPasswordInput{ID: userID})
+	result, err := (API{}).ResetUserPassword(&models.ResetUserPasswordInput{
+		RequesterID: aws.String(systemUserID),
+		ID:          userID,
+	})
 	assert.Nil(t, result)
 	assert.Error(t, err)
 	mockGateway.AssertExpectations(t)
@@ -47,7 +50,10 @@ func TestResetUserPassword(t *testing.T) {
 	userGateway = mockGateway
 	mockGateway.On("ResetUserPassword", userID).Return(nil)
 
-	result, err := (API{}).ResetUserPassword(&models.ResetUserPasswordInput{ID: userID})
+	result, err := (API{}).ResetUserPassword(&models.ResetUserPasswordInput{
+		RequesterID: aws.String(systemUserID),
+		ID:          userID,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, &models.ResetUserPasswordOutput{ID: userID}, result)
 	mockGateway.AssertExpectations(t)

--- a/internal/core/users_api/api/update_user.go
+++ b/internal/core/users_api/api/update_user.go
@@ -24,6 +24,10 @@ import (
 
 // UpdateUser modifies user attributes.
 func (API) UpdateUser(input *models.UpdateUserInput) (*models.UpdateUserOutput, error) {
+	if err := validateRequester(input.RequesterID); err != nil {
+		return nil, err
+	}
+
 	if err := userGateway.UpdateUser(input); err != nil {
 		return nil, err
 	}

--- a/internal/core/users_api/api/update_user_test.go
+++ b/internal/core/users_api/api/update_user_test.go
@@ -32,7 +32,10 @@ import (
 func TestUpdateUser(t *testing.T) {
 	mockGateway := &cognito.MockUserGateway{}
 	userGateway = mockGateway
-	input := &models.UpdateUserInput{ID: aws.String("user-id")}
+	input := &models.UpdateUserInput{
+		RequesterID: aws.String(systemUserID),
+		ID:          aws.String("user-id"),
+	}
 	mockGateway.On("UpdateUser", input).Return(nil)
 	mockGateway.On("GetUser", input.ID).Return(
 		&models.User{ID: aws.String("user-id")}, nil)

--- a/internal/core/users_api/cognito/delete_user_test.go
+++ b/internal/core/users_api/cognito/delete_user_test.go
@@ -30,6 +30,12 @@ func TestDeleteUser(t *testing.T) {
 	mockCognitoClient := &mockCognitoClient{}
 	gw := &UsersGateway{userPoolClient: mockCognitoClient}
 
+	mockCognitoClient.On("AdminUserGlobalSignOut",
+		&provider.AdminUserGlobalSignOutInput{
+			Username:   mockUserID,
+			UserPoolId: gw.userPoolID,
+		},
+	).Return((*provider.AdminUserGlobalSignOutOutput)(nil), nil)
 	mockCognitoClient.On(
 		"AdminDeleteUser",
 		&provider.AdminDeleteUserInput{
@@ -46,6 +52,12 @@ func TestDeleteUserFailed(t *testing.T) {
 	mockCognitoClient := &mockCognitoClient{}
 	gw := &UsersGateway{userPoolClient: mockCognitoClient}
 
+	mockCognitoClient.On("AdminUserGlobalSignOut",
+		&provider.AdminUserGlobalSignOutInput{
+			Username:   mockUserID,
+			UserPoolId: gw.userPoolID,
+		},
+	).Return((*provider.AdminUserGlobalSignOutOutput)(nil), nil)
 	mockCognitoClient.On(
 		"AdminDeleteUser",
 		&provider.AdminDeleteUserInput{

--- a/internal/core/users_api/cognito/list_users.go
+++ b/internal/core/users_api/cognito/list_users.go
@@ -30,9 +30,9 @@ import (
 )
 
 // ListUsers calls cognito api to list users that belongs to a user pool
-func (g *UsersGateway) ListUsers(input *models.ListUsersInput) ([]*models.User, error) {
+func (g *UsersGateway) ListUsers(input *models.ListUsersInput) ([]models.User, error) {
 	cognitoInput := &provider.ListUsersInput{UserPoolId: g.userPoolID}
-	var result []*models.User
+	var result []models.User
 
 	// There will almost always be 1 page of users and there is no paging for this in the frontend.
 	// In the very unlikely event there is more than 1 page, we loop over all pages here.
@@ -52,7 +52,7 @@ func (g *UsersGateway) ListUsers(input *models.ListUsersInput) ([]*models.User, 
 				}
 			}
 
-			result = append(result, user)
+			result = append(result, *user)
 		}
 		return true
 	})

--- a/internal/core/users_api/cognito/list_users_test.go
+++ b/internal/core/users_api/cognito/list_users_test.go
@@ -55,7 +55,7 @@ func TestListUsers(t *testing.T) {
 	result, err := gw.ListUsers(&models.ListUsersInput{})
 	require.NoError(t, err)
 
-	expected := []*models.User{
+	expected := []models.User{
 		{
 			CreatedAt:  aws.Int64(now.Unix()),
 			Email:      aws.String("joe.blow@example.com"),

--- a/internal/core/users_api/cognito/mock_cognito_client.go
+++ b/internal/core/users_api/cognito/mock_cognito_client.go
@@ -50,6 +50,14 @@ func (m *mockCognitoClient) AdminResetUserPassword(
 	args := m.Called(input)
 	return args.Get(0).(*provider.AdminResetUserPasswordOutput), args.Error(1)
 }
+
+func (m *mockCognitoClient) AdminUserGlobalSignOut(
+	input *provider.AdminUserGlobalSignOutInput) (*provider.AdminUserGlobalSignOutOutput, error) {
+
+	args := m.Called(input)
+	return args.Get(0).(*provider.AdminUserGlobalSignOutOutput), args.Error(1)
+}
+
 func (m *mockCognitoClient) AdminUpdateUserAttributes(
 	input *provider.AdminUpdateUserAttributesInput) (*provider.AdminUpdateUserAttributesOutput, error) {
 

--- a/internal/core/users_api/cognito/mock_gateway.go
+++ b/internal/core/users_api/cognito/mock_gateway.go
@@ -53,9 +53,9 @@ func (m *MockUserGateway) GetUser(id *string) (*models.User, error) {
 }
 
 // ListUsers mocks ListUsers for testing
-func (m *MockUserGateway) ListUsers(input *models.ListUsersInput) ([]*models.User, error) {
+func (m *MockUserGateway) ListUsers(input *models.ListUsersInput) ([]models.User, error) {
 	args := m.Called(input)
-	return args.Get(0).([]*models.User), args.Error(1)
+	return args.Get(0).([]models.User), args.Error(1)
 }
 
 // ResetUserPassword mocks ResetUserPassword for testing

--- a/internal/core/users_api/cognito/users_gateway.go
+++ b/internal/core/users_api/cognito/users_gateway.go
@@ -32,7 +32,7 @@ type API interface {
 	CreateUser(*models.InviteUserInput) (*models.User, error)
 	DeleteUser(*string) error
 	GetUser(*string) (*models.User, error)
-	ListUsers(*models.ListUsersInput) ([]*models.User, error)
+	ListUsers(*models.ListUsersInput) ([]models.User, error)
 	ResetUserPassword(*string) error
 	UpdateUser(*models.UpdateUserInput) error
 }


### PR DESCRIPTION
## Background

When a Panther user is deleted, we remove them from the Cognito pool immediately, but their access token is still valid for up to 1 hour. That is a common limitation in many auth systems, Cognito included - we don't have any way to invalidate that token nor is the expiration configurable.

But we can take some steps to limit the damage a deleted account can do. In particular, today it is possible for a deleted account to continue to create new user accounts every hour to maintain indefinite access to the system. To prevent that, all user management write operations now require proof of the requester identity, which is validated against the Cognito pool.

We will address this more fundamentally in the next quarter with some kind of unified API where a single point of entry can handle extra validation of this kind for *all* requests, not just extra-sensitive ones like user management.

## Changes

- Invoke `AdminGlobalSignOutUser` before deleting a user - this will invalidate their *refresh* token
- All `users-api` modify operations (Invite, Delete, Update, ResetPassword) now require a `requesterId`. This ID is set by AppSync from the login token, so it cannot be spoofed from the user's browser. The `users-api` verifies the requester is still a valid account in Cognito before continuing.

## Testing

- Fresh deploy
- New integration test to ensure `InviteUser` fails if the requester no longer exists in Cognito
- Tested user invite/update/delete/passwordReset from the Panther web app
- Using a deleted user session, tried to invite another user:

![Screen Shot 2020-07-02 at 1 32 32 PM](https://user-images.githubusercontent.com/3608925/86407684-582b2800-bc6a-11ea-97a7-e43539050cc7.png)

