### PR TITLE
Remove npm audit from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,17 +68,8 @@ jobs:
           name: Run test suite
           command: mage test:ci
 
-  npm_audit:
-    executor: panther-buildpack
-    steps:
-      - checkout
-      - run:
-          name: Audit NPM packages
-          command: npm audit --production # does not require installing packages first
-
 workflows:
   version: 2
   pipeline:
     jobs:
       - mage_test_ci
-      - npm_audit


### PR DESCRIPTION
## Background

A potentially controversial suggestion - let's remove `npm audit` from CI entirely.

`npm audit` will start failing as soon as any vulnerable package is discovered. While we do want to know about that as soon as possible, there's usually nothing we can do about it until days or weeks later when a patch is released. The failure is essentially never related to a pull request, yet we run the check on every PR.

The main downside, which @jacknagz identified again, is that all of our builds show as failing and it looks bad. The README and CircleCI show Panther as failing all builds:

![Screen Shot 2020-07-14 at 12 19 10 PM](https://user-images.githubusercontent.com/3608925/87467386-b7732b80-c5cc-11ea-9354-c1bfd24d3021.png)

And every PR will forever have the red X:

![Screen Shot 2020-07-14 at 12 22 57 PM](https://user-images.githubusercontent.com/3608925/87467443-cd80ec00-c5cc-11ea-8d2d-f1a894cd4573.png)

A check like this makes make more sense to run periodically, for example as part of every release cycle

## Changes

- Remove `npm audit` from CI config

## Testing

- CI
