### PR TITLE
Return http 400 and user friendly message when rule/policy test input is invalid json

### DIFF
--- a/internal/core/analysis_api/analysis/policy_engine.go
+++ b/internal/core/analysis_api/analysis/policy_engine.go
@@ -19,6 +19,7 @@ package analysis
  */
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -115,13 +116,21 @@ func makeTestSummary(policy *models.TestPolicy, engineOutput enginemodels.Policy
 	return testResults, nil
 }
 
+type TestInputError struct {
+	err error
+}
+
+func (e *TestInputError) Error() string {
+	return e.err.Error()
+}
+
 func makeTestResources(policy *models.TestPolicy) ([]enginemodels.Resource, error) {
 	resources := make([]enginemodels.Resource, len(policy.Tests))
 	for i, test := range policy.Tests {
-		// TODO(giorgosp): Can swagger unmarshall this already?
 		var attrs map[string]interface{}
 		if err := jsoniter.UnmarshalFromString(string(test.Resource), &attrs); err != nil {
-			return resources, errors.Wrapf(err, "tests[%d].resource is not valid json", i)
+			//nolint // Error is capitalized because will be returned to the UI
+			return nil, &TestInputError{fmt.Errorf(`Resource for test "%s" is not valid json: %w`, test.Name, err)}
 		}
 
 		resources[i] = enginemodels.Resource{

--- a/internal/core/analysis_api/analysis/rule_engine.go
+++ b/internal/core/analysis_api/analysis/rule_engine.go
@@ -19,6 +19,7 @@ package analysis
  */
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
@@ -49,10 +50,10 @@ func (e *RuleEngine) TestRule(rule *models.TestPolicy) (models.TestPolicyResult,
 	// Build the list of events to run the rule against
 	inputEvents := make([]enginemodels.Event, len(rule.Tests))
 	for i, test := range rule.Tests {
-		// TODO(giorgosp): Can swagger unmarshall this already?
 		var attrs map[string]interface{}
 		if err := jsoniter.UnmarshalFromString(string(test.Resource), &attrs); err != nil {
-			return empty, errors.Wrapf(err, "tests[%d].event is not valid json", i)
+			//nolint // Error is capitalized because will be returned to the UI
+			return empty, &TestInputError{fmt.Errorf(`Event for test "%s" is not valid json: %w`, test.Name, err)}
 		}
 
 		inputEvents[i] = enginemodels.Event{

--- a/internal/core/analysis_api/handlers/test_policy.go
+++ b/internal/core/analysis_api/handlers/test_policy.go
@@ -25,6 +25,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/panther-labs/panther/api/gateway/analysis/models"
+	"github.com/panther-labs/panther/internal/core/analysis_api/analysis"
 	"github.com/panther-labs/panther/pkg/gatewayapi"
 )
 
@@ -40,6 +41,10 @@ func TestPolicy(request *events.APIGatewayProxyRequest) *events.APIGatewayProxyR
 		testResults, err = ruleEngine.TestRule(input)
 	} else {
 		testResults, err = policyEngine.TestPolicy(input)
+	}
+
+	if _, ok := err.(*analysis.TestInputError); ok {
+		return badRequest(err)
 	}
 	if err != nil {
 		return failedRequest(err.Error(), http.StatusInternalServerError)

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -21,6 +21,7 @@ package main
 import (
 	"bufio"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -297,9 +298,12 @@ func TestIntegrationAPI(t *testing.T) {
 		t.Run("SaveEnabledPolicyFailingTests", saveEnabledPolicyFailingTests)
 		t.Run("SaveDisabledPolicyFailingTests", saveDisabledPolicyFailingTests)
 		t.Run("SaveEnabledPolicyPassingTests", saveEnabledPolicyPassingTests)
+		t.Run("SavePolicyInvalidTestInputJson", savePolicyInvalidTestInputJSON)
+
 		t.Run("SaveEnabledRuleFailingTests", saveEnabledRuleFailingTests)
 		t.Run("SaveDisabledRuleFailingTests", saveDisabledRuleFailingTests)
 		t.Run("SaveEnabledRulePassingTests", saveEnabledRulePassingTests)
+		t.Run("SaveRuleInvalidTestInputJson", saveRuleInvalidTestInputJSON)
 	})
 	if t.Failed() {
 		return
@@ -716,6 +720,61 @@ func saveEnabledPolicyPassingTests(t *testing.T) {
 	})
 }
 
+func savePolicyInvalidTestInputJSON(t *testing.T) {
+	policyID := uuid.New().String()
+	defer cleanupPoliciesRules(t, policyID)
+	body := "def policy(resource): return True"
+	tests := []*models.UnitTest{
+		{
+			Name:           "PolicyName",
+			ExpectedResult: true,
+			Resource:       "invalid json",
+		},
+	}
+	req := models.UpdatePolicy{
+		AutoRemediationID:         policy.AutoRemediationID,
+		AutoRemediationParameters: policy.AutoRemediationParameters,
+		Body:                      models.Body(body),
+		Description:               policy.Description,
+		DisplayName:               policy.DisplayName,
+		Enabled:                   true,
+		ID:                        models.ID(policyID),
+		ResourceTypes:             policy.ResourceTypes,
+		Severity:                  policy.Severity,
+		Suppressions:              policy.Suppressions,
+		Tags:                      policy.Tags,
+		OutputIds:                 policy.OutputIds,
+		UserID:                    userID,
+		Tests:                     tests,
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		_, err := apiClient.Operations.CreatePolicy(&operations.CreatePolicyParams{
+			Body:       &req,
+			HTTPClient: httpClient,
+		})
+		require.Error(t, err)
+		e, ok := err.(*operations.CreatePolicyBadRequest)
+		require.True(t, ok, err)
+
+		expectedErrorPrefix := fmt.Sprintf(`Resource for test "%s" is not valid json:`, tests[0].Name)
+		require.True(t, strings.HasPrefix(*e.Payload.Message, expectedErrorPrefix), *e.Payload.Message)
+	})
+
+	t.Run("Modify", func(t *testing.T) {
+		_, err := apiClient.Operations.ModifyPolicy(&operations.ModifyPolicyParams{
+			Body:       &req,
+			HTTPClient: httpClient,
+		})
+		require.Error(t, err)
+		e, ok := err.(*operations.ModifyPolicyBadRequest)
+		require.True(t, ok, err)
+
+		expectedErrorPrefix := fmt.Sprintf(`Resource for test "%s" is not valid json:`, tests[0].Name)
+		require.True(t, strings.HasPrefix(*e.Payload.Message, expectedErrorPrefix), *e.Payload.Message)
+	})
+}
+
 // Tests that a rule cannot be saved if it is enabled and its tests fail.
 func saveEnabledRuleFailingTests(t *testing.T) {
 	ruleID := uuid.New().String()
@@ -812,6 +871,57 @@ func saveEnabledRulePassingTests(t *testing.T) {
 			HTTPClient: httpClient,
 		})
 		require.NoError(t, err)
+	})
+}
+
+func saveRuleInvalidTestInputJSON(t *testing.T) {
+	ruleID := uuid.New().String()
+	defer cleanupPoliciesRules(t, ruleID)
+	body := "def rule(event): return True"
+	tests := []*models.UnitTest{
+		{
+			Name:           "Trigger alert",
+			ExpectedResult: true,
+			Resource:       "invalid json",
+		},
+	}
+	req := models.UpdateRule{
+		Body:               models.Body(body),
+		Description:        rule.Description,
+		Enabled:            true,
+		ID:                 models.ID(ruleID),
+		LogTypes:           rule.LogTypes,
+		Severity:           rule.Severity,
+		UserID:             userID,
+		DedupPeriodMinutes: rule.DedupPeriodMinutes,
+		Tags:               rule.Tags,
+		Tests:              tests,
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		_, err := apiClient.Operations.CreateRule(&operations.CreateRuleParams{
+			Body:       &req,
+			HTTPClient: httpClient,
+		})
+		require.Error(t, err)
+		e, ok := err.(*operations.CreateRuleBadRequest)
+		require.True(t, ok, err)
+
+		expectedErrorPrefix := fmt.Sprintf(`Event for test "%s" is not valid json:`, tests[0].Name)
+		require.True(t, strings.HasPrefix(*e.Payload.Message, expectedErrorPrefix), *e.Payload.Message)
+	})
+
+	t.Run("Modify", func(t *testing.T) {
+		_, err := apiClient.Operations.ModifyRule(&operations.ModifyRuleParams{
+			Body:       &req,
+			HTTPClient: httpClient,
+		})
+		require.Error(t, err)
+		e, ok := err.(*operations.ModifyRuleBadRequest)
+		require.True(t, ok, err)
+
+		expectedErrorPrefix := fmt.Sprintf(`Event for test "%s" is not valid json:`, tests[0].Name)
+		require.True(t, strings.HasPrefix(*e.Payload.Message, expectedErrorPrefix), *e.Payload.Message)
 	})
 }
 

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -576,6 +576,8 @@ func saveEnabledPolicyFailingTests(t *testing.T) {
 		},
 	}
 	policyID := uuid.New().String()
+	defer cleanupPoliciesRules(t, policyID)
+
 	req := models.UpdatePolicy{
 		AutoRemediationID:         policy.AutoRemediationID,
 		AutoRemediationParameters: policy.AutoRemediationParameters,
@@ -594,21 +596,6 @@ func saveEnabledPolicyFailingTests(t *testing.T) {
 	}
 
 	expectedErrorMessage := "cannot save an enabled policy with failing unit tests"
-
-	defer func() {
-		result, err := apiClient.Operations.DeletePolicies(&operations.DeletePoliciesParams{
-			Body: &models.DeletePolicies{
-				Policies: []*models.DeleteEntry{
-					{
-						ID: models.ID(policyID),
-					},
-				},
-			},
-			HTTPClient: httpClient,
-		})
-		require.NoError(t, err)
-		assert.Equal(t, &operations.DeletePoliciesOK{}, result)
-	}()
 
 	t.Run("Create", func(t *testing.T) {
 		_, err := apiClient.Operations.CreatePolicy(&operations.CreatePolicyParams{
@@ -687,6 +674,10 @@ func saveEnabledPolicyPassingTests(t *testing.T) {
 	tests := []*models.UnitTest{
 		{
 			Name:           "Compliant",
+			ExpectedResult: true,
+			Resource:       `{}`,
+		}, {
+			Name:           "Compliant 2",
 			ExpectedResult: true,
 			Resource:       `{}`,
 		},
@@ -777,6 +768,8 @@ func saveEnabledRuleFailingTests(t *testing.T) {
 }
 
 // Tests that a rule can be saved if it is enabled and its tests pass.
+// This is different than createRuleSuccess test. createRuleSuccess saves
+// a rule without tests.
 func saveEnabledRulePassingTests(t *testing.T) {
 	ruleID := uuid.New().String()
 	defer cleanupPoliciesRules(t, ruleID)
@@ -784,6 +777,10 @@ func saveEnabledRulePassingTests(t *testing.T) {
 	tests := []*models.UnitTest{
 		{
 			Name:           "Trigger alert",
+			ExpectedResult: true,
+			Resource:       `{}`,
+		}, {
+			Name:           "Trigger alert 2",
 			ExpectedResult: true,
 			Resource:       `{}`,
 		},


### PR DESCRIPTION
## Background

When a rule/policy unit test contains invalid json as the event/resource input, an http 500 was returned and user wouldn't
know what the problem would be as the UI redirects to a generic page for server errors.

## Changes

This PR returns a user friendly message along with an http 400 (bad request) status code.

## Testing

Added integration tests

**UI screenshot**
Clicking Run All
<img width="1377" alt="Screenshot 2020-07-23 at 5 20 46 PM" src="https://user-images.githubusercontent.com/3627869/88373494-9961b400-cda0-11ea-8c0b-fec1882eb6fd.png">

Clicking Save
<img width="1479" alt="Screenshot 2020-07-24 at 11 27 56 AM" src="https://user-images.githubusercontent.com/3627869/88373564-bb5b3680-cda0-11ea-8584-48c27254b225.png">

