### PR TITLE
Sync zap logger on `lambdalogger.ConfigureGlobal`

### DIFF
--- a/pkg/lambdalogger/logger.go
+++ b/pkg/lambdalogger/logger.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -88,6 +89,10 @@ func ConfigureGlobal(
 		log.Panic("failed to build zap logger: " + err.Error())
 	}
 
+	// Sync the current global logger so we don't miss any log lines
+	if err := zap.L().Sync(); err != nil {
+		panic(errors.Wrap(err, "failed to sync logger"))
+	}
 	zap.ReplaceGlobals(logger)
 	return lc, logger
 }


### PR DESCRIPTION
## Background

The current state of `lambdalogger` uses `zap.ReplaceGlobals()` on each lambda invocation.
Apart from the overhead of creating a new zap logger on each lambda invocation the implementation does not call `Sync()`
on the previous global logger. This has the potential of losing buffered log lines from the last Lambda invocation.
This patch forces the `Sync` on the logger that gets replaced to avoid this. It would be desired to avoid replacing the global logger on each lambda invocation but such a change would be quite big and should be considered in a separate PR.

## Changes

- Call `zap.Logger.Sync()` on the logger that gets replaced by `lambdalogger.ConfigureGlobal()` to ensure all log lines are written to stdout

## Testing

- mage test:ci
