### PR TITLE
Call the rule engine (not policy) when saving a rule

### DIFF
--- a/internal/core/analysis_api/handlers/create_rule.go
+++ b/internal/core/analysis_api/handlers/create_rule.go
@@ -118,7 +118,7 @@ func enabledRuleTestsPass(rule *models.UpdateRule) (bool, error) {
 		ResourceTypes: rule.LogTypes,
 		Tests:         rule.Tests,
 	}
-	testResults, err := policyEngine.TestPolicy(tp)
+	testResults, err := ruleEngine.TestRule(tp)
 	if err != nil {
 		return false, err
 	}

--- a/internal/core/analysis_api/handlers/test_policy.go
+++ b/internal/core/analysis_api/handlers/test_policy.go
@@ -28,7 +28,7 @@ import (
 	"github.com/panther-labs/panther/pkg/gatewayapi"
 )
 
-// TestPolicy runs a policy against a set of unit tests.
+// TestPolicy runs a policy (or rule) against a set of unit tests.
 func TestPolicy(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyResponse {
 	input, err := parseTestPolicy(request)
 	if err != nil {


### PR DESCRIPTION
## Background

Bug fix where rule saving calls the policy engine to test the rule instead of the rule engine.

## Changes

The fix

## Testing

Added integration tests for successfully saving a rule and a policy with passing tests.
