### PR TITLE
Update pouncejs to ^0.45.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2445,6 +2445,11 @@
         }
       }
     },
+    "@juggle/resize-observer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.2.0.tgz",
+      "integrity": "sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg=="
+    },
     "@kwsites/exec-p": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@kwsites/exec-p/-/exec-p-0.4.0.tgz",
@@ -11781,12 +11786,13 @@
       "dev": true
     },
     "pouncejs": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/pouncejs/-/pouncejs-0.43.0.tgz",
-      "integrity": "sha512-qhfIdtkb7EEorTw8wTH/PuRog2TgnQ0Lw+deLZyBTjeejPrW8TGSUyNrM0MhWKpsK17najEr1xdENfMm+0g3uw==",
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/pouncejs/-/pouncejs-0.45.1.tgz",
+      "integrity": "sha512-iDr4OlTZDCfjmirFOpanNe3FBqYvGSb63bj+L7Ge7gvU+1NcJVPVLT3TgxZQLN7Uh0I3qbQdaHFpLs09rII7Ow==",
       "requires": {
         "@emotion/react": "^11.0.0-next.12",
         "@emotion/styled": "^11.0.0-next.12",
+        "@juggle/resize-observer": "^3.2.0",
         "@reach/dialog": "^0.10.3",
         "@reach/menu-button": "^0.10.3",
         "@reach/tabs": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "history": "^4.10.1",
     "linkifyjs": "^2.1.9",
     "lodash-es": "^4.17.15",
-    "pouncejs": "^0.43.0",
+    "pouncejs": "^0.45.1",
     "qrcode.react": "^1.0.0",
     "query-string": "^6.10.1",
     "react": "^16.12.0",


### PR DESCRIPTION
## Background

Safari versions prior to [13.0.1](https://caniuse.com/#feat=resizeobserver) do not support the Resize Observer API, thus the app is crashing due to `pouncejs` misconfiguration of the polyfill. This issue is related to this [pounce pull request](https://github.com/panther-labs/pounce/pull/78) and we shall bump a new `pounce` release before merging. Also, there is a pending commit missing updating the `package-lock.json` file.


![Screenshot 2020-07-07 at 11 47 02 AM](https://user-images.githubusercontent.com/1022166/86776554-f818f500-c060-11ea-9189-edc710630d10.png)

## Changes

- Bump the `pouncejs` dependency on the latest one.

## Testing

- Checkout the branch and run `npm I && npm run start` when the server fires up navigate to the app using Safari.
