### PR TITLE
Added SQS support

### DIFF
--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -44,8 +44,8 @@ type LambdaInput struct {
 
 // CheckIntegrationInput is used to check the health of a potential configuration.
 type CheckIntegrationInput struct {
-	AWSAccountID     string `genericapi:"redact" json:"awsAccountId" validate:"required,len=12,numeric"`
-	IntegrationType  string `json:"integrationType" validate:"required,oneof=aws-scan aws-s3"`
+	AWSAccountID     string `genericapi:"redact" json:"awsAccountId" validate:"omitempty,len=12,numeric"`
+	IntegrationType  string `json:"integrationType" validate:"oneof=aws-scan aws-s3 aws-sqs"`
 	IntegrationLabel string `json:"integrationLabel" validate:"required,integrationLabel"`
 
 	// Checks for cloudsec integrations
@@ -56,6 +56,9 @@ type CheckIntegrationInput struct {
 	S3Bucket string `json:"s3Bucket"`
 	S3Prefix string `json:"s3Prefix"`
 	KmsKey   string `json:"kmsKey"`
+
+	// Checks for Sqs configuration
+	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 }
 
 //
@@ -70,7 +73,7 @@ type PutIntegrationInput struct {
 // PutIntegrationSettings are all the settings for the new integration.
 type PutIntegrationSettings struct {
 	IntegrationLabel   string   `json:"integrationLabel" validate:"required,integrationLabel,excludesall='<>&\""`
-	IntegrationType    string   `json:"integrationType" validate:"required,oneof=aws-scan aws-s3"`
+	IntegrationType    string   `json:"integrationType" validate:"oneof=aws-scan aws-s3 aws-sqs"`
 	UserID             string   `json:"userId" validate:"required,uuid4"`
 	AWSAccountID       string   `genericapi:"redact" json:"awsAccountId" validate:"omitempty,len=12,numeric"`
 	CWEEnabled         *bool    `json:"cweEnabled"`
@@ -80,15 +83,17 @@ type PutIntegrationSettings struct {
 	S3Prefix           string   `json:"s3Prefix" validate:"omitempty,min=1"`
 	KmsKey             string   `json:"kmsKey" validate:"omitempty,kmsKeyArn"`
 	LogTypes           []string `json:"logTypes" validate:"omitempty,min=1"`
+
+	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 }
 
 //
 // ListIntegrations: Used by the Scheduler to find integrations to scan
 //
 
-// ListIntegrationsInput allows filtering by the IntegrationType or Enabled fields
+// ListIntegrationsInput allows filtering by the IntegrationType field
 type ListIntegrationsInput struct {
-	IntegrationType *string `json:"integrationType" validate:"omitempty,oneof=aws-scan aws-s3"`
+	IntegrationType *string `json:"integrationType" validate:"omitempty,oneof=aws-scan aws-s3 aws-sqs"`
 }
 
 // UpdateIntegrationSettingsInput is used to update integration settings.
@@ -102,6 +107,8 @@ type UpdateIntegrationSettingsInput struct {
 	S3Prefix           string   `json:"s3Prefix" validate:"omitempty,min=1"`
 	KmsKey             string   `json:"kmsKey" validate:"omitempty,kmsKeyArn"`
 	LogTypes           []string `json:"logTypes" validate:"omitempty,min=1"`
+
+	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 }
 
 // DeleteIntegrationInput is used to delete a specific item from the database.
@@ -147,7 +154,7 @@ type UpdateIntegrationLastScanStartInput struct {
 
 // UpdateIntegrationLastScanEndInput is used to update scan information at the end of a scan.
 type UpdateIntegrationLastScanEndInput struct {
-	ScanStatus           string    `json:"scanStatus" validate:"required,oneof=ok error scanning"`
+	ScanStatus           string    `json:"scanStatus" validate:"oneof=ok error scanning"`
 	IntegrationID        string    `json:"integrationId" validate:"required,uuid4"`
 	LastScanEndTime      time.Time `json:"lastScanEndTime" validate:"required"`
 	EventStatus          string    `json:"eventStatus"`

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -18,7 +18,9 @@ package models
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import "time"
+import (
+	"time"
+)
 
 // SourceIntegration represents a Panther integration with a source.
 type SourceIntegration struct {
@@ -43,21 +45,22 @@ type SourceIntegrationScanInformation struct {
 
 // SourceIntegrationMetadata is general settings and metadata for an integration.
 type SourceIntegrationMetadata struct {
-	AWSAccountID       string    `json:"awsAccountId,omitempty"`
-	CreatedAtTime      time.Time `json:"createdAtTime,omitempty"`
-	CreatedBy          string    `json:"createdBy,omitempty"`
-	IntegrationID      string    `json:"integrationId,omitempty"`
-	IntegrationLabel   string    `json:"integrationLabel,omitempty"`
-	IntegrationType    string    `json:"integrationType,omitempty"`
-	RemediationEnabled *bool     `json:"remediationEnabled,omitempty"`
-	CWEEnabled         *bool     `json:"cweEnabled,omitempty"`
-	ScanIntervalMins   int       `json:"scanIntervalMins,omitempty"`
-	S3Bucket           string    `json:"s3Bucket,omitempty"`
-	S3Prefix           string    `json:"s3Prefix,omitempty"`
-	KmsKey             string    `json:"kmsKey,omitempty"`
-	LogTypes           []string  `json:"logTypes,omitempty"`
-	LogProcessingRole  string    `json:"logProcessingRole,omitempty"`
-	StackName          string    `json:"stackName,omitempty"`
+	AWSAccountID       string     `json:"awsAccountId,omitempty"`
+	CreatedAtTime      time.Time  `json:"createdAtTime,omitempty"`
+	CreatedBy          string     `json:"createdBy,omitempty"`
+	IntegrationID      string     `json:"integrationId,omitempty"`
+	IntegrationLabel   string     `json:"integrationLabel,omitempty"`
+	IntegrationType    string     `json:"integrationType,omitempty"`
+	RemediationEnabled *bool      `json:"remediationEnabled,omitempty"`
+	CWEEnabled         *bool      `json:"cweEnabled,omitempty"`
+	ScanIntervalMins   int        `json:"scanIntervalMins,omitempty"`
+	S3Bucket           string     `json:"s3Bucket,omitempty"`
+	S3Prefix           string     `json:"s3Prefix,omitempty"`
+	KmsKey             string     `json:"kmsKey,omitempty"`
+	LogTypes           []string   `json:"logTypes,omitempty"`
+	LogProcessingRole  string     `json:"logProcessingRole,omitempty"`
+	StackName          string     `json:"stackName,omitempty"`
+	SqsConfig          *SqsConfig `json:"sqsConfig,omitempty"`
 }
 
 type SourceIntegrationHealth struct {
@@ -72,6 +75,9 @@ type SourceIntegrationHealth struct {
 	ProcessingRoleStatus SourceIntegrationItemStatus `json:"processingRoleStatus,omitempty"`
 	S3BucketStatus       SourceIntegrationItemStatus `json:"s3BucketStatus,omitempty"`
 	KMSKeyStatus         SourceIntegrationItemStatus `json:"kmsKeyStatus,omitempty"`
+
+	// Checks for Sqs integrations
+	SqsStatus SourceIntegrationItemStatus `json:"sqsStatus"`
 }
 
 type SourceIntegrationItemStatus struct {
@@ -82,4 +88,25 @@ type SourceIntegrationItemStatus struct {
 type SourceIntegrationTemplate struct {
 	Body      string `json:"body"`
 	StackName string `json:"stackName"`
+}
+
+// The S3 Prefix where the SQS data will be stored
+const SqsS3Prefix = "forwarder"
+
+type SqsConfig struct {
+	// The log types associated with the source. Needs to be set by UI.
+	LogTypes []string `json:"logTypes" validate:"required,min=1"`
+	// The AWS Principals that are allowed to send data to this source. Needs to be set by UI.
+	AllowedPrincipals []string `json:"allowedPrincipals"`
+	// The ARNS (e.g. SNS topic ARNs) that are allowed to send data to this source. Needs to be set by UI.
+	AllowedSourceArns []string `json:"allowedSourceArns"`
+
+	// The Panther-internal S3 bucket where the data from this source will be available
+	S3Bucket string `json:"s3Bucket"`
+	// The S3 prefix where the data from this source will be available
+	S3Prefix string `json:"s3Prefix"`
+	// The Role that the log processor can use to access this data
+	LogProcessingRole string `json:"logProcessingRole"`
+	// THe URL of the SQS queue
+	QueueURL string `json:"queueUrl"`
 }

--- a/api/lambda/source/models/vars.go
+++ b/api/lambda/source/models/vars.go
@@ -23,6 +23,8 @@ const (
 	IntegrationTypeAWSScan = "aws-scan"
 	// IntegrationTypeAWS3 is the integration type for importing data from customer S3 buckets.
 	IntegrationTypeAWS3 = "aws-s3"
+	// IntegrationTypeSqs is integration type for pulling data from an SQS queue.
+	IntegrationTypeSqs = "aws-sqs"
 
 	// StatusError is the string set in the database when an error occurs in a scan.
 	StatusError = "error"

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -332,7 +332,41 @@ Resources:
               Bool:
                 aws:SecureTransport: false
 
-  ProcessedData: # processed security logs
+  InputDataBucket: # contains data that are input to Panther log analysis
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      LoggingConfiguration: !If
+        - EnableAccessLogs
+        - DestinationBucketName: !If [ExternalAccessLogs, !Ref AccessLogsBucket, !Ref AuditLogs]
+          LogFilePrefix: !Sub panther-input-data-${AWS::AccountId}-${AWS::Region}/
+        - !Ref AWS::NoValue
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      # Short expiration because this data is sent to Panther.
+      LifecycleConfiguration:
+        Rules:
+          - Id: WeekExpiration
+            Status: Enabled
+            ExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 7
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      AccessControl: Private
+      VersioningConfiguration:
+        Status: Enabled
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Topic: !Ref InputNotificationsTopic
+            Event: s3:ObjectCreated:*
+
+  ProcessedData: # processed security logs (JSON stage data)
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -845,6 +879,13 @@ Resources:
               - kms:GenerateDataKey
               - kms:Decrypt
             Resource: '*'
+          - Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action:
+              - kms:GenerateDataKey
+              - kms:Decrypt
+            Resource: '*'
 
   QueueEncryptionKeyAlias:
     Type: AWS::KMS::Alias
@@ -897,6 +938,37 @@ Resources:
             Action: sns:Subscribe
             Resource: !Ref ProcessedDataNotifications
 
+  InputNotificationsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: panther-boostrap-input-data-notifications
+      # <cfndoc>
+      # This topic triggers the log analysis flow for data integrations configured internally by Panther e.g. data by Amazon EventBridge.
+      # </cfndoc>
+      KmsMasterKeyId: !Ref QueueEncryptionKey
+
+  InputNotificationsTopicPolicy: # allow SNS subscriptions for S3 bucket
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref InputNotificationsTopic
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          # Reference: https://amzn.to/2ouFmhK
+          - Sid: AllowS3EventNotifications
+            Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref InputNotificationsTopic
+          - Sid: AllowSubscriptionToPantherInput
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
+            Action: sns:Subscribe
+            Resource: !Ref InputNotificationsTopic
+
   AlarmNotifications:
     Condition: CreateAlarmSNSTopic
     Type: AWS::SNS::Topic
@@ -927,6 +999,9 @@ Outputs:
     Condition: IsDeployFromSource
     Description: S3 bucket name for Panther CloudFormation packaging
     Value: !Ref Source
+  InputDataBucket:
+    Description: S3 bucket name for bucket that will contain data that are meant to be processed by the log analysis
+    Value: !Ref InputDataBucket
 
   # Networking + elb
   SubnetOneId:
@@ -993,6 +1068,9 @@ Outputs:
   ProcessedDataTopicArn:
     Description: SNS topic ARN for processed log data notifications
     Value: !Ref ProcessedDataNotifications
+  InputDataTopicArn:
+    Description: SNS topic ARN for data that is sent as input to Log Analysis
+    Value: !Ref InputNotificationsTopic
   AlarmTopicArn:
     Description: SNS topic ARN for CloudWatch alarms
     Value: !If [CreateAlarmSNSTopic, !Ref AlarmNotifications, !Ref AlarmTopicArn]

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -83,6 +83,12 @@ Parameters:
   UserPoolId:
     Type: String
     Description: Cognito user pool ID
+  InputDataBucket:
+    Type: String
+    Description: S3 bucket name for bucket that will contain data that are meant to be processed by the log analysis
+  InputDataTopicArn:
+    Type: String
+    Description: SNS topic ARN for data that is sent as input to Log Analysis
 
 Mappings:
   Alerts:
@@ -755,6 +761,10 @@ Resources:
           LOG_PROCESSOR_QUEUE_ARN: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-input-data-notifications-queue
           PROCESSED_DATA_BUCKET: !Ref ProcessedDataBucket
           TABLE_NAME: !Ref IntegrationsTable
+          ACCOUNT_ID: !Ref AWS::AccountId
+          INPUT_DATA_ROLE_ARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/PantherInputDataLogProcessingRole-${AWS::Region}
+          INPUT_DATA_BUCKET_NAME: !Ref InputDataBucket
+          INPUT_DATA_TOPIC_ARN: !Ref InputDataTopicArn
       FunctionName: panther-source-api
       # <cfndoc>
       # The `panther-source-api` lambda manages Cloud Security and Log Analysis sources. This includes
@@ -845,6 +855,24 @@ Resources:
                 - s3:GetObject
                 - s3:PutObject
               Resource: !Sub arn:aws:s3:::${AthenaResultsBucket}*
+        - Id: CreateSqsQueues # Allows Lambda to manage SQS source queues - these are SQS queues users send data to for log analysis
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - sqs:CreateQueue
+                - sqs:DeleteQueue
+                - sqs:SetQueueAttributes
+              Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-source-*
+        - Id: ConfigureMessageForwarderLambda
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - lambda:CreateEventSourceMapping
+                - lambda:ListEventSourceMappings
+                - lambda:DeleteEventSourceMapping
+              Resource: '*'
 
   SourceApiLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -67,6 +67,12 @@ Parameters:
     Type: String
     Description: Enable XRay tracing on Lambda and API Gateway
     AllowedValues: ['', Active, PassThrough]
+  InputDataBucket:
+    Type: String
+    Description: S3 bucket which stores incoming logs that are meant to be processed by log analysis
+  InputDataTopicArn:
+    Type: String
+    Description: The ARN of the input data SNS topic
 
 Mappings:
   Functions:
@@ -85,6 +91,9 @@ Mappings:
     Updater:
       Memory: 512
       Timeout: 900 # set to max to allow syncs
+    MessageForwarder:
+      Memory: 128
+      Timeout: 30
 
 Conditions:
   AttachLayers: !Not [!Equals [!Join ['', !Ref LayerVersionArns], '']]
@@ -108,6 +117,42 @@ Resources:
       TablesSignature: !Ref TablesSignature
       ProcessedDataBucket: !Ref ProcessedDataBucket
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
+
+  InputDataSnsSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: sqs
+      Endpoint: !GetAtt LogProcessorQueue.Arn
+      Region: !Ref AWS::Region
+      TopicArn: !Ref InputDataTopicArn
+      RawMessageDelivery: false
+
+  InputDataLogProcessingRole: # Role that has access to data in the InputDataBucket
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub PantherInputDataLogProcessingRole-${AWS::Region}
+      MaxSessionDuration: 3600 # 1 hour
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              Bool:
+                aws:SecureTransport: true
+      Policies:
+        - PolicyName: ReadData
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: s3:GetBucketLocation
+                Resource: !Sub arn:aws:s3:::${InputDataBucket}
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub arn:aws:s3:::${InputDataBucket}/*
 
   ###### Alerts API #####
   AlertsApiLogGroup:
@@ -422,6 +467,7 @@ Resources:
           PROCESSED_DATA_BUCKET: !Ref ProcessedDataBucket
           SNS_TOPIC_ARN: !Ref ProcessedDataTopicArn
           SQS_QUEUE_URL: !Ref LogProcessorQueue
+          INPUT_DATA_BUCKET: !Ref InputDataBucket
       Events:
         Queue:
           Type: SQS
@@ -458,6 +504,15 @@ Resources:
             - Effect: Allow
               Action: sts:AssumeRole
               Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherLogProcessingRole-*
+              Condition:
+                Bool:
+                  aws:SecureTransport: true
+        - Id: AssumePantherInputDataLogProcessingRole
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: sts:AssumeRole
+              Resource: !GetAtt InputDataLogProcessingRole.Arn
               Condition:
                 Bool:
                   aws:SecureTransport: true
@@ -901,3 +956,120 @@ Resources:
             pip: !Ref PythonLayerVersionArn
             global: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:panther-engine-globals:LATEST
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
+
+  ### Amazon SQS forwarder Resources###
+  MessageForwarderFirehose:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: panther-forwarder-firehose
+      DeliveryStreamType: DirectPut
+      ExtendedS3DestinationConfiguration:
+        BucketARN: !Sub arn:${AWS::Partition}:s3:::${InputDataBucket}
+        Prefix: forwarder/
+        BufferingHints:
+          # Data is flushed once one of the buffer hints are satisfied.
+          IntervalInSeconds: 60
+          SizeInMBs: 128
+        CompressionFormat: GZIP
+        RoleARN: !GetAtt MessageForwarderFirehoseRole.Arn
+
+  MessageForwarderFirehoseRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref AWS::AccountId
+      Policies:
+        - PolicyName: WriteToDataBucket
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                  - s3:PutObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::${InputDataBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${InputDataBucket}/forwarder/*
+
+  MessageForwarderLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/panther-message-forwarder
+      RetentionInDays: !Ref CloudWatchLogRetentionDays
+
+  MessageForwarderMetricFilters:
+    Type: Custom::LambdaMetricFilters
+    Properties:
+      LogGroupName: !Ref MessageForwarderLogGroup
+      ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
+
+  MessageForwarderAlarms:
+    Type: Custom::LambdaAlarms
+    Properties:
+      AlarmTopicArn: !Ref AlarmTopicArn
+      CustomResourceVersion: !Ref CustomResourceVersion
+      FunctionMemoryMB: !FindInMap [Functions, MessageForwarder, Memory]
+      FunctionName: !Ref MessageForwarderFunction
+      FunctionTimeoutSec: !FindInMap [Functions, MessageForwarder, Timeout]
+      ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
+
+  MessageForwarderFunction:
+    # !!!!!!!!! WARNING !!!!!!!!! #
+    # The triggers of this Lambda are managed at runtime, NOT in CloudFormation.
+    # We should NEVER specify a trigger for this Lambda in CloudFormation since this will cause CFN to override
+    # all runtime-managed triggers
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: panther-message-forwarder
+      # <cfndoc>
+      # This Lambda pulls data from user configured SQS sources and pushes them to Panther
+      # for further processing.
+      # Failure Impact
+      # Panther will stop processing data from SQS sources.
+      # </cfndoc>
+      Description: Pulls logs from external sources
+      CodeUri: ../out/bin/internal/log_analysis/message_forwarder/main
+      Handler: main
+      Layers: !If [AttachLayers, !Ref LayerVersionArns, !Ref 'AWS::NoValue']
+      MemorySize: !FindInMap [Functions, MessageForwarder, Memory]
+      Runtime: go1.x
+      Timeout: !FindInMap [Functions, MessageForwarder, Timeout]
+      Environment:
+        Variables:
+          DEBUG: !Ref Debug
+          STREAM_NAME: !Ref MessageForwarderFirehose
+      Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
+      Policies:
+        - Id: ReadFromSqs
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - sqs:ReceiveMessage
+                - sqs:DeleteMessage
+                - sqs:GetQueueAttributes
+              Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-*
+        - Id: WriteToFirehose
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: firehose:PutRecordBatch
+              Resource: !GetAtt MessageForwarderFirehose.Arn
+        - Id: InvokeSourceAPI
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: lambda:InvokeFunction
+              Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-source-api

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -258,6 +258,8 @@ Resources:
         SqsKeyId: !GetAtt Bootstrap.Outputs.QueueEncryptionKeyId
         TracingMode: !Ref TracingMode
         UserPoolId: !GetAtt Bootstrap.Outputs.UserPoolId
+        InputDataBucket: !GetAtt Bootstrap.Outputs.InputDataBucket
+        InputDataTopicArn: !GetAtt Bootstrap.Outputs.InputDataTopicArn
       Tags:
         - Key: Application
           Value: Panther
@@ -301,6 +303,8 @@ Resources:
         SqsKeyId: !GetAtt Bootstrap.Outputs.QueueEncryptionKeyId
         TablesSignature: !FindInMap [Constants, Panther, Version] # this changes with version, forcing table schema updates
         TracingMode: !Ref TracingMode
+        InputDataBucket: !GetAtt Bootstrap.Outputs.InputDataBucket
+        InputDataTopicArn: !GetAtt Bootstrap.Outputs.InputDataTopicArn
       Tags:
         - Key: Application
           Value: Panther

--- a/docs/gitbook/operations/runbooks.md
+++ b/docs/gitbook/operations/runbooks.md
@@ -130,6 +130,9 @@ The `panther-aws-remediation` lambda executes automated infrastructure remediati
  Failure Impact
  * Failure of this lambda will mean specific remediations are failing and infrastructure will remain in violation of policy.
 
+## panther-boostrap-input-data-notifications
+This topic triggers the log analysis flow for data integrations configured internally by Panther e.g. data by Amazon EventBridge.
+
 ## panther-cfn-custom-resources
 Used by CloudFormation when deploying or updating Panther.
 
@@ -269,6 +272,12 @@ The lambda function that processes S3 files from
  * Failed events will go into the `panther-input-data-notifications-queue-dlq`. When the system has recovered they should be
  * re-queued to the `panther-input-data-notifications-queue` using the Panther tool `requeue`.
  * There is the possibility of duplicate data ingested if the failures had partial results.
+
+## panther-message-forwarder
+This Lambda pulls data from user configured SQS sources and pushes them to Panther
+ for further processing.
+ Failure Impact
+ Panther will stop processing data from SQS sources.
 
 ## panther-metrics-api
 The `panther-metrics-api` lambda handles requests for metric data by properly translating

--- a/internal/core/source_api/api/lambda_utils.go
+++ b/internal/core/source_api/api/lambda_utils.go
@@ -1,0 +1,72 @@
+package api
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	messageForwarderLambda = "panther-message-forwarder"
+)
+
+func AddSourceAsLambdaTrigger(integrationID string) error {
+	input := &lambda.CreateEventSourceMappingInput{
+		EventSourceArn: aws.String(SourceSqsQueueArn(integrationID)),
+		FunctionName:   aws.String(messageForwarderLambda),
+		Enabled:        aws.Bool(true),
+	}
+	_, err := lambdaClient.CreateEventSourceMapping(input)
+	if err != nil {
+		return errors.Wrap(err, "failed to configure new trigger for message forwarder lambda")
+	}
+	return nil
+}
+
+func RemoveSourceFromLambdaTrigger(integrationID string) error {
+	listInput := &lambda.ListEventSourceMappingsInput{
+		FunctionName:   aws.String(messageForwarderLambda),
+		EventSourceArn: aws.String(SourceSqsQueueArn(integrationID)),
+		MaxItems:       aws.Int64(1),
+	}
+	listOutput, err := lambdaClient.ListEventSourceMappings(listInput)
+	if err != nil {
+		return errors.Wrap(err, "failed to list lambda event mappings")
+	}
+
+	if len(listOutput.EventSourceMappings) == 0 {
+		zap.L().Debug("the panther-message-forwarder lambda doesn't have an event source for the specific integration",
+			zap.String("integrationId", integrationID))
+		return nil
+	}
+	eventSourceUUID := listOutput.EventSourceMappings[0].UUID
+
+	deleteInput := &lambda.DeleteEventSourceMappingInput{
+		UUID: eventSourceUUID,
+	}
+	_, err = lambdaClient.DeleteEventSourceMapping(deleteInput)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete source mapping")
+	}
+
+	return nil
+}

--- a/internal/core/source_api/api/list_integrations.go
+++ b/internal/core/source_api/api/list_integrations.go
@@ -23,15 +23,15 @@ import (
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
-// ListIntegrations returns all enabled integrations across each organization.
-//
-// The output of this handler is used to schedule pollers.
+var genericListError = &genericapi.InternalError{Message: "Failed to list integrations"}
+
+// ListIntegrations returns all enabled integrations.
 func (API) ListIntegrations(
 	input *models.ListIntegrationsInput) ([]*models.SourceIntegration, error) {
 
 	integrationItems, err := dynamoClient.ScanIntegrations(input.IntegrationType)
 	if err != nil {
-		return nil, &genericapi.InternalError{Message: "Failed to list integrations"}
+		return nil, genericListError
 	}
 
 	result := make([]*models.SourceIntegration, len(integrationItems))

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -54,6 +54,16 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		item.LastScanStartTime = input.LastScanStartTime
 		item.LastScanEndTime = input.LastScanEndTime
 		item.StackName = input.StackName
+	case models.IntegrationTypeSqs:
+		item.SqsConfig = &ddb.SqsConfig{
+			QueueURL:          input.SqsConfig.QueueURL,
+			S3Bucket:          input.SqsConfig.S3Bucket,
+			S3Prefix:          input.SqsConfig.S3Prefix,
+			LogProcessingRole: input.SqsConfig.LogProcessingRole,
+			LogTypes:          input.SqsConfig.LogTypes,
+			AllowedPrincipals: input.SqsConfig.AllowedPrincipals,
+			AllowedSourceArns: input.SqsConfig.AllowedSourceArns,
+		}
 	}
 	return item
 }
@@ -88,6 +98,16 @@ func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 		integration.LastScanEndTime = item.LastScanEndTime
 		integration.LastScanErrorMessage = item.LastScanErrorMessage
 		integration.StackName = item.StackName
+	case models.IntegrationTypeSqs:
+		integration.SqsConfig = &models.SqsConfig{
+			S3Bucket:          item.SqsConfig.S3Bucket,
+			S3Prefix:          item.SqsConfig.S3Prefix,
+			LogProcessingRole: item.SqsConfig.LogProcessingRole,
+			QueueURL:          item.SqsConfig.QueueURL,
+			LogTypes:          item.SqsConfig.LogTypes,
+			AllowedPrincipals: item.SqsConfig.AllowedPrincipals,
+			AllowedSourceArns: item.SqsConfig.AllowedSourceArns,
+		}
 	}
 	return integration
 }

--- a/internal/core/source_api/api/vars.go
+++ b/internal/core/source_api/api/vars.go
@@ -28,6 +28,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/glue/glueiface"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -51,6 +53,7 @@ var (
 	templateS3Client s3iface.S3API
 	glueClient       glueiface.GlueAPI
 	athenaClient     athenaiface.AthenaAPI
+	lambdaClient     lambdaiface.LambdaAPI
 )
 
 type envConfig struct {
@@ -59,6 +62,10 @@ type envConfig struct {
 	LogProcessorQueueArn    string `required:"true" split_words:"true"`
 	ProcessedDataBucket     string `required:"true" split_words:"true"`
 	TableName               string `required:"true" split_words:"true"`
+	AccountID               string `required:"true" split_words:"true"`
+	InputDataRoleArn        string `required:"true" split_words:"true"`
+	InputDataBucketName     string `required:"true" split_words:"true"`
+	InputDataTopicArn       string `required:"true" split_words:"true"`
 }
 
 // Setup parses the environment and constructs AWS and http clients on a cold Lambda start.
@@ -74,6 +81,7 @@ func Setup() {
 	})
 	glueClient = glue.New(awsSession)
 	athenaClient = athena.New(awsSession)
+	lambdaClient = lambda.New(awsSession)
 }
 
 // API provides receiver methods for each route handler.

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -41,13 +41,25 @@ type Integration struct {
 	S3Bucket          string   `json:"s3Bucket,omitempty"`
 	S3Prefix          string   `json:"s3Prefix,omitempty"`
 	KmsKey            string   `json:"kmsKey,omitempty"`
-	LogTypes          []string `json:"logTypes,omitempty" dynamodbav:"logTypes,stringset"`
+	LogTypes          []string `json:"logTypes,omitempty" dynamodbav:",stringset"`
 	StackName         string   `json:"stackName,omitempty"`
 	LogProcessingRole string   `json:"logProcessingRole,omitempty"`
+
+	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 }
 
 type IntegrationStatus struct {
 	ScanStatus        string     `json:"scanStatus,omitempty"`
 	EventStatus       string     `json:"eventStatus,omitempty"`
 	LastEventReceived *time.Time `json:"lastEventReceived,omitempty"`
+}
+
+type SqsConfig struct {
+	S3Bucket          string   `json:"s3Bucket,omitempty"`
+	S3Prefix          string   `json:"s3Prefix,omitempty"`
+	LogProcessingRole string   `json:"logProcessingRole,omitempty"`
+	LogTypes          []string `json:"logTypes" dynamodbav:",stringset"`
+	AllowedPrincipals []string `json:"allowedPrincipals" dynamodbav:",stringset"`
+	AllowedSourceArns []string `json:"allowedSourceArns" dynamodbav:",stringset"`
+	QueueURL          string   `json:"queueUrl,omitempty"`
 }

--- a/internal/log_analysis/log_processor/sources/message_forwarder_reader.go
+++ b/internal/log_analysis/log_processor/sources/message_forwarder_reader.go
@@ -1,0 +1,64 @@
+package sources
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"bytes"
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/forwarder"
+)
+
+type MessageForwarderReader struct {
+	dec    *jsoniter.Decoder
+	buffer bytes.Buffer
+}
+
+// Reader for messages sent by the Message Forwarder Lambda
+func NewMessageForwarderReader(input io.Reader) *MessageForwarderReader {
+	return &MessageForwarderReader{
+		dec: jsoniter.NewDecoder(input),
+	}
+}
+
+func (r *MessageForwarderReader) Read(p []byte) (n int, err error) {
+	if len(r.buffer.Bytes()) > 0 {
+		return r.buffer.Read(p)
+	}
+	if err = r.fill(); err != nil {
+		return 0, err
+	}
+	return r.buffer.Read(p)
+}
+
+func (r *MessageForwarderReader) fill() error {
+	event := forwarder.Message{}
+	if !r.dec.More() {
+		return io.EOF
+	}
+	if err := r.dec.Decode(&event); err != nil {
+		return err
+	}
+	if _, err := r.buffer.WriteString(event.Payload + "\n"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/log_analysis/log_processor/sources/message_forwarder_reader_test.go
+++ b/internal/log_analysis/log_processor/sources/message_forwarder_reader_test.go
@@ -1,0 +1,108 @@
+package sources
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	forwarderMessagePayload = "test"
+	forwarderMessageSample  = fmt.Sprintf(`{"payload": "%s", "sourceId": "c08e3245-5251-4d72-b9da-46f6b6ac7b30"}`,
+		forwarderMessagePayload)
+)
+
+func TestReadForwarderMessage(t *testing.T) {
+	reader := NewMessageForwarderReader(strings.NewReader(forwarderMessageSample + "\n"))
+
+	result, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, forwarderMessagePayload+"\n", string(result))
+}
+
+func TestReadForwarderMessages(t *testing.T) {
+	reader := NewMessageForwarderReader(strings.NewReader(forwarderMessageSample + "\n" + forwarderMessageSample + "\n"))
+
+	bufferedReader := bufio.NewReader(reader)
+	line, err := bufferedReader.ReadString('\n')
+	require.Equal(t, forwarderMessagePayload+"\n", line)
+	require.NoError(t, err)
+
+	line, err = bufferedReader.ReadString('\n')
+	require.Equal(t, forwarderMessagePayload+"\n", line)
+	require.Error(t, io.EOF, err)
+}
+
+func TestReadForwarderInvalidJson(t *testing.T) {
+	reader := NewMessageForwarderReader(strings.NewReader("{'test':1"))
+	buffer := make([]byte, 10)
+
+	bytesRead, err := reader.Read(buffer)
+
+	require.Equal(t, 0, bytesRead)
+	require.Error(t, io.EOF, err)
+	require.Equal(t, buffer, make([]byte, 10))
+}
+
+func TestReadForwarderEmptyString(t *testing.T) {
+	reader := NewMessageForwarderReader(strings.NewReader(""))
+
+	buffer := make([]byte, 10)
+	bytesRead, err := reader.Read(buffer)
+	require.Equal(t, 0, bytesRead)
+	require.Error(t, io.EOF, err)
+	require.Equal(t, buffer, make([]byte, 10))
+}
+
+func TestReadForwarderMessagePartialRead(t *testing.T) {
+	reader := NewMessageForwarderReader(strings.NewReader(forwarderMessageSample + "\n"))
+
+	// make the buffer intentionally smaller
+	// so that we need to invoke the reader twice
+	truncatedPayloadSize := len(forwarderMessagePayload) - 1
+	buffer := make([]byte, truncatedPayloadSize)
+
+	// should read payload partially
+	bytesRead, err := reader.Read(buffer)
+	require.NoError(t, err)
+	require.Equal(t, truncatedPayloadSize, bytesRead)
+	require.Equal(t, forwarderMessagePayload[:truncatedPayloadSize], string(buffer))
+
+	// clear the buffer
+	buffer = make([]byte, 2)
+	// should read remaining
+	bytesRead, err = reader.Read(buffer)
+	require.NoError(t, err)
+	require.Equal(t, 2, bytesRead)
+	require.Equal(t, forwarderMessagePayload[truncatedPayloadSize:]+"\n", string(buffer))
+
+	// clear the buffer
+	buffer = make([]byte, 1)
+
+	bytesRead, err = reader.Read(buffer)
+	require.Error(t, io.EOF, err)
+	require.Equal(t, 0, bytesRead)
+}

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -242,6 +242,8 @@ func getSourceS3Info(source *models.SourceIntegration) (string, string) {
 	switch source.IntegrationType {
 	case models.IntegrationTypeAWS3:
 		return source.S3Bucket, source.S3Prefix
+	case models.IntegrationTypeSqs:
+		return source.SqsConfig.S3Bucket, source.SqsConfig.S3Prefix
 	}
 	return "", ""
 }
@@ -250,6 +252,8 @@ func getSourceLogProcessingRole(source *models.SourceIntegration) (roleArn strin
 	switch source.IntegrationType {
 	case models.IntegrationTypeAWS3:
 		roleArn = source.LogProcessingRole
+	case models.IntegrationTypeSqs:
+		roleArn = source.SqsConfig.LogProcessingRole
 	}
 	return roleArn
 }

--- a/internal/log_analysis/message_forwarder/cache/cache.go
+++ b/internal/log_analysis/message_forwarder/cache/cache.go
@@ -1,0 +1,66 @@
+package cache
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// A cache that will be refreshed
+type Refreshable struct {
+	kv              map[string]interface{}
+	refreshFunc     func() (map[string]interface{}, error)
+	minimumInterval time.Duration
+	lastRefresh     time.Time
+}
+
+func New(refreshFunc func() (map[string]interface{}, error)) *Refreshable {
+	return &Refreshable{
+		kv:              make(map[string]interface{}),
+		refreshFunc:     refreshFunc,
+		minimumInterval: 1 * time.Minute,
+	}
+}
+
+// Retrieves the value for the provided key from the cache. It will return an empty string if no value was present.
+// If the key is not present in the cache and more than `lastRefresh` time has passed since the last time
+// the cache was refreshed, we try to refresh the cache again.
+func (c *Refreshable) Get(key string) (value interface{}, found bool) {
+	value, found = c.kv[key]
+	// Invoke refresh function if the value was not found
+	// Avoid invoking the refresh function multiple times
+	if !found && time.Since(c.lastRefresh) > c.minimumInterval {
+		c.runRefresh()
+		value, found = c.kv[key]
+	}
+	return value, found
+}
+
+// Runs the fresh method and repopulate the cache
+func (c *Refreshable) runRefresh() {
+	newMap, err := c.refreshFunc()
+	if err != nil {
+		zap.L().Warn("failed to refresh cache", zap.Error(err))
+		return
+	}
+	c.kv = newMap
+	c.lastRefresh = time.Now()
+}

--- a/internal/log_analysis/message_forwarder/cache/cache_test.go
+++ b/internal/log_analysis/message_forwarder/cache/cache_test.go
@@ -1,0 +1,86 @@
+package cache
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var cacheFuncReturnValue = map[string]interface{}{
+	"key": "value",
+}
+
+func TestRetrieveValue(t *testing.T) {
+	timesCalled := 0
+	refreshFunc := func() (map[string]interface{}, error) {
+		timesCalled++
+		return cacheFuncReturnValue, nil
+	}
+	cache := New(refreshFunc)
+	value, ok := cache.Get("key")
+	assert.Equal(t, "value", value)
+	assert.True(t, ok)
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestRetrieveDoesNotExist(t *testing.T) {
+	timesCalled := 0
+	refreshFunc := func() (map[string]interface{}, error) {
+		timesCalled++
+		return cacheFuncReturnValue, nil
+	}
+	cache := New(refreshFunc)
+	value, ok := cache.Get("key-does-not-exist")
+	assert.False(t, ok)
+	assert.Nil(t, value)
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestRetrieveReturnsError(t *testing.T) {
+	timesCalled := 0
+	refreshFunc := func() (map[string]interface{}, error) {
+		timesCalled++
+		return cacheFuncReturnValue, errors.New("error")
+	}
+	cache := New(refreshFunc)
+	value, ok := cache.Get("key-does-not-exist")
+	assert.False(t, ok)
+	assert.Nil(t, value)
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestRetrieveValueShouldRespectMinimumInterval(t *testing.T) {
+	timesCalled := 0
+	refreshFunc := func() (map[string]interface{}, error) {
+		timesCalled++
+		return cacheFuncReturnValue, nil
+	}
+	cache := New(refreshFunc)
+	value, ok := cache.Get("key")
+	assert.Equal(t, "value", value)
+	assert.True(t, ok)
+	// This should not trigger refreshing of the cache
+	value, ok = cache.Get("new-key")
+	assert.Nil(t, value)
+	assert.False(t, ok)
+	assert.Equal(t, 1, timesCalled)
+}

--- a/internal/log_analysis/message_forwarder/config/config.go
+++ b/internal/log_analysis/message_forwarder/config/config.go
@@ -1,0 +1,54 @@
+package config
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
+	"github.com/kelseyhightower/envconfig"
+)
+
+var (
+	Env            EnvConfig
+	awsSession     *session.Session
+	FirehoseClient firehoseiface.FirehoseAPI
+	LambdaClient   lambdaiface.LambdaAPI
+)
+
+const (
+	SourceAPIFunctionName = "panther-source-api"
+	MaxRetries            = 10
+)
+
+type EnvConfig struct {
+	StreamName string `required:"true" split_words:"true"`
+}
+
+// Setup parses the environment and builds the AWS and http clients.
+func Setup() {
+	envconfig.MustProcess("", &Env)
+	awsSession = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(MaxRetries)))
+
+	FirehoseClient = firehose.New(awsSession)
+	LambdaClient = lambda.New(awsSession)
+}

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder.go
@@ -1,0 +1,120 @@
+package forwarder
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	sourcemodels "github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/cache"
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/config"
+	"github.com/panther-labs/panther/pkg/awsbatch/firehosebatch"
+	"github.com/panther-labs/panther/pkg/genericapi"
+)
+
+type Message struct {
+	Payload             string `json:"payload" validate:"required,min=1"`
+	SourceIntegrationID string `json:"sourceId" validate:"required,uuid4"`
+}
+
+const RecordDelimiter = '\n'
+
+var sourcesCache = cache.New(getSourceInfo)
+
+func Handle(ctx context.Context, event *events.SQSEvent) error {
+	var firehoseRecords []*firehose.Record
+	for _, record := range event.Records {
+		queueName := getQueueNameFromArn(record.EventSourceARN)
+		zap.L().Debug("Found queue name", zap.String("queueName", queueName))
+		cacheValue, ok := sourcesCache.Get(queueName)
+		// Integration ID not present, skipping
+		if !ok {
+			zap.L().Warn("didn't find integrationId for message, skipping")
+			continue
+		}
+		integrationID := cacheValue.(string)
+		zap.L().Debug("Found integration", zap.String("integrationId", integrationID))
+		message := Message{
+			Payload:             record.Body,
+			SourceIntegrationID: integrationID,
+		}
+		data, err := jsoniter.Marshal(message)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal event")
+		}
+		// Adding new line
+		data = append(data, RecordDelimiter)
+		firehoseRecords = append(firehoseRecords, &firehose.Record{Data: data})
+	}
+
+	zap.L().Debug("Sending data", zap.Int("size", len(firehoseRecords)))
+
+	if len(firehoseRecords) == 0 {
+		zap.L().Debug("No records to process")
+		return nil
+	}
+	// Maximum Kinesis Firehose batch put request is 4MB, maximum SQS queue message size is 256KB
+	// Since each Lambda invocation pulls up to 10 messages, each PutRecordBatch request cannot reach the 4MB limit.
+	request := firehose.PutRecordBatchInput{
+		Records:            firehoseRecords,
+		DeliveryStreamName: &config.Env.StreamName,
+	}
+	return firehosebatch.Send(ctx, config.FirehoseClient, request, config.MaxRetries)
+}
+
+func getSourceInfo() (map[string]interface{}, error) {
+	input := &sourcemodels.LambdaInput{ListIntegrations: &sourcemodels.ListIntegrationsInput{
+		IntegrationType: aws.String(sourcemodels.IntegrationTypeSqs),
+	}}
+	var output []*sourcemodels.SourceIntegration
+	err := genericapi.Invoke(config.LambdaClient, config.SourceAPIFunctionName, input, &output)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch available integrations")
+	}
+	result := make(map[string]interface{}, len(output))
+	for _, source := range output {
+		result[getQueueNameFromURL(source.SqsConfig.QueueURL)] = source.IntegrationID
+	}
+	return result, nil
+}
+
+func getQueueNameFromArn(queueArn string) string {
+	parseArn, err := arn.Parse(queueArn)
+	if err != nil {
+		panic("failed to parse Queue arn")
+	}
+	return parseArn.Resource
+}
+
+func getQueueNameFromURL(queueURL string) string {
+	urlParts := strings.Split(queueURL, "/")
+	if len(urlParts) == 0 {
+		panic("failed to parse queue URL")
+	}
+	return urlParts[len(urlParts)-1]
+}

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
@@ -1,0 +1,250 @@
+package forwarder
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/cache"
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/config"
+	"github.com/panther-labs/panther/pkg/testutils"
+)
+
+var availableSqsSources = []*models.SourceIntegration{
+	{
+		SourceIntegrationMetadata: models.SourceIntegrationMetadata{
+			IntegrationID:   "45c378a7-2e36-4b12-8e16-2d3c49ff1371",
+			IntegrationType: models.IntegrationTypeSqs,
+			SqsConfig: &models.SqsConfig{
+				QueueURL: "https://sqs.eu-west-2.amazonaws.com/123456789012/test-queue-1",
+			},
+		},
+	},
+	{
+		SourceIntegrationMetadata: models.SourceIntegrationMetadata{
+			IntegrationID:   "45c378a7-2e36-4b12-8e16-2d3c49ff1372",
+			IntegrationType: models.IntegrationTypeSqs,
+			SqsConfig: &models.SqsConfig{
+				QueueURL: "https://sqs.eu-west-2.amazonaws.com/123456789012/test-queue-2",
+			},
+		},
+	},
+}
+
+func TestShouldSendBatchRequest(t *testing.T) {
+	mockLambda := &testutils.LambdaMock{}
+	config.LambdaClient = mockLambda
+	mockFirehose := &testutils.FirehoseMock{}
+	config.FirehoseClient = mockFirehose
+	config.Env.StreamName = "testStreamName"
+	resetCache()
+
+	sqsEvent := &events.SQSEvent{
+		Records: []events.SQSMessage{
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:test-queue-1",
+				Body:           "payload1",
+			},
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:test-queue-2",
+				Body:           "payload2",
+			},
+		},
+	}
+
+	marshaledSources, err := jsoniter.Marshal(availableSqsSources)
+	require.NoError(t, err)
+
+	mockLambda.On("Invoke", mock.Anything).Return(
+		&lambda.InvokeOutput{
+			Payload:    marshaledSources,
+			StatusCode: aws.Int64(http.StatusOK),
+		}, nil)
+
+	expectedForwarderMessages := []Message{
+		{
+			Payload:             "payload1",
+			SourceIntegrationID: "45c378a7-2e36-4b12-8e16-2d3c49ff1371",
+		},
+		{
+			Payload:             "payload2",
+			SourceIntegrationID: "45c378a7-2e36-4b12-8e16-2d3c49ff1372",
+		},
+	}
+	var expectedFirehoseRecords []*firehose.Record
+	for _, message := range expectedForwarderMessages {
+		serializedMsg, err := jsoniter.MarshalToString(message)
+		require.NoError(t, err)
+		expectedFirehoseRecords = append(expectedFirehoseRecords, &firehose.Record{
+			Data: []byte(serializedMsg + "\n"),
+		})
+	}
+
+	expectedFirehoseInput := &firehose.PutRecordBatchInput{
+		Records:            expectedFirehoseRecords,
+		DeliveryStreamName: aws.String("testStreamName"),
+	}
+	mockFirehose.On("PutRecordBatchWithContext", mock.Anything, expectedFirehoseInput, mock.Anything).
+		Return(&firehose.PutRecordBatchOutput{}, nil)
+
+	require.NoError(t, Handle(context.TODO(), sqsEvent))
+
+	mockLambda.AssertExpectations(t)
+	mockFirehose.AssertExpectations(t)
+}
+
+func TestShouldSkipMessagesNotRelatedToSource(t *testing.T) {
+	mockLambda := &testutils.LambdaMock{}
+	config.LambdaClient = mockLambda
+	mockFirehose := &testutils.FirehoseMock{}
+	config.FirehoseClient = mockFirehose
+	config.Env.StreamName = "testStreamName"
+	resetCache()
+
+	sqsEvent := &events.SQSEvent{
+		Records: []events.SQSMessage{
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:test-queue-1",
+				Body:           "payload1",
+			},
+			// This message is coming from an unregistered queue and should be ignored
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:unregistered-queue",
+				Body:           "payload2",
+			},
+		},
+	}
+
+	marshaledSources, err := jsoniter.Marshal(availableSqsSources)
+	require.NoError(t, err)
+
+	mockLambda.On("Invoke", mock.Anything).Return(
+		&lambda.InvokeOutput{
+			Payload:    marshaledSources,
+			StatusCode: aws.Int64(http.StatusOK),
+		}, nil)
+
+	expectedForwarderMessage := Message{
+		Payload:             "payload1",
+		SourceIntegrationID: "45c378a7-2e36-4b12-8e16-2d3c49ff1371",
+	}
+
+	serializedMsg, err := jsoniter.MarshalToString(expectedForwarderMessage)
+	require.NoError(t, err)
+	expectedFirehoseRecord := &firehose.Record{
+		Data: []byte(serializedMsg + "\n"),
+	}
+
+	expectedFirehoseInput := &firehose.PutRecordBatchInput{
+		Records:            []*firehose.Record{expectedFirehoseRecord},
+		DeliveryStreamName: aws.String("testStreamName"),
+	}
+
+	mockFirehose.On("PutRecordBatchWithContext", mock.Anything, expectedFirehoseInput, mock.Anything).
+		Return(&firehose.PutRecordBatchOutput{}, nil)
+
+	require.NoError(t, Handle(context.TODO(), sqsEvent))
+
+	mockLambda.AssertExpectations(t)
+	mockFirehose.AssertExpectations(t)
+}
+
+func TestShouldFailIfPartialFailureToPutRecord(t *testing.T) {
+	mockLambda := &testutils.LambdaMock{}
+	config.LambdaClient = mockLambda
+	mockFirehose := &testutils.FirehoseMock{}
+	config.FirehoseClient = mockFirehose
+	resetCache()
+
+	sqsEvent := &events.SQSEvent{
+		Records: []events.SQSMessage{
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:test-queue-1",
+				Body:           "payload1",
+			},
+		},
+	}
+
+	marshaledSources, err := jsoniter.Marshal(availableSqsSources)
+	require.NoError(t, err)
+
+	mockLambda.On("Invoke", mock.Anything).Return(
+		&lambda.InvokeOutput{
+			Payload:    marshaledSources,
+			StatusCode: aws.Int64(http.StatusOK),
+		}, nil)
+
+	mockFirehose.On("PutRecordBatchWithContext", mock.Anything, mock.Anything, mock.Anything).Return(
+		&firehose.PutRecordBatchOutput{FailedPutCount: aws.Int64(1)}, nil)
+
+	require.Error(t, Handle(context.TODO(), sqsEvent))
+
+	mockLambda.AssertExpectations(t)
+	mockFirehose.AssertExpectations(t)
+}
+
+func TestShouldFailIfFailureToPutRecord(t *testing.T) {
+	mockLambda := &testutils.LambdaMock{}
+	config.LambdaClient = mockLambda
+	mockFirehose := &testutils.FirehoseMock{}
+	config.FirehoseClient = mockFirehose
+	resetCache()
+
+	sqsEvent := &events.SQSEvent{
+		Records: []events.SQSMessage{
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:test-queue-1",
+				Body:           "payload1",
+			},
+		},
+	}
+
+	marshaledSources, err := jsoniter.Marshal(availableSqsSources)
+	require.NoError(t, err)
+
+	mockLambda.On("Invoke", mock.Anything).Return(
+		&lambda.InvokeOutput{
+			Payload:    marshaledSources,
+			StatusCode: aws.Int64(http.StatusOK),
+		}, nil)
+
+	mockFirehose.On("PutRecordBatchWithContext", mock.Anything, mock.Anything, mock.Anything).Return(
+		&firehose.PutRecordBatchOutput{}, errors.New("error"))
+
+	require.Error(t, Handle(context.TODO(), sqsEvent))
+
+	mockLambda.AssertExpectations(t)
+	mockFirehose.AssertExpectations(t)
+}
+
+func resetCache() {
+	sourcesCache = cache.New(getSourceInfo)
+}

--- a/internal/log_analysis/message_forwarder/main/lambda.go
+++ b/internal/log_analysis/message_forwarder/main/lambda.go
@@ -1,0 +1,48 @@
+package main
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	"go.uber.org/zap"
+
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/config"
+	"github.com/panther-labs/panther/internal/log_analysis/message_forwarder/forwarder"
+	"github.com/panther-labs/panther/pkg/lambdalogger"
+	"github.com/panther-labs/panther/pkg/oplog"
+)
+
+func main() {
+	lambda.Start(handle)
+}
+
+func handle(ctx context.Context, event *events.SQSEvent) (err error) {
+	config.Setup()
+	lc, _ := lambdalogger.ConfigureGlobal(ctx, nil)
+	operation := oplog.NewManager("log_analysis", "message_forwarder").
+		Start(lc.InvokedFunctionArn, zap.String("service", "lambda")).
+		WithMemUsed(lambdacontext.MemoryLimitInMB)
+	defer operation.Stop().Log(err)
+	err = forwarder.Handle(ctx, event)
+	return err
+}

--- a/pkg/awsbatch/firehosebatch/firehosebatch.go
+++ b/pkg/awsbatch/firehosebatch/firehosebatch.go
@@ -1,0 +1,78 @@
+package firehosebatch
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
+)
+
+// Will call PutRecordBatch, retrying individual record failures.
+// TODO  This method doesn't currently handle  requests greater than 4MB or 500 records
+func Send(ctx context.Context, client firehoseiface.FirehoseAPI, input firehose.PutRecordBatchInput, maxRetries int) error {
+	batchRequest := &request{
+		ctx:              ctx,
+		client:           client,
+		streamName:       input.DeliveryStreamName,
+		remainingRecords: input.Records,
+	}
+	operationBackoff := backoff.WithContext(
+		backoff.WithMaxRetries(
+			backoff.NewExponentialBackOff(), uint64(maxRetries)),
+		ctx)
+	if err := backoff.Retry(batchRequest.send, operationBackoff); err != nil {
+		return errors.Wrap(err, "failed to send PutRecordBatch")
+	}
+	return nil
+}
+
+type request struct {
+	ctx              context.Context
+	client           firehoseiface.FirehoseAPI
+	streamName       *string
+	remainingRecords []*firehose.Record
+}
+
+func (r *request) send() error {
+	request := &firehose.PutRecordBatchInput{
+		DeliveryStreamName: r.streamName,
+		Records:            r.remainingRecords,
+	}
+	response, err := r.client.PutRecordBatchWithContext(r.ctx, request)
+	if err != nil {
+		return err
+	}
+	if aws.Int64Value(response.FailedPutCount) == 0 {
+		return nil
+	}
+
+	var recordsToRetry []*firehose.Record
+	for i, record := range response.RequestResponses {
+		if record.ErrorCode != nil {
+			recordsToRetry = append(recordsToRetry, request.Records[i])
+		}
+	}
+	r.remainingRecords = recordsToRetry
+	return errors.Errorf("failed to send %d events", len(recordsToRetry))
+}

--- a/pkg/awsbatch/firehosebatch/firehosebatch_test.go
+++ b/pkg/awsbatch/firehosebatch/firehosebatch_test.go
@@ -1,0 +1,140 @@
+package firehosebatch
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/pkg/testutils"
+)
+
+func TestRetryInCaseOfError(t *testing.T) {
+	t.Parallel()
+	mockClient := &testutils.FirehoseMock{}
+	input := firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String("stream"),
+	}
+	mockClient.On("PutRecordBatchWithContext", mock.Anything, &input, mock.Anything).
+		Return(&firehose.PutRecordBatchOutput{}, errors.New("failure")).Times(3)
+
+	require.Error(t, Send(context.TODO(), mockClient, input, 2))
+	mockClient.AssertExpectations(t)
+}
+
+func TestDoNotRetryIfContextCancelled(t *testing.T) {
+	t.Parallel()
+	mockClient := &testutils.FirehoseMock{}
+	input := firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String("stream"),
+	}
+	ctx, cancelFun := context.WithCancel(context.Background())
+	// Cancelling the context. We shouldn't retry
+	cancelFun()
+	// This operation should run only once - we shouldn't retry since context has been cancelled
+	mockClient.On("PutRecordBatchWithContext", mock.Anything, &input, mock.Anything).
+		Return(&firehose.PutRecordBatchOutput{}, errors.New("failure")).Once()
+
+	require.Error(t, Send(ctx, mockClient, input, 2))
+	mockClient.AssertExpectations(t)
+}
+
+func TestRetryIfPartialFailure(t *testing.T) {
+	t.Parallel()
+	mockClient := &testutils.FirehoseMock{}
+	input := firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String("stream"),
+		Records: []*firehose.Record{
+			{
+				Data: []byte("record1"),
+			},
+			{
+				Data: []byte("record2"),
+			},
+		},
+	}
+	partialFailureOutput := &firehose.PutRecordBatchOutput{
+		FailedPutCount: aws.Int64(1),
+		RequestResponses: []*firehose.PutRecordBatchResponseEntry{
+			{
+				RecordId: aws.String("1"), //  record succeeded
+			},
+			{
+				ErrorCode: aws.String("error"), // record failed
+			},
+		},
+	}
+	partialRequestInput := &firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String("stream"),
+		Records: []*firehose.Record{
+			{
+				Data: []byte("record2"),
+			},
+		},
+	}
+	mockClient.On("PutRecordBatchWithContext", mock.Anything, &input, mock.Anything).
+		Return(partialFailureOutput, nil).Once()
+	mockClient.On("PutRecordBatchWithContext", mock.Anything, partialRequestInput, mock.Anything).
+		Return(&firehose.PutRecordBatchOutput{}, nil).Once()
+
+	require.NoError(t, Send(context.TODO(), mockClient, input, 2))
+	mockClient.AssertExpectations(t)
+}
+
+func TestFailIfPartialRetriesFailed(t *testing.T) {
+	t.Parallel()
+	mockClient := &testutils.FirehoseMock{}
+	input := firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String("stream"),
+		Records: []*firehose.Record{
+			{
+				Data: []byte("record"),
+			},
+		},
+	}
+	partialFailureOutput := &firehose.PutRecordBatchOutput{
+		FailedPutCount: aws.Int64(1),
+		RequestResponses: []*firehose.PutRecordBatchResponseEntry{
+			{
+				ErrorCode: aws.String("error"), // record failed
+			},
+		},
+	}
+	partialRequestInput := &firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String("stream"),
+		Records: []*firehose.Record{
+			{
+				Data: []byte("record"),
+			},
+		},
+	}
+	mockClient.On("PutRecordBatchWithContext", mock.Anything, &input, mock.Anything).
+		Return(partialFailureOutput, nil).Once()
+	mockClient.On("PutRecordBatchWithContext", mock.Anything, partialRequestInput, mock.Anything).
+		Return(partialFailureOutput, nil).Twice()
+
+	require.Error(t, Send(context.TODO(), mockClient, input, 2))
+	mockClient.AssertExpectations(t)
+}

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -19,12 +19,16 @@ package testutils
  */
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/glue/glueiface"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -60,6 +64,11 @@ func (m *S3Mock) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error
 	return args.Get(0).(*s3.GetObjectOutput), args.Error(1)
 }
 
+func (m *S3Mock) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, options ...request.Option) (*s3.GetObjectOutput, error) {
+	args := m.Called(ctx, input, options)
+	return args.Get(0).(*s3.GetObjectOutput), args.Error(1)
+}
+
 func (m *S3Mock) GetBucketLocation(input *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*s3.GetBucketLocationOutput), args.Error(1)
@@ -67,6 +76,14 @@ func (m *S3Mock) GetBucketLocation(input *s3.GetBucketLocationInput) (*s3.GetBuc
 
 func (m *S3Mock) ListObjectsV2Pages(input *s3.ListObjectsV2Input, f func(page *s3.ListObjectsV2Output, morePages bool) bool) error {
 	args := m.Called(input, f)
+	f(args.Get(0).(*s3.ListObjectsV2Output), false)
+	return args.Error(1)
+}
+
+func (m *S3Mock) ListObjectsV2PagesWithContext(ctx aws.Context, input *s3.ListObjectsV2Input,
+	f func(page *s3.ListObjectsV2Output, morePages bool) bool, options ...request.Option) error {
+
+	args := m.Called(ctx, input, f, options)
 	f(args.Get(0).(*s3.ListObjectsV2Output), false)
 	return args.Error(1)
 }
@@ -79,6 +96,25 @@ type LambdaMock struct {
 func (m *LambdaMock) Invoke(input *lambda.InvokeInput) (*lambda.InvokeOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*lambda.InvokeOutput), args.Error(1)
+}
+
+func (m *LambdaMock) CreateEventSourceMapping(
+	input *lambda.CreateEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error) {
+
+	args := m.Called(input)
+	return args.Get(0).(*lambda.EventSourceMappingConfiguration), args.Error(1)
+}
+
+func (m *LambdaMock) ListEventSourceMappings(input *lambda.ListEventSourceMappingsInput) (*lambda.ListEventSourceMappingsOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*lambda.ListEventSourceMappingsOutput), args.Error(1)
+}
+
+func (m *LambdaMock) DeleteEventSourceMapping(
+	input *lambda.DeleteEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error) {
+
+	args := m.Called(input)
+	return args.Get(0).(*lambda.EventSourceMappingConfiguration), args.Error(1)
 }
 
 type DynamoDBMock struct {
@@ -144,6 +180,16 @@ func (m *SqsMock) DeleteMessageBatch(input *sqs.DeleteMessageBatchInput) (*sqs.D
 func (m *SqsMock) ReceiveMessage(input *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*sqs.ReceiveMessageOutput), args.Error(1)
+}
+
+func (m *SqsMock) CreateQueue(input *sqs.CreateQueueInput) (*sqs.CreateQueueOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.CreateQueueOutput), args.Error(1)
+}
+
+func (m *SqsMock) DeleteQueue(input *sqs.DeleteQueueInput) (*sqs.DeleteQueueOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.DeleteQueueOutput), args.Error(1)
 }
 
 type EventBridgeMock struct {
@@ -244,4 +290,18 @@ type SnsMock struct {
 func (m *SnsMock) Publish(input *sns.PublishInput) (*sns.PublishOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*sns.PublishOutput), args.Error(1)
+}
+
+type FirehoseMock struct {
+	firehoseiface.FirehoseAPI
+	mock.Mock
+}
+
+func (m *FirehoseMock) PutRecordBatchWithContext(
+	ctx aws.Context,
+	input *firehose.PutRecordBatchInput,
+	options ...request.Option) (*firehose.PutRecordBatchOutput, error) {
+
+	args := m.Called(ctx, input, options)
+	return args.Get(0).(*firehose.PutRecordBatchOutput), args.Error(1)
 }

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -478,6 +478,8 @@ func deployCoreStack(settings *config.PantherConfig, outputs map[string]string) 
 		"SqsKeyId":                   outputs["QueueEncryptionKeyId"],
 		"TracingMode":                settings.Monitoring.TracingMode,
 		"UserPoolId":                 outputs["UserPoolId"],
+		"InputDataBucket":            outputs["InputDataBucket"],
+		"InputDataTopicArn":          outputs["InputDataTopicArn"],
 	})
 	return err
 }
@@ -513,6 +515,8 @@ func deployLogAnalysisStack(settings *config.PantherConfig, outputs map[string]s
 		"SqsKeyId":                     outputs["QueueEncryptionKeyId"],
 		"TablesSignature":              tablesSignature,
 		"TracingMode":                  settings.Monitoring.TracingMode,
+		"InputDataBucket":              outputs["InputDataBucket"],
+		"InputDataTopicArn":            outputs["InputDataTopicArn"],
 	})
 	return err
 }


### PR DESCRIPTION
## Background

Adding new SQS Source type. 
This is an import from code already in enterprise. 

## Testing

- `mage test:ci`
- Deployed to account. Verified: 
1. Create/Update/Delete source
2. Sending messages to SQS queue. Seeing log processor process it as expected. 
