### PR TITLE
Replaced cache.modify with cache.evict for deletions 

### DIFF
--- a/web/src/components/modals/DeleteComplianceSourceModal/DeleteComplianceSourceModal.tsx
+++ b/web/src/components/modals/DeleteComplianceSourceModal/DeleteComplianceSourceModal.tsx
@@ -36,7 +36,6 @@ const DeleteSourceModal: React.FC<DeleteComplianceSourceModalProps> = ({ source,
     optimisticResponse: () => ({ deleteComplianceIntegration: true }),
     update: cache => {
       cache.evict({ id: cache.identify(source) });
-      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeleteComplianceSourceModal/DeleteComplianceSourceModal.tsx
+++ b/web/src/components/modals/DeleteComplianceSourceModal/DeleteComplianceSourceModal.tsx
@@ -35,14 +35,7 @@ const DeleteSourceModal: React.FC<DeleteComplianceSourceModalProps> = ({ source,
     },
     optimisticResponse: () => ({ deleteComplianceIntegration: true }),
     update: cache => {
-      cache.modify({
-        fields: {
-          listComplianceIntegrations: (queryData, { toReference }) => {
-            const deletedSource = toReference(source);
-            return queryData.filter(({ __ref }) => __ref !== deletedSource.__ref);
-          },
-        },
-      });
+      cache.evict({ id: cache.identify(source) });
       cache.gc();
     },
     onCompleted: () => {

--- a/web/src/components/modals/DeleteDestinationModal/DeleteDestinationModal.tsx
+++ b/web/src/components/modals/DeleteDestinationModal/DeleteDestinationModal.tsx
@@ -41,7 +41,6 @@ const DeleteDestinationModal: React.FC<DeleteDestinationModalProps> = ({
     },
     update: async cache => {
       cache.evict({ id: cache.identify(destination) });
-      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeleteDestinationModal/DeleteDestinationModal.tsx
+++ b/web/src/components/modals/DeleteDestinationModal/DeleteDestinationModal.tsx
@@ -40,14 +40,7 @@ const DeleteDestinationModal: React.FC<DeleteDestinationModalProps> = ({
       deleteDestination: true,
     },
     update: async cache => {
-      cache.modify({
-        fields: {
-          destinations: (destinations, helpers) => {
-            const destinationRef = helpers.toReference(destination);
-            return destinations.filter(dest => dest.__ref !== destinationRef.__ref);
-          },
-        },
-      });
+      cache.evict({ id: cache.identify(destination) });
       cache.gc();
     },
     onCompleted: () => {

--- a/web/src/components/modals/DeleteGlobalPythonModuleModal/DeleteGlobalPythonModuleModal.tsx
+++ b/web/src/components/modals/DeleteGlobalPythonModuleModal/DeleteGlobalPythonModuleModal.tsx
@@ -51,7 +51,6 @@ const DeleteGlobalModal: React.FC<DeleteGlobalPythonModuleModalProps> = ({
     },
     update: async cache => {
       cache.evict({ id: cache.identify(globalPythonModule) });
-      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeleteGlobalPythonModuleModal/DeleteGlobalPythonModuleModal.tsx
+++ b/web/src/components/modals/DeleteGlobalPythonModuleModal/DeleteGlobalPythonModuleModal.tsx
@@ -50,17 +50,7 @@ const DeleteGlobalModal: React.FC<DeleteGlobalPythonModuleModalProps> = ({
       deleteGlobalPythonModule: true,
     },
     update: async cache => {
-      cache.modify({
-        fields: {
-          listGlobalPythonModules: (data, helpers) => {
-            const globalRef = helpers.toReference(globalPythonModule);
-            return {
-              ...data,
-              globals: data.globals.filter(p => p.__ref !== globalRef.__ref),
-            };
-          },
-        },
-      });
+      cache.evict({ id: cache.identify(globalPythonModule) });
       cache.gc();
     },
     onCompleted: () => {

--- a/web/src/components/modals/DeleteLogSourceModal/DeleteLogSourceModal.tsx
+++ b/web/src/components/modals/DeleteLogSourceModal/DeleteLogSourceModal.tsx
@@ -41,7 +41,6 @@ const DeleteLogSourceModal: React.FC<DeleteLogSourceModalProps> = ({
     optimisticResponse: () => ({ deleteLogIntegration: true }),
     update: cache => {
       cache.evict({ id: cache.identify(source) });
-      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeleteLogSourceModal/DeleteLogSourceModal.tsx
+++ b/web/src/components/modals/DeleteLogSourceModal/DeleteLogSourceModal.tsx
@@ -40,14 +40,8 @@ const DeleteLogSourceModal: React.FC<DeleteLogSourceModalProps> = ({
     },
     optimisticResponse: () => ({ deleteLogIntegration: true }),
     update: cache => {
-      cache.modify({
-        fields: {
-          listLogIntegrations: (queryData, { toReference }) => {
-            const deletedSource = toReference(source);
-            return queryData.filter(({ __ref }) => __ref !== deletedSource.__ref);
-          },
-        },
-      });
+      cache.evict({ id: cache.identify(source) });
+      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
+++ b/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
@@ -48,7 +48,6 @@ const DeletePolicyModal: React.FC<DeletePolicyModalProps> = ({ policy, ...rest }
     update: async cache => {
       cache.evict({ id: cache.identify({ ...policy, __typename: 'PolicySummary' }) });
       cache.evict({ id: cache.identify({ ...policy, __typename: 'PolicyDetails' }) });
-      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
+++ b/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
@@ -46,31 +46,8 @@ const DeletePolicyModal: React.FC<DeletePolicyModalProps> = ({ policy, ...rest }
       deletePolicy: true,
     },
     update: async cache => {
-      cache.modify({
-        fields: {
-          policies: (data, helpers) => {
-            const policyRef = helpers.toReference({
-              __typename: 'PolicySummary',
-              id: policy.id,
-            });
-            return {
-              ...data,
-              policies: data.policies.filter(p => p.__ref !== policyRef.__ref),
-            };
-          },
-          policy: (data, helpers) => {
-            const policyRef = helpers.toReference({
-              __typename: 'PolicyDetails',
-              id: policy.id,
-            });
-            if (policyRef.__ref !== data.__ref) {
-              return data;
-            }
-            return helpers.DELETE;
-          },
-        },
-      });
-
+      cache.evict({ id: cache.identify({ ...policy, __typename: 'PolicySummary' }) });
+      cache.evict({ id: cache.identify({ ...policy, __typename: 'PolicyDetails' }) });
       cache.gc();
     },
     onCompleted: () => {

--- a/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
+++ b/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
@@ -48,7 +48,6 @@ const DeleteRuleModal: React.FC<DeleteRuleModalProps> = ({ rule, ...rest }) => {
     update: async cache => {
       cache.evict({ id: cache.identify({ ...rule, __typename: 'RuleSummary' }) });
       cache.evict({ id: cache.identify({ ...rule, __typename: 'RuleDetails' }) });
-      cache.gc();
     },
     onCompleted: () => {
       pushSnackbar({

--- a/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
+++ b/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
@@ -46,27 +46,8 @@ const DeleteRuleModal: React.FC<DeleteRuleModalProps> = ({ rule, ...rest }) => {
       deleteRule: true,
     },
     update: async cache => {
-      cache.modify({
-        fields: {
-          rules: (data, helpers) => {
-            const ruleRef = helpers.toReference({
-              __typename: 'RuleSummary',
-              id: rule.id,
-            });
-            return { ...data, rules: data.rules.filter(r => r.__ref !== ruleRef.__ref) };
-          },
-          rule: (data, helpers) => {
-            const ruleRef = helpers.toReference({
-              __typename: 'RuleDetails',
-              id: rule.id,
-            });
-            if (ruleRef.__ref !== data.__ref) {
-              return data;
-            }
-            return helpers.DELETE;
-          },
-        },
-      });
+      cache.evict({ id: cache.identify({ ...rule, __typename: 'RuleSummary' }) });
+      cache.evict({ id: cache.identify({ ...rule, __typename: 'RuleDetails' }) });
       cache.gc();
     },
     onCompleted: () => {

--- a/web/src/components/modals/DeleteUserModal/DeleteUserModal.tsx
+++ b/web/src/components/modals/DeleteUserModal/DeleteUserModal.tsx
@@ -40,14 +40,7 @@ const DeleteUserModal: React.FC<DeleteUserModalProps> = ({ user, ...rest }) => {
       deleteUser: true,
     },
     update: async cache => {
-      cache.modify({
-        fields: {
-          users: (data, helpers) => {
-            const userRef = helpers.toReference(user);
-            return data.filter(u => u.__ref !== userRef.__ref);
-          },
-        },
-      });
+      cache.evict({ id: cache.identify(user) });
       cache.gc();
     },
     onCompleted: async () => {

--- a/web/src/components/modals/DeleteUserModal/DeleteUserModal.tsx
+++ b/web/src/components/modals/DeleteUserModal/DeleteUserModal.tsx
@@ -41,7 +41,6 @@ const DeleteUserModal: React.FC<DeleteUserModalProps> = ({ user, ...rest }) => {
     },
     update: async cache => {
       cache.evict({ id: cache.identify(user) });
-      cache.gc();
     },
     onCompleted: async () => {
       pushSnackbar({


### PR DESCRIPTION
## Background

With the latest apollo upgrade, we can substitute `cache.modify` code for deletions with one liners `cache.evict`. This will provide clarity as well with getting us up to date with the latest version. Users shouldn't notice any difference. 

## Changes

- Replace cache.modify in `DeleteComplianceSourceModal`, `DeleteDestinationModal`, `DeleteGlobalPythonModuleModal`, `DeleteLogSourceModal`, `DeletePolicyModal`, `DeleteRuleModal`, `DeleteUserModal`

## Testing

- Verified cached object are removed both from apollo cache and from the UI.

