### PR TITLE
Add helper types and functions to enforce proper JSONL output.

### DIFF
--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -177,6 +177,8 @@ func (destination *S3Destination) SendEvents(parsedEventChannel chan *parsers.Re
 
 		buffer := bufferSet.getBuffer(event)
 
+		// TODO: [destinations/S3] Use `jsonutil.AppendJoinLines` strip new lines from rendered JSON
+		// event.JSON = jsonutil.AppendJoinLines(event.JSON[:0], event.JSON)
 		err := bufferSet.addEvent(buffer, event.JSON)
 		if err != nil {
 			failed = true

--- a/internal/log_analysis/log_processor/jsonutil/jsonl.go
+++ b/internal/log_analysis/log_processor/jsonutil/jsonl.go
@@ -1,0 +1,126 @@
+package jsonutil
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"bytes"
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+// AppendJoinLines appends src to dst omitting new lines ('\n').
+// It can be used for removing new lines from a jsoniter.RawMessage so it can safely be used in JSONL.
+// It is safe to use tha same buffer as dest and src to remove new lines in-place:
+// ```go
+// ```
+func AppendJoinLines(dst, src []byte) []byte {
+	const newLine = '\n'
+	for len(src) > 0 {
+		if pos := bytes.IndexByte(src, newLine); 0 <= pos && pos < len(src) {
+			dst, src = append(dst, src[:pos]...), src[pos+1:]
+		} else {
+			return append(dst, src...)
+		}
+	}
+	return dst
+}
+
+type EncoderJSONL struct {
+	stream *jsoniter.Stream
+	buffer AppendWriter
+	n      int
+	w      io.Writer
+}
+
+func NewEncoderJSONL(w io.Writer, api jsoniter.API) *EncoderJSONL {
+	if api == nil {
+		api = jsoniter.ConfigDefault
+	}
+	encoder := EncoderJSONL{
+		w: w,
+	}
+	encoder.stream = jsoniter.NewStream(api, &encoder.buffer, 4096)
+	return &encoder
+}
+
+func (e *EncoderJSONL) Encode(val interface{}) error {
+	if err := e.stream.Error; err != nil {
+		return err
+	}
+	e.buffer.Reset()
+	e.stream.WriteVal(val)
+	if err := e.stream.Flush(); err != nil {
+		return err
+	}
+	if err := e.incr(); err != nil {
+		return err
+	}
+	// Strip new lines in-place
+	e.buffer.B = AppendJoinLines(e.buffer.B[:0], e.buffer.B)
+	if _, err := e.w.Write(e.buffer.B); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *EncoderJSONL) NumLines() int {
+	return e.n
+}
+
+func (e *EncoderJSONL) Reset(w io.Writer) {
+	e.stream.Reset(&e.buffer)
+	e.buffer.Reset()
+	*e = EncoderJSONL{
+		buffer: e.buffer,
+		stream: e.stream,
+		w:      w,
+	}
+}
+
+func (e *EncoderJSONL) incr() error {
+	if e.n > 0 {
+		if _, err := e.w.Write([]byte("\n")); err != nil {
+			return err
+		}
+	}
+	e.n++
+	return nil
+}
+
+type AppendWriter struct {
+	B []byte
+}
+
+func (w *AppendWriter) Reset() {
+	w.B = w.B[:0]
+}
+
+func (w *AppendWriter) Write(p []byte) (int, error) {
+	w.B = append(w.B, p...)
+	return len(p), nil
+}
+func (w *AppendWriter) WriteByte(b byte) error {
+	w.B = append(w.B, b)
+	return nil
+}
+func (w *AppendWriter) WriteString(s string) (int, error) {
+	w.B = append(w.B, s...)
+	return len(s), nil
+}

--- a/internal/log_analysis/log_processor/jsonutil/jsonl_test.go
+++ b/internal/log_analysis/log_processor/jsonutil/jsonl_test.go
@@ -1,0 +1,83 @@
+package jsonutil
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendJoinLines(t *testing.T) {
+	{
+		input := []byte(`foo
+bar
+`)
+		out := AppendJoinLines(nil, input)
+		require.Equal(t, `foobar`, string(out))
+	}
+	{
+		input := []byte(`foo bar `)
+		out := AppendJoinLines(nil, input)
+		require.Equal(t, `foo bar `, string(out))
+	}
+	{
+		// inplace
+		input := []byte(`foo
+bar
+`)
+		input = AppendJoinLines(input[:0], input)
+		require.Equal(t, `foobar`, string(input))
+	}
+}
+
+func ExampleAppendJoinLines() {
+	// Use AppendJoinLines to replace new lines in-place
+	msg := []byte(`
+{
+  "foo": "bar"
+}`)
+	msg = AppendJoinLines(msg[:0], msg)
+	fmt.Println(string(msg))
+	// Output:{  "foo": "bar"}
+}
+
+func TestNewEncoderJSONL(t *testing.T) {
+	buffer := bytes.Buffer{}
+	enc := NewEncoderJSONL(&buffer, nil)
+	require.Equal(t, 0, enc.NumLines())
+	require.NoError(t, enc.Encode("foo"))
+	require.Equal(t, 1, enc.NumLines())
+	require.Equal(t, buffer.String(), `"foo"`)
+	msg := jsoniter.RawMessage(`{
+    "foo": "bar"
+}`)
+	require.NoError(t, enc.Encode(msg))
+	require.Equal(t, `"foo"
+{    "foo": "bar"}`, buffer.String())
+	require.Equal(t, 2, enc.NumLines())
+	buffer.Reset()
+	enc.Reset(&buffer)
+	require.NoError(t, enc.Encode(msg))
+	require.Equal(t, `{    "foo": "bar"}`, buffer.String())
+	require.Equal(t, 1, enc.NumLines())
+}


### PR DESCRIPTION
## Background

There is a corner case when using `jsoniter.RawMessage` and writing output to `JSONL` files.

If the input contains formatted `JSON` that includes newline characters, the output will not strip these new lines resulting
in `JSONL` output that is invalid.

This PR adds helpers and methods to enforce proper JSONL formatting regardless of input JSON.
The helpers of this PR are meant to be used by any part of Panther that needs to output JSONL and is unsure about the input JSON format (ie calls to external JSON APIs in log pullers).

## Changes

- Adds `AppendJoinLines` low level helper to strip new lines from input.
- Adds `EncoderJSONL` type that writes proper JSONL output to the underlying `io.Writer`
- Adds `SingleLineRawMessage` type that acts like `jsoniter.RawMessage` but strips all new line characters.

## Testing

- Unit tests

