### PR TITLE
Refactor: stabilize module imports

### DIFF
--- a/web/src/apollo/cleanParamsLink.ts
+++ b/web/src/apollo/cleanParamsLink.ts
@@ -17,7 +17,7 @@
  */
 
 import { ApolloLink } from '@apollo/client';
-import { getMainDefinition } from '@apollo/client/utilities/graphql/getFromAST';
+import { getMainDefinition } from 'apollo-utilities';
 import { OperationDefinitionNode } from 'graphql';
 
 /**

--- a/web/src/apollo/createErrorLink.ts
+++ b/web/src/apollo/createErrorLink.ts
@@ -18,7 +18,7 @@
 
 import { History } from 'history';
 import { LocationErrorState } from 'Components/utils/ApiErrorFallback';
-import { getOperationName } from '@apollo/client/utilities/graphql/getFromAST';
+import { getOperationName } from 'apollo-utilities';
 import { ListRemediationsDocument } from 'Components/forms/PolicyForm';
 import { RuleTeaserDocument } from 'Pages/AlertDetails';
 import { ErrorResponse, onError } from 'apollo-link-error';

--- a/web/src/components/modals/ResetUserPasswordModal/ResetUserPasswordModal.tsx
+++ b/web/src/components/modals/ResetUserPasswordModal/ResetUserPasswordModal.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { ModalProps, useSnackbar } from 'pouncejs';
 import { ListUsersDocument } from 'Pages/Users';
-import { getOperationName } from '@apollo/client/utilities/graphql/getFromAST';
+import { getOperationName } from 'apollo-utilities';
 import ConfirmModal from 'Components/modals/ConfirmModal';
 import { UserDetails } from 'Source/graphql/fragments/UserDetails.generated';
 import { useResetUserPassword } from './graphql/resetUserPassword.generated';

--- a/web/src/components/sidesheets/PolicyBulkUploadSidesheet/PolicyBulkUploadSidesheet.tsx
+++ b/web/src/components/sidesheets/PolicyBulkUploadSidesheet/PolicyBulkUploadSidesheet.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { PANTHER_SCHEMA_DOCS_LINK } from 'Source/constants';
 import { ListPoliciesDocument } from 'Pages/ListPolicies';
 import { ListRulesDocument } from 'Pages/ListRules';
-import { getOperationName } from '@apollo/client/utilities/graphql/getFromAST';
+import { getOperationName } from 'apollo-utilities';
 import { extractErrorMessage } from 'Helpers/utils';
 import { useUploadPolicies } from './graphql/uploadPolicies.generated';
 

--- a/web/src/hooks/usePolicySuppression.tsx
+++ b/web/src/hooks/usePolicySuppression.tsx
@@ -21,7 +21,7 @@ import { PolicyDetails, ResourceDetails } from 'Generated/schema';
 import { useSnackbar } from 'pouncejs';
 import { ResourceDetailsDocument } from 'Pages/ResourceDetails';
 import { PolicyDetailsDocument } from 'Pages/PolicyDetails';
-import { getOperationName } from '@apollo/client/utilities/graphql/getFromAST';
+import { getOperationName } from 'apollo-utilities';
 import { extractErrorMessage } from 'Helpers/utils';
 import { useSuppressPolicy } from './graphql/suppressPolicy.generated';
 

--- a/web/src/hooks/useResourceRemediation.tsx
+++ b/web/src/hooks/useResourceRemediation.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { useSnackbar } from 'pouncejs';
-import { getOperationName } from '@apollo/client/utilities/graphql/getFromAST';
+import { getOperationName } from 'apollo-utilities';
 import { ResourceDetailsDocument } from 'Pages/ResourceDetails';
 import { PolicyDetailsDocument } from 'Pages/PolicyDetails';
 import { extractErrorMessage } from 'Helpers/utils';


### PR DESCRIPTION
## Background

**This is  pre-cursor to the  test suite  setup**

This PR changes  the imports of some common Apollo functions, from `@apollo/client/utilities/graphql/getFromAST` to `apollo-utilities`.  The `apollo-utilities` package is already  present and is a dependency of almost all of our apollo OSS packages. 

The reason behind this change  is  that the former doesn't have commonJS exports, while the latter does. This will helps us during testing,  since Jest won't be forced to transpile any ES6 or TS  to commonJS in `node_modules` packages. 

## Changes

- Change  import of utility functions from deep non-transpiled paths to separate  commonJS utility package

## Testing

- App works as expected
- Utility funcs have the  same  code
