### PR TITLE
Support rule threshold

### DIFF
--- a/api/gateway/analysis/api.yml
+++ b/api/gateway/analysis/api.yml
@@ -1259,6 +1259,8 @@ definitions:
         $ref: '#/definitions/dedupPeriodMinutes'
       reports:
         $ref: '#/definitions/reports'
+      threshold:
+        $ref: '#/definitions/threshold'
     required:
       - body
       - createdAt
@@ -1279,6 +1281,7 @@ definitions:
       - versionId
       - dedupPeriodMinutes
       - reports
+      - threshold
 
   UpdateRule:
     type: object
@@ -1313,6 +1316,8 @@ definitions:
         $ref: '#/definitions/dedupPeriodMinutes'
       reports:
         $ref: '#/definitions/reports'
+      threshold:
+        $ref: '#/definitions/threshold'
     required:
       - body
       - enabled
@@ -1430,6 +1435,12 @@ definitions:
     maximum: 1440 # 1 day in minutes
     default: 60
 
+  threshold:
+    description: The threshold (number of events) that will have to be reached during the dedupPeriodMinutes in order for the rule to fire an alarm
+    type: integer
+    minimum: 0
+    default: 0
+
   description:
     description: Summary of the policy and its purpose
     type: string
@@ -1456,7 +1467,7 @@ definitions:
 
   outputIds:
     description: >
-      A list of destinations IDs to send an alert that overrides the 
+      A list of destinations IDs to send an alert that overrides the
       severity rating triggers set in the destination itself.
     type: array
     maxItems: 500

--- a/api/gateway/analysis/models/rule.go
+++ b/api/gateway/analysis/models/rule.go
@@ -109,6 +109,10 @@ type Rule struct {
 	// Required: true
 	Tests TestSuite `json:"tests"`
 
+	// threshold
+	// Required: true
+	Threshold Threshold `json:"threshold"`
+
 	// version Id
 	// Required: true
 	VersionID VersionID `json:"versionId"`
@@ -187,6 +191,10 @@ func (m *Rule) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateTests(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateThreshold(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -425,6 +433,18 @@ func (m *Rule) validateTests(formats strfmt.Registry) error {
 	if err := m.Tests.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tests")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *Rule) validateThreshold(formats strfmt.Registry) error {
+
+	if err := m.Threshold.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("threshold")
 		}
 		return err
 	}

--- a/api/gateway/analysis/models/threshold.go
+++ b/api/gateway/analysis/models/threshold.go
@@ -24,39 +24,22 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"strconv"
-
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/validate"
 )
 
-// OutputIds A list of destinations IDs to send an alert that overrides the severity rating triggers set in the destination itself.
+// Threshold The threshold (number of events) that will have to be reached during the dedupPeriodMinutes in order for the rule to fire an alarm
 //
-//
-// swagger:model outputIds
-type OutputIds []string
+// swagger:model threshold
+type Threshold int64
 
-// Validate validates this output ids
-func (m OutputIds) Validate(formats strfmt.Registry) error {
+// Validate validates this threshold
+func (m Threshold) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	iOutputIdsSize := int64(len(m))
-
-	if err := validate.MaxItems("", "body", iOutputIdsSize, 500); err != nil {
+	if err := validate.MinimumInt("", "body", int64(m), 0, false); err != nil {
 		return err
-	}
-
-	if err := validate.UniqueItems("", "body", m); err != nil {
-		return err
-	}
-
-	for i := 0; i < len(m); i++ {
-
-		if err := validate.Pattern(strconv.Itoa(i), "body", string(m[i]), `[a-zA-Z0-9\-\. ]{1,200}`); err != nil {
-			return err
-		}
-
 	}
 
 	if len(res) > 0 {

--- a/api/gateway/analysis/models/update_rule.go
+++ b/api/gateway/analysis/models/update_rule.go
@@ -80,6 +80,9 @@ type UpdateRule struct {
 	// tests
 	Tests TestSuite `json:"tests,omitempty"`
 
+	// threshold
+	Threshold Threshold `json:"threshold,omitempty"`
+
 	// user Id
 	// Required: true
 	UserID UserID `json:"userId"`
@@ -142,6 +145,10 @@ func (m *UpdateRule) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateTests(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateThreshold(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -356,6 +363,22 @@ func (m *UpdateRule) validateTests(formats strfmt.Registry) error {
 	if err := m.Tests.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tests")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *UpdateRule) validateThreshold(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Threshold) { // not required
+		return nil
+	}
+
+	if err := m.Threshold.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("threshold")
 		}
 		return err
 	}

--- a/internal/core/analysis_api/handlers/create_rule.go
+++ b/internal/core/analysis_api/handlers/create_rule.go
@@ -55,6 +55,7 @@ func CreateRule(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyR
 	item := &tableItem{
 		Body:               input.Body,
 		DedupPeriodMinutes: input.DedupPeriodMinutes,
+		Threshold:          input.Threshold,
 		Description:        input.Description,
 		DisplayName:        input.DisplayName,
 		Enabled:            input.Enabled,

--- a/internal/core/analysis_api/handlers/dynamo.go
+++ b/internal/core/analysis_api/handlers/dynamo.go
@@ -53,6 +53,7 @@ type tableItem struct {
 	CreatedAt                 models.ModifyTime                `json:"createdAt"`
 	CreatedBy                 models.UserID                    `json:"createdBy"`
 	DedupPeriodMinutes        models.DedupPeriodMinutes        `json:"dedupPeriodMinutes,omitempty"`
+	Threshold                 models.Threshold                 `json:"threshold,omitempty"`
 	Description               models.Description               `json:"description,omitempty"`
 	DisplayName               models.DisplayName               `json:"displayName,omitempty"`
 	Enabled                   models.Enabled                   `json:"enabled"`
@@ -168,6 +169,7 @@ func (r *tableItem) Rule() *models.Rule {
 		Tests:              r.Tests,
 		VersionID:          r.VersionID,
 		DedupPeriodMinutes: r.DedupPeriodMinutes,
+		Threshold:          r.Threshold,
 	}
 	gatewayapi.ReplaceMapSliceNils(result)
 	return result

--- a/internal/core/analysis_api/handlers/modify_rule.go
+++ b/internal/core/analysis_api/handlers/modify_rule.go
@@ -46,6 +46,7 @@ func ModifyRule(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyR
 	item := &tableItem{
 		Body:               input.Body,
 		DedupPeriodMinutes: input.DedupPeriodMinutes,
+		Threshold:          input.Threshold,
 		Description:        input.Description,
 		DisplayName:        input.DisplayName,
 		Enabled:            input.Enabled,

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -204,6 +204,7 @@ var (
 		OutputIds:          []string{"test-output1", "test-output2"},
 		Reports:            map[string][]string{},
 		DedupPeriodMinutes: 1440,
+		Threshold:          10,
 	}
 
 	global = &models.Global{
@@ -783,6 +784,7 @@ func createRuleSuccess(t *testing.T) {
 			DedupPeriodMinutes: rule.DedupPeriodMinutes,
 			Tags:               rule.Tags,
 			OutputIds:          rule.OutputIds,
+			Threshold:          rule.Threshold,
 		},
 		HTTPClient: httpClient,
 	})
@@ -1004,6 +1006,7 @@ func modifyRule(t *testing.T) {
 	expectedRule := *rule
 	expectedRule.Description = "SkyNet integration"
 	expectedRule.DedupPeriodMinutes = 60
+	expectedRule.Threshold = rule.Threshold + 1
 
 	result, err := apiClient.Operations.ModifyRule(&operations.ModifyRuleParams{
 		Body: &models.UpdateRule{
@@ -1017,6 +1020,7 @@ func modifyRule(t *testing.T) {
 			DedupPeriodMinutes: expectedRule.DedupPeriodMinutes,
 			Tags:               expectedRule.Tags,
 			OutputIds:          expectedRule.OutputIds,
+			Threshold:          expectedRule.Threshold,
 		},
 		HTTPClient: httpClient,
 	})

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -52,13 +52,13 @@ func (h *Handler) Do(oldAlertDedupEvent, newAlertDedupEvent *AlertDedupEvent) (e
 	if oldAlertDedupEvent != nil {
 		oldRule, err = h.Cache.Get(oldAlertDedupEvent.RuleID, oldAlertDedupEvent.RuleVersion)
 		if err != nil {
-			return errors.Wrap(err, "failed to get rule information")
+			return errors.Wrapf(err, "failed to get rule information for %s.%s", oldAlertDedupEvent.RuleID, oldAlertDedupEvent.RuleVersion)
 		}
 	}
 
 	newRule, err := h.Cache.Get(newAlertDedupEvent.RuleID, newAlertDedupEvent.RuleVersion)
 	if err != nil {
-		return errors.Wrap(err, "failed to get rule information")
+		return errors.Wrapf(err, "failed to get rule information for %s.%s", newAlertDedupEvent.RuleID, newAlertDedupEvent.RuleVersion)
 	}
 
 	if shouldIgnoreChange(newRule, newAlertDedupEvent) {

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -88,6 +88,7 @@ var (
 )
 
 func TestHandleStoreAndSendNotification(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -153,6 +154,7 @@ func TestHandleStoreAndSendNotification(t *testing.T) {
 }
 
 func TestHandleStoreAndSendNotificationNoRuleDisplayNameNoTitle(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -235,6 +237,7 @@ func TestHandleStoreAndSendNotificationNoRuleDisplayNameNoTitle(t *testing.T) {
 }
 
 func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -311,6 +314,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 }
 
 func TestHandleStoreAndSendNotificationNilOldDedup(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -376,6 +380,7 @@ func TestHandleStoreAndSendNotificationNilOldDedup(t *testing.T) {
 }
 
 func TestHandleUpdateAlert(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -429,6 +434,7 @@ func TestHandleUpdateAlert(t *testing.T) {
 }
 
 func TestHandleUpdateAlertDDBError(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -463,6 +469,7 @@ func TestHandleUpdateAlertDDBError(t *testing.T) {
 }
 
 func TestHandleShouldNotCreateOrUpdateAlertIfThresholdNotReached(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}
@@ -498,6 +505,7 @@ func TestHandleShouldNotCreateOrUpdateAlertIfThresholdNotReached(t *testing.T) {
 }
 
 func TestHandleShouldCreateAlertIfThresholdNowReached(t *testing.T) {
+	t.Parallel()
 	ddbMock := &testutils.DynamoDBMock{}
 	sqsMock := &testutils.SqsMock{}
 	mockRoundTripper := &mockRoundTripper{}

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -223,11 +223,21 @@ func TestHandleStoreAndSendNotificationNoRuleDisplayNameNoTitle(t *testing.T) {
 	sqsMock.On("SendMessage", expectedSendMessageInput).Return(&sqs.SendMessageOutput{}, nil)
 
 	expectedAlert := &Alert{
-		ID:              "b25dc23fb2a0b362da8428dbec1381a8",
-		TimePartition:   "defaultPartition",
-		Severity:        string(testRuleResponse.Severity),
-		Title:           newAlertDedupEventWithoutTitle.RuleID,
-		AlertDedupEvent: *newAlertDedupEventWithoutTitle,
+		ID:            "b25dc23fb2a0b362da8428dbec1381a8",
+		TimePartition: "defaultPartition",
+		Severity:      string(testRuleResponse.Severity),
+		Title:         newAlertDedupEventWithoutTitle.RuleID,
+		AlertDedupEvent: AlertDedupEvent{
+			RuleID:              newAlertDedupEventWithoutTitle.RuleID,
+			RuleVersion:         newAlertDedupEventWithoutTitle.RuleVersion,
+			LogTypes:            newAlertDedupEventWithoutTitle.LogTypes,
+			EventCount:          newAlertDedupEventWithoutTitle.EventCount,
+			AlertCount:          newAlertDedupEventWithoutTitle.AlertCount,
+			DeduplicationString: newAlertDedupEventWithoutTitle.DeduplicationString,
+			GeneratedTitle:      newAlertDedupEventWithoutTitle.GeneratedTitle,
+			UpdateTime:          newAlertDedupEventWithoutTitle.UpdateTime,
+			CreationTime:        newAlertDedupEventWithoutTitle.UpdateTime,
+		},
 	}
 
 	expectedMarshaledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)
@@ -293,7 +303,17 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 		Severity:        string(testRuleResponse.Severity),
 		RuleDisplayName: aws.String(string(testRuleResponse.DisplayName)),
 		Title:           "DisplayName",
-		AlertDedupEvent: *newAlertDedupEvent,
+		AlertDedupEvent: AlertDedupEvent{
+			RuleID:              newAlertDedupEvent.RuleID,
+			RuleVersion:         newAlertDedupEvent.RuleVersion,
+			LogTypes:            newAlertDedupEvent.LogTypes,
+			EventCount:          newAlertDedupEvent.EventCount,
+			AlertCount:          newAlertDedupEvent.AlertCount,
+			DeduplicationString: newAlertDedupEvent.DeduplicationString,
+			GeneratedTitle:      newAlertDedupEvent.GeneratedTitle,
+			UpdateTime:          newAlertDedupEvent.UpdateTime,
+			CreationTime:        newAlertDedupEvent.UpdateTime,
+		},
 	}
 
 	expectedMarshaledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)
@@ -309,7 +329,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 		RuleVersion:         newAlertDedupEvent.RuleVersion,
 		DeduplicationString: newAlertDedupEvent.DeduplicationString,
 		AlertCount:          newAlertDedupEvent.AlertCount,
-		CreationTime:        newAlertDedupEvent.CreationTime,
+		CreationTime:        newAlertDedupEvent.UpdateTime,
 		UpdateTime:          newAlertDedupEvent.UpdateTime,
 		EventCount:          newAlertDedupEvent.EventCount,
 		LogTypes:            newAlertDedupEvent.LogTypes,

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -275,7 +275,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 	}
 
 	expectedAlertNotification := &alertModel.Alert{
-		CreatedAt:           newAlertDedupEvent.CreationTime,
+		CreatedAt:           newAlertDedupEvent.UpdateTime,
 		AnalysisDescription: aws.String(string(testRuleResponse.Description)),
 		AnalysisID:          newAlertDedupEvent.RuleID,
 		Version:             aws.String(newAlertDedupEvent.RuleVersion),
@@ -329,7 +329,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 		RuleVersion:         newAlertDedupEvent.RuleVersion,
 		DeduplicationString: newAlertDedupEvent.DeduplicationString,
 		AlertCount:          newAlertDedupEvent.AlertCount,
-		CreationTime:        newAlertDedupEvent.UpdateTime,
+		CreationTime:        newAlertDedupEvent.CreationTime,
 		UpdateTime:          newAlertDedupEvent.UpdateTime,
 		EventCount:          newAlertDedupEvent.EventCount,
 		LogTypes:            newAlertDedupEvent.LogTypes,
@@ -362,7 +362,7 @@ func TestHandleStoreAndSendNotificationNilOldDedup(t *testing.T) {
 	}
 
 	expectedAlertNotification := &alertModel.Alert{
-		CreatedAt:           newAlertDedupEvent.CreationTime,
+		CreatedAt:           newAlertDedupEvent.UpdateTime,
 		AnalysisDescription: aws.String(string(testRuleResponse.Description)),
 		AnalysisID:          newAlertDedupEvent.RuleID,
 		AnalysisName:        aws.String(string(testRuleResponse.DisplayName)),
@@ -390,7 +390,17 @@ func TestHandleStoreAndSendNotificationNilOldDedup(t *testing.T) {
 		Severity:        string(testRuleResponse.Severity),
 		Title:           aws.StringValue(newAlertDedupEvent.GeneratedTitle),
 		RuleDisplayName: aws.String(string(testRuleResponse.DisplayName)),
-		AlertDedupEvent: *newAlertDedupEvent,
+		AlertDedupEvent: AlertDedupEvent{
+			RuleID:              newAlertDedupEvent.RuleID,
+			RuleVersion:         newAlertDedupEvent.RuleVersion,
+			LogTypes:            newAlertDedupEvent.LogTypes,
+			EventCount:          newAlertDedupEvent.EventCount,
+			AlertCount:          newAlertDedupEvent.AlertCount,
+			DeduplicationString: newAlertDedupEvent.DeduplicationString,
+			GeneratedTitle:      newAlertDedupEvent.GeneratedTitle,
+			UpdateTime:          newAlertDedupEvent.UpdateTime,
+			CreationTime:        newAlertDedupEvent.UpdateTime,
+		},
 	}
 
 	expectedMarshaledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -59,7 +59,7 @@ var (
 		DeduplicationString: "dedupString",
 		AlertCount:          10,
 		CreationTime:        time.Now().UTC(),
-		UpdateTime:          time.Now().UTC(),
+		UpdateTime:          time.Now().UTC().Add(1 * time.Minute),
 		EventCount:          100,
 		LogTypes:            []string{"Log.Type.1", "Log.Type.2"},
 		GeneratedTitle:      aws.String("test title"),
@@ -71,7 +71,7 @@ var (
 		DeduplicationString: oldAlertDedupEvent.DeduplicationString,
 		AlertCount:          oldAlertDedupEvent.AlertCount + 1,
 		CreationTime:        time.Now().UTC(),
-		UpdateTime:          time.Now().UTC(),
+		UpdateTime:          time.Now().UTC().Add(1 * time.Minute),
 		EventCount:          oldAlertDedupEvent.EventCount,
 		LogTypes:            oldAlertDedupEvent.LogTypes,
 		GeneratedTitle:      oldAlertDedupEvent.GeneratedTitle,
@@ -106,7 +106,7 @@ func TestHandleStoreAndSendNotification(t *testing.T) {
 	}
 
 	expectedAlertNotification := &alertModel.Alert{
-		CreatedAt:           newAlertDedupEvent.CreationTime,
+		CreatedAt:           newAlertDedupEvent.UpdateTime,
 		AnalysisDescription: aws.String(string(testRuleResponse.Description)),
 		AnalysisID:          newAlertDedupEvent.RuleID,
 		Version:             aws.String(newAlertDedupEvent.RuleVersion),
@@ -134,7 +134,17 @@ func TestHandleStoreAndSendNotification(t *testing.T) {
 		Severity:        string(testRuleResponse.Severity),
 		RuleDisplayName: aws.String(string(testRuleResponse.DisplayName)),
 		Title:           aws.StringValue(newAlertDedupEvent.GeneratedTitle),
-		AlertDedupEvent: *newAlertDedupEvent,
+		AlertDedupEvent: AlertDedupEvent{
+			RuleID:              newAlertDedupEvent.RuleID,
+			RuleVersion:         newAlertDedupEvent.RuleVersion,
+			LogTypes:            newAlertDedupEvent.LogTypes,
+			EventCount:          newAlertDedupEvent.EventCount,
+			AlertCount:          newAlertDedupEvent.AlertCount,
+			DeduplicationString: newAlertDedupEvent.DeduplicationString,
+			GeneratedTitle:      newAlertDedupEvent.GeneratedTitle,
+			UpdateTime:          newAlertDedupEvent.UpdateTime,
+			CreationTime:        newAlertDedupEvent.UpdateTime,
+		},
 	}
 
 	expectedMarshaledAlert, err := dynamodbattribute.MarshalMap(expectedAlert)
@@ -177,13 +187,13 @@ func TestHandleStoreAndSendNotificationNoRuleDisplayNameNoTitle(t *testing.T) {
 		DeduplicationString: oldAlertDedupEvent.DeduplicationString,
 		AlertCount:          oldAlertDedupEvent.AlertCount + 1,
 		CreationTime:        time.Now().UTC(),
-		UpdateTime:          time.Now().UTC(),
+		UpdateTime:          time.Now().UTC().Add(1 * time.Minute),
 		EventCount:          oldAlertDedupEvent.EventCount,
 		LogTypes:            oldAlertDedupEvent.LogTypes,
 	}
 
 	expectedAlertNotification := &alertModel.Alert{
-		CreatedAt:           newAlertDedupEventWithoutTitle.CreationTime,
+		CreatedAt:           newAlertDedupEventWithoutTitle.UpdateTime,
 		AnalysisDescription: aws.String(string(testRuleResponse.Description)),
 		AnalysisID:          newAlertDedupEventWithoutTitle.RuleID,
 		Version:             aws.String(newAlertDedupEventWithoutTitle.RuleVersion),

--- a/internal/log_analysis/alert_forwarder/forwarder/rule_cache.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/rule_cache.go
@@ -1,0 +1,81 @@
+package forwarder
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"net/http"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	policiesclient "github.com/panther-labs/panther/api/gateway/analysis/client"
+	policiesoperations "github.com/panther-labs/panther/api/gateway/analysis/client/operations"
+	"github.com/panther-labs/panther/api/gateway/analysis/models"
+)
+
+// s3ClientCacheKey -> S3 client
+type RuleCache struct {
+	cache        *lru.ARCCache
+	httpClient   *http.Client
+	policyClient *policiesclient.PantherAnalysis
+}
+
+func NewCache(httpClient *http.Client, policyClient *policiesclient.PantherAnalysis) *RuleCache {
+	cache, err := lru.NewARC(1000)
+	if err != nil {
+		panic("failed to create cache")
+	}
+	return &RuleCache{
+		cache:        cache,
+		policyClient: policyClient,
+		httpClient:   httpClient,
+	}
+}
+
+func (c *RuleCache) Get(id, version string) (*models.Rule, error) {
+	value, ok := c.cache.Get(cacheKey(id, version))
+	if !ok {
+		rule, err := c.getRuleInfo(id, version)
+		if err != nil {
+			return nil, err
+		}
+		value = rule
+		c.cache.Add(cacheKey(id, version), value)
+	}
+	return value.(*models.Rule), nil
+}
+
+func cacheKey(id, version string) string {
+	return id + ":" + version
+}
+
+func (c *RuleCache) getRuleInfo(id, version string) (*models.Rule, error) {
+	zap.L().Debug("calling analysis API to retrieve information for rule", zap.String("ruleId", id), zap.String("ruleVersion", version))
+	rule, err := c.policyClient.Operations.GetRule(&policiesoperations.GetRuleParams{
+		RuleID:     id,
+		VersionID:  &version,
+		HTTPClient: c.httpClient,
+	})
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch information for ruleID [%s], version [%s]", id, version)
+	}
+	return rule.Payload, nil
+}

--- a/internal/log_analysis/alert_forwarder/forwarder/rule_cache.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/rule_cache.go
@@ -52,7 +52,7 @@ func NewCache(httpClient *http.Client, policyClient *policiesclient.PantherAnaly
 func (c *RuleCache) Get(id, version string) (*models.Rule, error) {
 	value, ok := c.cache.Get(cacheKey(id, version))
 	if !ok {
-		rule, err := c.getRuleInfo(id, version)
+		rule, err := c.getRule(id, version)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func cacheKey(id, version string) string {
 	return id + ":" + version
 }
 
-func (c *RuleCache) getRuleInfo(id, version string) (*models.Rule, error) {
+func (c *RuleCache) getRule(id, version string) (*models.Rule, error) {
 	zap.L().Debug("calling analysis API to retrieve information for rule", zap.String("ruleId", id), zap.String("ruleVersion", version))
 	rule, err := c.policyClient.Operations.GetRule(&policiesoperations.GetRuleParams{
 		RuleID:     id,

--- a/internal/log_analysis/alert_forwarder/main/config.go
+++ b/internal/log_analysis/alert_forwarder/main/config.go
@@ -1,4 +1,4 @@
-package forwarder
+package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
@@ -39,8 +39,8 @@ var (
 	sqsClient  sqsiface.SQSAPI
 
 	httpClient   *http.Client
-	policyConfig *policiesclient.TransportConfig
 	policyClient *policiesclient.PantherAnalysis
+	policyConfig *policiesclient.TransportConfig
 )
 
 type envConfig struct {


### PR DESCRIPTION
## Background

Closes #1110 

Added support for rule threshold. 
Now every Rule has a "threshold" field. If we see more than N matched events for a rule within a deduplication window, we create a new alert. If the number of matched events is below the threshold, no new alert will be created (however, we will store the matched events in S3/Athena)

## Changes

- Added new field in rule
- Added logic to ignore events if we haven't reached a threshold
- Made some improvements in the `alert_forwarder` package. Avoiding global variables allows us now to run all unit tests for forwarder in parallel

## Testing

- Unit tests
- Integration tests
- Deployed and verified behavior
