### PR TITLE
Add separate mage test commands

### DIFF
--- a/docs/gitbook/development.md
+++ b/docs/gitbook/development.md
@@ -75,8 +75,12 @@ Targets:
   master:publish      Publish a new Panther release (Panther team only)
   setup               Install all build and development dependencies
   teardown            Destroy all Panther infrastructure
+  test:cfn            Lint CloudFormation and Terraform templates
   test:ci             Run all required checks for a pull request
+  test:go             Test and lint Golang source code
   test:integration    Run integration tests (integration_test.go,integration.py)
+  test:python         Test and lint Python source code
+  test:web            Test and lint npm/web source
 ```
 
 You can easily chain `mage` commands together, for example: `mage clean setup test:ci deploy`


### PR DESCRIPTION
## Background

One of the backend engineers asked for separate `mage test` commands for Go code, so that he could iterate more quickly, I believe it was @alxarch 

## Changes

- Add `test:go`, `test:python`, `test:cfn`, and `test:web` commands - these run a subset of `test:ci` which apply only to the specific languages (no formatting)
- Allow the go linter to use multiple threads - it was the slowest task and would finish 30 seconds or more after every other task, it's better to let it run (by itself) with full parallelism rather than run it with only 1 process

## Testing

- Ran each `test` command independently
