### PR TITLE
Remove policy test resourcetype fields

### DIFF
--- a/api/gateway/analysis/api.yml
+++ b/api/gateway/analysis/api.yml
@@ -175,7 +175,6 @@ paths:
     #             "resource": {
     #                 "hello": "world"
     #             },
-    #             "type": "AWS.S3.Bucket"
     #         }
     #     ],
     #     "versionId": "TsKejJ6GGi_KdH65g2iu9bcww8JxkkwI"
@@ -876,13 +875,10 @@ definitions:
         $ref: '#/definitions/testName'
       resource:
         $ref: '#/definitions/testResource'
-      resourceType:
-        $ref: '#/definitions/testResourceType'
     required:
       - expectedResult
       - name
       - resource
-      - resourceType
 
   TestSuite:
     type: array
@@ -1521,11 +1517,6 @@ definitions:
 
   testName:
     description: The name of a unit test
-    type: string
-    minLength: 1
-
-  testResourceType:
-    description: The resource or log type of an individual unit test
     type: string
     minLength: 1
 

--- a/api/gateway/analysis/engine.go
+++ b/api/gateway/analysis/engine.go
@@ -76,7 +76,6 @@ type Rule struct {
 type Event struct {
 	Data interface{} `json:"data"`
 	ID   string      `json:"id"`
-	Type string      `json:"type"`
 }
 
 // RulesEngineOutput is the response returned when invoking in log analysis mode.

--- a/api/gateway/analysis/models/unit_test_swagger.go
+++ b/api/gateway/analysis/models/unit_test_swagger.go
@@ -45,10 +45,6 @@ type UnitTest struct {
 	// resource
 	// Required: true
 	Resource TestResource `json:"resource"`
-
-	// resource type
-	// Required: true
-	ResourceType TestResourceType `json:"resourceType"`
 }
 
 // Validate validates this unit test
@@ -64,10 +60,6 @@ func (m *UnitTest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateResource(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateResourceType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -106,18 +98,6 @@ func (m *UnitTest) validateResource(formats strfmt.Registry) error {
 	if err := m.Resource.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("resource")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *UnitTest) validateResourceType(formats strfmt.Registry) error {
-
-	if err := m.ResourceType.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("resourceType")
 		}
 		return err
 	}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -752,14 +752,12 @@ type PolicyUnitTest {
   expectedResult: Boolean
   name: String
   resource: String # The `attributes` field of the Resource in stringified JSON format
-  resourceType: String # The `resourceType` of the unit test
 }
 
 input PolicyUnitTestInput {
   expectedResult: Boolean
   name: String
   resource: String # The `attributes` field of the Resource in stringified JSON format
-  resourceType: String # The `resourceType` of the unit test
 }
 
 input UpdateUserInput {

--- a/internal/core/analysis_api/handlers/bulk_upload.go
+++ b/internal/core/analysis_api/handlers/bulk_upload.go
@@ -310,7 +310,6 @@ func buildRuleTest(test analysis.Test) (*models.UnitTest, error) {
 		ExpectedResult: models.TestExpectedResult(test.ExpectedResult),
 		Name:           models.TestName(test.Name),
 		Resource:       models.TestResource(log),
-		ResourceType:   models.TestResourceType(test.LogType),
 	}, nil
 }
 
@@ -324,7 +323,6 @@ func buildPolicyTest(test analysis.Test) (*models.UnitTest, error) {
 		ExpectedResult: models.TestExpectedResult(test.ExpectedResult),
 		Name:           models.TestName(test.Name),
 		Resource:       models.TestResource(resource),
-		ResourceType:   models.TestResourceType(test.ResourceType),
 	}, nil
 }
 

--- a/internal/core/analysis_api/handlers/test_policy.go
+++ b/internal/core/analysis_api/handlers/test_policy.go
@@ -140,7 +140,7 @@ func getRuleResults(input *models.TestPolicy) (*enginemodels.RulesEngineOutput, 
 		inputEvents[i] = enginemodels.Event{
 			Data: attrs,
 			ID:   testResourceID + strconv.Itoa(i),
-			Type: input.ResourceTypes[0],
+			Type: input.ResourceTypes[0], // TODO(giorgosp): Seems not used by the rules engine
 		}
 	}
 
@@ -193,7 +193,9 @@ func getPolicyResults(input *models.TestPolicy) (*enginemodels.PolicyEngineOutpu
 		resources[i] = enginemodels.Resource{
 			Attributes: attrs,
 			ID:         testResourceID + strconv.Itoa(i),
-			Type:       input.ResourceTypes[0],
+			// The engine picks a policy to run based on the input resource type. To make the engine run the
+			// input policy, we just pass one of its resource types in the input resource.
+			Type: input.ResourceTypes[0],
 		}
 	}
 

--- a/internal/core/analysis_api/handlers/test_policy.go
+++ b/internal/core/analysis_api/handlers/test_policy.go
@@ -140,7 +140,6 @@ func getRuleResults(input *models.TestPolicy) (*enginemodels.RulesEngineOutput, 
 		inputEvents[i] = enginemodels.Event{
 			Data: attrs,
 			ID:   testResourceID + strconv.Itoa(i),
-			Type: input.ResourceTypes[0], // TODO(giorgosp): Seems not used by the rules engine
 		}
 	}
 

--- a/internal/core/analysis_api/handlers/test_policy.go
+++ b/internal/core/analysis_api/handlers/test_policy.go
@@ -193,9 +193,7 @@ func getPolicyResults(input *models.TestPolicy) (*enginemodels.PolicyEngineOutpu
 		resources[i] = enginemodels.Resource{
 			Attributes: attrs,
 			ID:         testResourceID + strconv.Itoa(i),
-			// The engine picks a policy to run based on the input resource type. To make the engine run the
-			// input policy, we just pass one of its resource types in the input resource.
-			Type: input.ResourceTypes[0],
+			Type:       policyTestType(input),
 		}
 	}
 
@@ -245,4 +243,16 @@ func parseTestPolicy(request *events.APIGatewayProxyRequest) (*models.TestPolicy
 	}
 
 	return &result, nil
+}
+
+// policyTestType returns the resource type to use as the input to the policy engine.
+// The engine picks the policy to run based on the input resource type. To make the engine run the
+// input policy, we just pass one of its resource types in the input resource.
+// If the policy is applicable for all resource types, a placeholder value is returned since the engine will
+// run it for any resource type input.
+func policyTestType(input *models.TestPolicy) string {
+	if len(input.ResourceTypes) > 0 {
+		return input.ResourceTypes[0]
+	}
+	return "__ALL__"
 }

--- a/internal/core/analysis_api/handlers/util.go
+++ b/internal/core/analysis_api/handlers/util.go
@@ -286,7 +286,7 @@ func itemUpdated(oldItem, newItem *tableItem) bool {
 	for _, newTest := range newItem.Tests {
 		oldTest, ok := oldTests[newTest.Name]
 		// First check if the meta data of the test is equal
-		if !ok || oldTest.ResourceType != newTest.ResourceType || oldTest.ExpectedResult != newTest.ExpectedResult {
+		if !ok || oldTest.ExpectedResult != newTest.ExpectedResult {
 			// Something changed, so this item has been updated
 			return true
 		}

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -77,13 +77,11 @@ var (
 		Tests: []*models.UnitTest{
 			{
 				Name:           "This will be True",
-				ResourceType:   "AWS.S3.Bucket",
 				ExpectedResult: true,
 				Resource:       `{}`,
 			},
 			{
 				Name:           "This will also be True",
-				ResourceType:   "AWS.S3.Bucket",
 				ExpectedResult: true,
 				Resource:       `{"nested": {}}`,
 			},
@@ -110,7 +108,6 @@ var (
 		Tests: []*models.UnitTest{
 			{
 				Name:           "Log File Validation Disabled",
-				ResourceType:   "AWS.CloudTrail",
 				ExpectedResult: false,
 				Resource: `{
         "Info": {
@@ -132,7 +129,6 @@ var (
 			},
 			{
 				Name:           "Log File Validation Enabled",
-				ResourceType:   "AWS.CloudTrail",
 				ExpectedResult: true,
 				Resource: `{
         "Info": {
@@ -189,7 +185,6 @@ var (
 		Tests: []*models.UnitTest{
 			{
 				Name:           "This will be True",
-				ResourceType:   "AWS.S3.Bucket",
 				ExpectedResult: true,
 				Resource:       `{"Bucket": "empty"}`,
 			},
@@ -278,7 +273,6 @@ func TestIntegrationAPI(t *testing.T) {
 		t.Run("TestPolicyPass", testPolicyPass)
 		t.Run("TestPolicyFail", testPolicyFail)
 		t.Run("TestPolicyError", testPolicyError)
-		t.Run("TestPolicyNotApplicable", testPolicyNotApplicable)
 		t.Run("TestPolicyMixed", testPolicyMixed)
 	})
 
@@ -373,39 +367,6 @@ func testPolicyPass(t *testing.T) {
 	assert.Equal(t, expected, result.Payload)
 }
 
-func testPolicyNotApplicable(t *testing.T) {
-	result, err := apiClient.Operations.TestPolicy(&operations.TestPolicyParams{
-		Body: &models.TestPolicy{
-			AnalysisType:  models.AnalysisTypePOLICY,
-			Body:          policy.Body,
-			ResourceTypes: policy.ResourceTypes,
-			Tests: models.TestSuite{
-				{
-					ExpectedResult: policy.Tests[0].ExpectedResult,
-					Name:           policy.Tests[0].Name,
-					Resource:       policy.Tests[0].Resource,
-					ResourceType:   "Wrong Resource Type",
-				},
-			},
-		},
-		HTTPClient: httpClient,
-	})
-
-	require.NoError(t, err)
-	expected := &models.TestPolicyResult{
-		TestSummary: false,
-		TestsErrored: models.TestsErrored{
-			{
-				ErrorMessage: "test resource type Wrong Resource Type is not applicable to this policy",
-				Name:         string(policy.Tests[0].Name),
-			},
-		},
-		TestsFailed: models.TestsFailed{},
-		TestsPassed: models.TestsPassed{},
-	}
-	assert.Equal(t, expected, result.Payload)
-}
-
 func testPolicyFail(t *testing.T) {
 	result, err := apiClient.Operations.TestPolicy(&operations.TestPolicyParams{
 		Body: &models.TestPolicy{
@@ -468,25 +429,21 @@ func testPolicyMixed(t *testing.T) {
 					ExpectedResult: true,
 					Name:           "test-1",
 					Resource:       `{"Hello": true}`,
-					ResourceType:   "AWS.S3.Bucket",
 				},
 				{
 					ExpectedResult: false,
 					Name:           "test-2",
 					Resource:       `{"Hello": false}`,
-					ResourceType:   "AWS.S3.Bucket",
 				},
 				{
 					ExpectedResult: true,
 					Name:           "test-3",
 					Resource:       `{"Hello": false}`,
-					ResourceType:   "AWS.S3.Bucket",
 				},
 				{
 					ExpectedResult: true,
 					Name:           "test-4",
 					Resource:       `{"Goodbye": false}`,
-					ResourceType:   "AWS.S3.Bucket",
 				},
 			},
 		},
@@ -745,7 +702,6 @@ func modifySuccess(t *testing.T) {
 	expectedPolicy.Tests = []*models.UnitTest{
 		{
 			Name:           "This will be True",
-			ResourceType:   "AWS.S3.Bucket",
 			ExpectedResult: true,
 			Resource:       `{}`,
 		},

--- a/internal/core/analysis_api/main/lambda.go
+++ b/internal/core/analysis_api/main/lambda.go
@@ -19,6 +19,8 @@ package main
  */
 
 import (
+	"fmt"
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 
 	"github.com/panther-labs/panther/internal/core/analysis_api/handlers"
@@ -51,6 +53,16 @@ var methodHandlers = map[string]gatewayapi.RequestHandler{
 	"POST /delete": handlers.DeletePolicies,
 	"GET /enabled": handlers.GetEnabledAnalyses,
 	"POST /test":   handlers.TestPolicy,
+
+	"GET /local": local,
+}
+
+func local(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyResponse {
+	fmt.Println(request)
+	return &events.APIGatewayProxyResponse{
+		Body:       `{"hello":"json"}`,
+		StatusCode: 200,
+	}
 }
 
 func main() {

--- a/internal/core/analysis_api/main/lambda.go
+++ b/internal/core/analysis_api/main/lambda.go
@@ -19,8 +19,6 @@ package main
  */
 
 import (
-	"fmt"
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 
 	"github.com/panther-labs/panther/internal/core/analysis_api/handlers"
@@ -53,16 +51,6 @@ var methodHandlers = map[string]gatewayapi.RequestHandler{
 	"POST /delete": handlers.DeletePolicies,
 	"GET /enabled": handlers.GetEnabledAnalyses,
 	"POST /test":   handlers.TestPolicy,
-
-	"GET /local": local,
-}
-
-func local(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyResponse {
-	fmt.Println(request)
-	return &events.APIGatewayProxyResponse{
-		Body:       `{"hello":"json"}`,
-		StatusCode: 200,
-	}
 }
 
 func main() {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -769,7 +769,6 @@ export type PolicyUnitTest = {
   expectedResult?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
   resource?: Maybe<Scalars['String']>;
-  resourceType?: Maybe<Scalars['String']>;
 };
 
 export type PolicyUnitTestError = {
@@ -782,7 +781,6 @@ export type PolicyUnitTestInput = {
   expectedResult?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
   resource?: Maybe<Scalars['String']>;
-  resourceType?: Maybe<Scalars['String']>;
 };
 
 export type Query = {
@@ -2080,7 +2078,6 @@ export type PolicyUnitTestResolvers<
   expectedResult?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   resource?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  resourceType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/BaseRuleFormTestSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/BaseRuleFormTestSection.tsx
@@ -20,11 +20,9 @@ import React, { MouseEvent } from 'react';
 import { AnalysisTypeEnum, PolicyUnitTest, PolicyUnitTestInput } from 'Generated/schema';
 import { FieldArray, FastField as Field, useFormikContext } from 'formik';
 import { Button, Flex, Icon, Grid, Box, Alert, AbstractButton } from 'pouncejs';
-import { LOG_TYPES, RESOURCE_TYPES } from 'Source/constants';
 import { formatJSON, extractErrorMessage, generateRandomColor } from 'Helpers/utils';
 import FormikTextInput from 'Components/fields/TextInput';
 import FormikEditor from 'Components/fields/Editor';
-import FormikCombobox from 'Components/fields/ComboBox';
 import FormikRadio from 'Components/fields/Radio';
 import { PolicyFormValues } from 'Components/forms/PolicyForm';
 import { RuleFormValues } from 'Components/forms/RuleForm';
@@ -90,7 +88,6 @@ const BaseRuleFormTestSection: React.FC = () => {
             name: `Test-${generateRandomColor()}`,
             expectedResult: true,
             resource: formatJSON({}),
-            resourceType: isPolicy ? RESOURCE_TYPES[0] : LOG_TYPES[0],
           };
 
           // adds a test
@@ -174,15 +171,6 @@ const BaseRuleFormTestSection: React.FC = () => {
                     placeholder="The name of your test"
                     label="Name"
                   />
-                  <Field
-                    as={FormikCombobox}
-                    searchable
-                    name={`tests[${activeTabIndex}].resourceType`}
-                    items={isPolicy ? RESOURCE_TYPES : LOG_TYPES}
-                    label={`${isPolicy ? 'Resource' : 'Log'} Type`}
-                    placeholder={`Select a ${isPolicy ? 'resource' : 'log'} type to test`}
-                  />
-
                   <Flex align="center" spacing={5}>
                     <Box fontSize="medium" fontWeight="medium" flexGrow={1} textAlign="right">
                       {isPolicy

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/BaseRuleFormTestSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/BaseRuleFormTestSection.tsx
@@ -164,7 +164,7 @@ const BaseRuleFormTestSection: React.FC = () => {
                     </Box>
                   ))}
                 </Flex>
-                <Grid columnGap={5} templateColumns="1fr 1fr 2fr" mt={2} mb={6}>
+                <Grid columnGap={5} templateColumns="1fr 2fr" mt={2} mb={6}>
                   <Field
                     as={FormikTextInput}
                     name={`tests[${activeTabIndex}].name`}

--- a/web/src/components/forms/PolicyForm/PolicyForm.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyForm.tsx
@@ -43,7 +43,6 @@ const validationSchema = Yup.object().shape({
         name: Yup.string().required(),
         expectedResult: Yup.boolean().required(),
         resource: Yup.string().required(),
-        resourceType: Yup.string().required(),
       })
     )
     .unique('Test names must be unique', 'name'),

--- a/web/src/components/forms/RuleForm/RuleForm.tsx
+++ b/web/src/components/forms/RuleForm/RuleForm.tsx
@@ -42,9 +42,8 @@ const validationSchema = Yup.object().shape({
     .of(
       Yup.object().shape({
         name: Yup.string().required(),
-        boolean: Yup.boolean().required(),
+        expectedResult: Yup.boolean().required(),
         resource: Yup.string().required(),
-        resourceType: Yup.string().required(),
       })
     )
     .unique('Test names must be unique', 'name'),

--- a/web/src/graphql/fragments/PolicyDetailsExtra.generated.ts
+++ b/web/src/graphql/fragments/PolicyDetailsExtra.generated.ts
@@ -24,11 +24,7 @@ import gql from 'graphql-tag';
 
 export type PolicyDetailsExtra = Pick<Types.PolicyDetails, 'body'> & {
   tests?: Types.Maybe<
-    Array<
-      Types.Maybe<
-        Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource' | 'resourceType'>
-      >
-    >
+    Array<Types.Maybe<Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource'>>>
   >;
 };
 
@@ -39,7 +35,6 @@ export const PolicyDetailsExtra = gql`
       expectedResult
       name
       resource
-      resourceType
     }
   }
 `;

--- a/web/src/graphql/fragments/PolicyDetailsExtra.graphql
+++ b/web/src/graphql/fragments/PolicyDetailsExtra.graphql
@@ -4,6 +4,5 @@ fragment PolicyDetailsExtra on PolicyDetails {
     expectedResult
     name
     resource
-    resourceType
   }
 }

--- a/web/src/graphql/fragments/RuleFull.generated.ts
+++ b/web/src/graphql/fragments/RuleFull.generated.ts
@@ -26,11 +26,7 @@ import gql from 'graphql-tag';
 
 export type RuleFull = Pick<Types.RuleDetails, 'body'> & {
   tests?: Types.Maybe<
-    Array<
-      Types.Maybe<
-        Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource' | 'resourceType'>
-      >
-    >
+    Array<Types.Maybe<Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource'>>>
   >;
 } & RuleBasic &
   RuleDates;
@@ -44,7 +40,6 @@ export const RuleFull = gql`
       expectedResult
       name
       resource
-      resourceType
     }
   }
   ${RuleBasic}

--- a/web/src/graphql/fragments/RuleFull.graphql
+++ b/web/src/graphql/fragments/RuleFull.graphql
@@ -6,6 +6,5 @@ fragment RuleFull on RuleDetails {
     expectedResult
     name
     resource
-    resourceType
   }
 }

--- a/web/src/pages/EditPolicy/graphql/updatePolicy.generated.ts
+++ b/web/src/pages/EditPolicy/graphql/updatePolicy.generated.ts
@@ -48,11 +48,7 @@ export type UpdatePolicy = {
       | 'tags'
     > & {
       tests?: Types.Maybe<
-        Array<
-          Types.Maybe<
-            Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource' | 'resourceType'>
-          >
-        >
+        Array<Types.Maybe<Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource'>>>
       >;
     }
   >;
@@ -79,7 +75,6 @@ export const UpdatePolicyDocument = gql`
         expectedResult
         name
         resource
-        resourceType
       }
     }
   }

--- a/web/src/pages/EditPolicy/graphql/updatePolicy.graphql
+++ b/web/src/pages/EditPolicy/graphql/updatePolicy.graphql
@@ -18,7 +18,6 @@ mutation UpdatePolicy($input: UpdatePolicyInput!) {
             expectedResult
             name
             resource
-            resourceType
         }
     }
 }

--- a/web/src/pages/EditRule/graphql/ruleDetails.generated.ts
+++ b/web/src/pages/EditRule/graphql/ruleDetails.generated.ts
@@ -46,11 +46,7 @@ export type RuleDetails = {
       | 'tags'
     > & {
       tests?: Types.Maybe<
-        Array<
-          Types.Maybe<
-            Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource' | 'resourceType'>
-          >
-        >
+        Array<Types.Maybe<Pick<Types.PolicyUnitTest, 'expectedResult' | 'name' | 'resource'>>>
       >;
     }
   >;
@@ -75,7 +71,6 @@ export const RuleDetailsDocument = gql`
         expectedResult
         name
         resource
-        resourceType
       }
     }
   }

--- a/web/src/pages/EditRule/graphql/ruleDetails.graphql
+++ b/web/src/pages/EditRule/graphql/ruleDetails.graphql
@@ -16,7 +16,6 @@ query RuleDetails($input: GetRuleInput!) {
       expectedResult
       name
       resource
-      resourceType
     }
   }
 }


### PR DESCRIPTION
## Background

The Resource Type (and Log Type) field in Policy/Rule unit tests are not needed and don't offer any extra feature
to the user. See #610 for more context.

## Changes

These fields are removed both from the web and backend/api code.

## Testing

With `mage test:integration` and manually.

@3nvi the frontend change (cleaning up the fields) seemed trivial and went ahead and implemented it in the 3rd commit but I can split it to a different issue/PR if you wish.
