### PR TITLE
Send Cognito username from AppSync instead of sub

### DIFF
--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -223,7 +223,7 @@ Resources:
           "operation": "Invoke",
           "payload": $util.toJson({
             "resetUserPassword": {
-              "requesterId": $ctx.identity.sub,
+              "requesterId": $ctx.identity.username,
               "id": $ctx.args.id
             }
           })
@@ -244,7 +244,7 @@ Resources:
       DataSourceName: !GetAtt UsersAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $ctx.args.input)
-        $util.qr($input.put("requesterId", $ctx.identity.sub))
+        $util.qr($input.put("requesterId", $ctx.identity.username))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",
@@ -272,7 +272,7 @@ Resources:
           "operation": "Invoke",
           "payload": $util.toJson({
             "removeUser": {
-              "requesterId": $ctx.identity.sub,
+              "requesterId": $ctx.identity.username,
               "id": $ctx.args.id
             }
           })
@@ -315,7 +315,7 @@ Resources:
       DataSourceName: !GetAtt UsersAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("requesterId", $ctx.identity.sub))
+        $util.qr($input.put("requesterId", $ctx.identity.username))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",
@@ -385,7 +385,7 @@ Resources:
       DataSourceName: !GetAtt DestinationsAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",
@@ -434,7 +434,7 @@ Resources:
       DataSourceName: !GetAtt DestinationsAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",
@@ -680,7 +680,7 @@ Resources:
       DataSourceName: !GetAtt SourceAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $ctx.args.input)
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         $util.qr($input.put("scanIntervalMins", 1440))
         $util.qr($input.put("integrationType", "aws-scan"))
         {
@@ -706,7 +706,7 @@ Resources:
       DataSourceName: !GetAtt SourceAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $ctx.args.input)
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         $util.qr($input.put("integrationType", "aws-s3"))
         {
           "version" : "2017-02-28",
@@ -929,7 +929,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -960,7 +960,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1022,7 +1022,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1141,7 +1141,7 @@ Resources:
       DataSourceName: !GetAtt RemediationAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "GET",
@@ -1377,7 +1377,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1408,7 +1408,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1499,7 +1499,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1559,7 +1559,7 @@ Resources:
       DataSourceName: !GetAtt AnalysisAPIHttpDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version": "2018-05-29",
           "method": "POST",
@@ -1665,7 +1665,7 @@ Resources:
       DataSourceName: !GetAtt AlertsAPILambdaDataSource.Name
       RequestMappingTemplate: |
         #set ($input = $util.defaultIfNull($ctx.args.input, {}))
-        $util.qr($input.put("userId", $ctx.identity.sub))
+        $util.qr($input.put("userId", $ctx.identity.username))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",


### PR DESCRIPTION
## Background

Cognito actually has 2 different user kinds of user IDs: a *username* and a *sub*:

From [the AppSync docs](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html#aws-appsync-resolver-context-reference-identity), the `identity` context contains both:

> sub: The UUID of the authenticated user.

> username: The user name of the authenticated user. In the case of AMAZON_COGNITO_USER_POOLS authorization, the value of username is the value of attribute cognito:username.

For all users so far, these values have been the same:

![Screen Shot 2020-07-29 at 9 41 26 AM](https://user-images.githubusercontent.com/3608925/88828274-dd2d3280-d17f-11ea-811c-87acb16fb7e4.png)

However, with the addition of SAML users in Panther Enterprise, the username looks like `PantherSSO_email@example.com` while the `sub` is still a UUID. Currently, AppSync is sending the *sub* but all of the [AWS APIs](https://docs.aws.amazon.com/sdk-for-go/api/service/cognitoidentityprovider/) require the *username* in the backend to read or update user information. This causes a problem where the enterprise backend can't validate users: https://github.com/panther-labs/panther-enterprise/issues/446

I have no idea what the "sub" is used for, but we can't use it in the backend for anything meaningful. The `username` is the true "userId" as far as Panther is concerned - it's immutable and unique and is the required key for all API operations. Therefore, AppSync needs to forward the "username" rather than the "sub"

## Changes

- Replace `ctx.identity.sub` with `ctx.identity.username` in the AppSync resolvers

Because these two values are always the same in open-source, this has no real effect on existing deployments. It's just the more correct mapping

## Testing

- Deployed, tested user operations with extra protections (inviting a new user, editing a user, etc)
