### PR TITLE
upgrade cfn-lint and ensure specs are current

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ boto3==1.12.49
 botocore==1.15.49
 certifi==2020.6.20
 cfn-flip==1.2.3
-cfn-lint==0.33.1
+cfn-lint==0.33.2
 chardet==3.0.4
 chevron==0.13.1
 click==7.1.2

--- a/tools/mage/setup.go
+++ b/tools/mage/setup.go
@@ -216,6 +216,11 @@ func installPythonEnv() error {
 		return fmt.Errorf("pip installation failed: %v", err)
 	}
 
+	// update cfn linter specs (cnf-lint is a python package)
+	if err := sh.RunV(pythonLibPath("cfn-lint"), "--update-specs"); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Background

The snowflake driver needs the latest cfn-lint specs.

## Changes

- Bump cnf-lint version
- Add code to `mage setup` that updates the cfn lint specs

## Testing

- mage clean setup test:ci
