### PR TITLE
Configurable ALB ingress security group

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -59,6 +59,11 @@ Parameters:
     Type: String
     Description: Enable S3 access logging for all Panther buckets.
     AllowedValues: [true, false]
+  LoadBalancerSecurityGroupCidr:
+    Type: String
+    Description: Allow HTTP(S) ingress access to the web app (ALB) security group from this IP block. Use 0.0.0.0/0 to allow unrestricted access
+    # cfn-lint suggested this regex pattern:
+    AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
   LogSubscriptionPrincipals:
     Type: CommaDelimitedList
     Description: The list of Principal ARNs to allow read access to the ProcessedDataBucket and subscribe access to ProcessedDataTopicArn
@@ -717,13 +722,11 @@ Resources:
       GroupDescription: Access to the public facing load balancer
       VpcId: !Ref VPC
       SecurityGroupIngress:
-        # Allow access to ALB from anywhere on the internet. If you want to restrict access to the
-        # load balancer from specific IPs, add your own network CIDRs.
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: !Ref LoadBalancerSecurityGroupCidr
           FromPort: 80
           ToPort: 80
           IpProtocol: tcp
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: !Ref LoadBalancerSecurityGroupCidr
           FromPort: 443
           ToPort: 443
           IpProtocol: tcp

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -103,6 +103,12 @@ Parameters:
     Type: CommaDelimitedList
     Description: Comma-separated list of at most 3 LayerVersion ARNs to attach to each Lambda function (e.g. if you have a serverless monitoring service)
     Default: ''
+  LoadBalancerSecurityGroupCidr:
+    Type: String
+    Description: Allow HTTP(S) ingress access to the web app (ALB) security group from this IP block. Use 0.0.0.0/0 to allow unrestricted access
+    Default: 0.0.0.0/0
+    # cfn-lint suggested this regex pattern:
+    AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
   LogProcessorLambdaMemorySize:
     Type: Number
     Description: Log processor Lambda memory allocation. Increase to eliminate out-of-memory errors or reduce processing time (in exchange for higher cost)
@@ -151,6 +157,7 @@ Resources:
         Debug: !Ref Debug
         DeployFromSource: false
         EnableS3AccessLogs: !Ref EnableS3AccessLogs
+        LoadBalancerSecurityGroupCidr: !Ref LoadBalancerSecurityGroupCidr
         LogSubscriptionPrincipals: !Join [',', !Ref LogSubscriptionPrincipals]
         TracingMode: !Ref TracingMode
       Tags:

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -22,6 +22,10 @@ Infra:
   # For example, this could be a serverless monitoring/security service.
   BaseLayerVersionArns: ''
 
+  # Allow HTTP(S) ingress access to the web app (ALB) security group from this IP block.
+  # Use 0.0.0.0/0 to allow unrestricted access
+  LoadBalancerSecurityGroupCidr: 0.0.0.0/0
+
   # Lambda functions scale memory and CPU together.
   # Those with the smallest memory are slower and cheaper.
   # Those with the larger memory are faster and more expensive.

--- a/tools/config/config.go
+++ b/tools/config/config.go
@@ -35,10 +35,11 @@ type PantherConfig struct {
 }
 
 type Infra struct {
-	BaseLayerVersionArns         string   `yaml:"BaseLayerVersionArns"`
-	LogProcessorLambdaMemorySize int      `yaml:"LogProcessorLambdaMemorySize"`
-	PipLayer                     []string `yaml:"PipLayer"`
-	PythonLayerVersionArn        string   `yaml:"PythonLayerVersionArn"`
+	BaseLayerVersionArns          string   `yaml:"BaseLayerVersionArns"`
+	LoadBalancerSecurityGroupCidr string   `yaml:"LoadBalancerSecurityGroupCidr"`
+	LogProcessorLambdaMemorySize  int      `yaml:"LogProcessorLambdaMemorySize"`
+	PipLayer                      []string `yaml:"PipLayer"`
+	PythonLayerVersionArn         string   `yaml:"PythonLayerVersionArn"`
 }
 
 type Monitoring struct {

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -348,16 +348,17 @@ func deployMainStacks(settings *config.PantherConfig, accountID string, outputs 
 
 func deployBootstrapStack(settings *config.PantherConfig) (map[string]string, error) {
 	return deployTemplate(bootstrapTemplate, "", bootstrapStack, map[string]string{
-		"AccessLogsBucket":           settings.Setup.S3AccessLogsBucket,
-		"AlarmTopicArn":              settings.Monitoring.AlarmSnsTopicArn,
-		"CloudWatchLogRetentionDays": strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
-		"CustomDomain":               settings.Web.CustomDomain,
-		"DataReplicationBucket":      settings.Setup.DataReplicationBucket,
-		"Debug":                      strconv.FormatBool(settings.Monitoring.Debug),
-		"DeployFromSource":           "true",
-		"EnableS3AccessLogs":         strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
-		"LogSubscriptionPrincipals":  strings.Join(settings.Setup.LogSubscriptions.PrincipalARNs, ","),
-		"TracingMode":                settings.Monitoring.TracingMode,
+		"AccessLogsBucket":              settings.Setup.S3AccessLogsBucket,
+		"AlarmTopicArn":                 settings.Monitoring.AlarmSnsTopicArn,
+		"CloudWatchLogRetentionDays":    strconv.Itoa(settings.Monitoring.CloudWatchLogRetentionDays),
+		"CustomDomain":                  settings.Web.CustomDomain,
+		"DataReplicationBucket":         settings.Setup.DataReplicationBucket,
+		"Debug":                         strconv.FormatBool(settings.Monitoring.Debug),
+		"DeployFromSource":              "true",
+		"EnableS3AccessLogs":            strconv.FormatBool(settings.Setup.EnableS3AccessLogs),
+		"LoadBalancerSecurityGroupCidr": settings.Infra.LoadBalancerSecurityGroupCidr,
+		"LogSubscriptionPrincipals":     strings.Join(settings.Setup.LogSubscriptions.PrincipalARNs, ","),
+		"TracingMode":                   settings.Monitoring.TracingMode,
 	})
 }
 


### PR DESCRIPTION
## Background

The ALB security group which allows HTTP(S) access to the web app (ALB) is currently 0.0.0.0/0

Not everyone wants an open security group like this, we need to provide a configuration option for the ingress cidr block.

## Changes

- Add `LoadBalancerSecurityGroupCidr` parameter to `bootstrap` and `master` stacks

## Testing

- `mage test:ci`
- `STACK=bootstrap mage deploy`
