### PR TITLE
Remove debug env hack

### DIFF
--- a/pkg/lambdalogger/logger.go
+++ b/pkg/lambdalogger/logger.go
@@ -34,16 +34,6 @@ const Application = "panther" // tag all logs with "application" -> "panther" (u
 // DebugEnabled is true if the DEBUG environment variable is set to true.
 var DebugEnabled = strings.ToLower(os.Getenv("DEBUG")) == "true"
 
-func init() {
-	if !DebugEnabled {
-		// Swagger HTTP clients log in DEBUG mode if the variable exists with any non-empty value.
-		// https://github.com/go-openapi/runtime/blob/master/logger/logger.go#L11
-		if err := os.Setenv("DEBUG", ""); err != nil {
-			log.Panic("failed to reset DEBUG environment variable: " + err.Error())
-		}
-	}
-}
-
 // ConfigureGlobal adds the Lambda request ID to the global zap logger.
 //
 // To add fields to every log message, include them in initialFields (the requestID is added for you).


### PR DESCRIPTION
## Background

The `lambdalogger` package loaded by all of our Lambda functions has a hack to work around a go-swagger limitation. Thankfully, swagger has since fixed this issue, so we can remove this code. This frees up lambda functions to inspect the `DEBUG` environment variable without having to worry about silent modifications to it from another package.

## Testing

- Deployed, integration tests
