### PR TITLE
Fix Navlink active URL checking

### DIFF
--- a/web/src/components/Navigation/NavLink.tsx
+++ b/web/src/components/Navigation/NavLink.tsx
@@ -19,6 +19,7 @@
 import { Box, Icon, IconProps, PseudoBox } from 'pouncejs';
 import React from 'react';
 import useRouter from 'Hooks/useRouter';
+import { addTrailingSlash } from 'Helpers/utils';
 import { Link as RRLink } from 'react-router-dom';
 
 type NavLinkProps = {
@@ -29,8 +30,10 @@ type NavLinkProps = {
 
 const NavLink: React.FC<NavLinkProps> = ({ icon, label, to }) => {
   const { location } = useRouter();
+  const pathname = addTrailingSlash(location.pathname);
+  const destination = addTrailingSlash(to);
+  const isActive = pathname.startsWith(destination);
 
-  const isActive = location.pathname.startsWith(to);
   return (
     <Box as={RRLink} display="block" to={to} my={1} aria-current={isActive ? 'page' : undefined}>
       <PseudoBox

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -316,3 +316,13 @@ export const generateRandomColor = () => Math.floor(Math.random() * 16777215).to
 export const remToPx = (rem: string) => {
   return parseFloat(rem) * parseFloat(getComputedStyle(document.documentElement).fontSize);
 };
+
+/**
+ * Appends a trailing slash if missing from a url.
+ *
+ * @param {String} url A URL to check
+ * @returns {String} A URL with a trailing slash
+ */
+export const addTrailingSlash = (url: string) => {
+  return url.endsWith('/') ? url : `${url}/`;
+};


### PR DESCRIPTION
## Background

Navlink component's active URL checking does not actually work with URLs without a trailing slash, this PR fixes this minor bug.

## Before
![Screenshot 2020-07-08 at 3 24 16 PM](https://user-images.githubusercontent.com/1022166/86919864-878dd900-c131-11ea-9938-0aafa01dd42f.png)

## After
![Screenshot 2020-07-08 at 3 24 39 PM](https://user-images.githubusercontent.com/1022166/86919875-8b216000-c131-11ea-94c8-7a9ee10b8ece.png)

## Changes
- Introduced a minimaL helper utility for URL checking
- Patched the `web/src/components/Navigation/NavLink.tsx` component.

## Testing

- Manually and visually.
