### PR TITLE
Feat: Lazy-load charting library

### DIFF
--- a/web/src/components/charts/BarChart/BarChart.tsx
+++ b/web/src/components/charts/BarChart/BarChart.tsx
@@ -17,7 +17,6 @@
  */
 
 import React from 'react';
-import echarts from 'echarts';
 import { Box, Theme, useTheme } from 'pouncejs';
 
 interface Data {
@@ -40,6 +39,13 @@ const BarChart: React.FC<BarChartProps> = ({ data, alignment = 'vertical' }) => 
     // We are not allowed to put async function directly in useEffect. Instead, we should define
     // our own async function and call it within useEffect
     (async () => {
+      // load the pie chart
+      const [echarts] = await Promise.all([
+        import(/* webpackChunkName: "echarts" */ 'echarts/lib/echarts'),
+        import(/* webpackChunkName: "echarts" */ 'echarts/lib/chart/bar'),
+        import(/* webpackChunkName: "echarts" */ 'echarts/lib/component/legendScroll'),
+      ]);
+
       /*
        * 'legendData' must be an array of values that matches 'series.name'in order
        * to display them in correct order and color


### PR DESCRIPTION
## Background

`echarts` is a **huge** library. Due to that up until recently we had it code-splitted. Somehow, this got removed and ended up being bundled in our main bundle.

This PR makes sure  it's code-split again

## Changes

- Code-split `echarts`

## Testing

See the data below. The reduction is `300KB` big (only see Gzipped sizes0.

#### Before

<img width="1673" alt="Screen Shot 2020-07-15 at 11 10 57 AM" src="https://user-images.githubusercontent.com/10436045/87521049-7c383180-c68c-11ea-8654-d7da0f167f4b.png">

#### After
<img width="1678" alt="Screen Shot 2020-07-15 at 11 11 47 AM" src="https://user-images.githubusercontent.com/10436045/87521105-92de8880-c68c-11ea-8d1a-ac8ee473f0bc.png">


