### PR TITLE
Add FOSSA test to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,7 @@ jobs:
           name: Check bundle size
           command: npm run bundlesize
 
-  # Upload dependency metadata to FOSSA, analyze offline
-  fossa_upload:
+  fossa:
     executor: panther-buildpack
     resource_class: small
     steps:
@@ -103,8 +102,11 @@ jobs:
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       - run:
-          command: fossa # generate config file, run dependency analysis, and upload metadata to FOSSA
+          # Generate config file, run dependency analysis, and upload metadata to FOSSA
+          command: fossa
       - run:
+          # Wait for license scan to finish, exit with error code if policy violations are found.
+          # Usually only takes ~3 minutes, times out after 10 min
           command: fossa test
 
 workflows:
@@ -114,4 +116,4 @@ workflows:
       - mage_test_ci
       - npm_audit
       - bundlesize
-      - fossa_upload
+      - fossa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,8 @@ jobs:
       - checkout
       - run:
           command: fossa # generate config file, run dependency analysis, and upload metadata to FOSSA
+      - run:
+          command: fossa test
 
 workflows:
   version: 2


### PR DESCRIPTION
## Background

Follow up to #1221 to see if we can run `fossa test` in CI more quickly now that the project has been bootstrapped.

EDIT: Indeed, we can! Now each PR will show a failing check if the license scan fails. If this continues to work well, we can make it a required check sometime in the future
