### PR TITLE
Streaming results for AWS.CloudTrail logs

### DIFF
--- a/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
@@ -58,7 +58,9 @@ func init() {
 			Description:  `AWSCloudTrail represents the content of a CloudTrail S3 object.`,
 			ReferenceURL: `https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html`,
 			Schema:       CloudTrail{},
-			NewParser:    parsers.AdapterFactory(&CloudTrailParser{}),
+			NewParser: func(_ interface{}) (parsers.Interface, error) {
+				return &CloudTrailStreamingParser{}, nil
+			},
 		},
 		logtypes.Config{
 			Name:         TypeCloudTrailDigest,

--- a/internal/log_analysis/log_processor/parsers/streaming.go
+++ b/internal/log_analysis/log_processor/parsers/streaming.go
@@ -1,0 +1,27 @@
+package parsers
+
+type ResultStream interface {
+	Next() (*Result, error)
+}
+
+type StreamResultsError interface {
+	error
+	Stream() ResultStream
+}
+
+func NewStreamResultsError(stream ResultStream) error {
+	return &streamResultsError{
+		stream: stream,
+	}
+}
+
+type streamResultsError struct {
+	stream ResultStream
+}
+
+func (*streamResultsError) Error() string {
+	return "streaming results"
+}
+func (s *streamResultsError) Stream() ResultStream {
+	return s.stream
+}

--- a/internal/log_analysis/log_processor/parsers/streaming.go
+++ b/internal/log_analysis/log_processor/parsers/streaming.go
@@ -1,5 +1,23 @@
 package parsers
 
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 type ResultStream interface {
 	Next() (*Result, error)
 }
@@ -24,4 +42,26 @@ func (*streamResultsError) Error() string {
 }
 func (s *streamResultsError) Stream() ResultStream {
 	return s.stream
+}
+
+func StreamResults(results ...*Result) ResultStream {
+	return &sliceResultStream{
+		results: results,
+	}
+}
+
+type sliceResultStream struct {
+	results []*Result
+	index   int
+}
+
+func (s *sliceResultStream) Next() (*Result, error) {
+	if i := s.index; 0 <= i && i < len(s.results) {
+		r := s.results[i]
+		s.index++
+		return r, nil
+	}
+	// send results to GC
+	s.results = nil
+	return nil, nil
 }

--- a/internal/log_analysis/log_processor/parsers/timestamp/timestamp_test.go
+++ b/internal/log_analysis/log_processor/parsers/timestamp/timestamp_test.go
@@ -24,6 +24,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -50,6 +51,14 @@ func TestTimestampRFC3339Unmarshal(t *testing.T) {
 	err := jsoniter.Unmarshal([]byte(unmarshalString), &ts)
 	assert.NoError(t, err)
 	assert.Equal(t, (RFC3339)(expectedTime), ts)
+	{
+		// Test that we can unmarshal from glue as well
+		unmarshalString := `"2019-12-15 01:01:01.000000000"`
+		var ts RFC3339
+		err := jsoniter.Unmarshal([]byte(unmarshalString), &ts)
+		assert.NoError(t, err)
+		assert.Equal(t, (RFC3339)(expectedTime), ts)
+	}
 }
 
 func TestTimestampANSICwithTZString(t *testing.T) {
@@ -153,4 +162,13 @@ func TestSuricataUnmarshal(t *testing.T) {
 	err := jsoniter.Unmarshal([]byte(unmarshalString), &ts)
 	assert.NoError(t, err)
 	assert.Equal(t, (SuricataTimestamp)(expectedTime), ts)
+}
+
+// Ensure no conflicts with existing layouts
+func TestIsGlueTimestampJSON(t *testing.T) {
+	require.False(t, isGlueTimestampJSON([]byte(ansicWithTZUnmarshalLayout)))
+	require.False(t, isGlueTimestampJSON([]byte(suricataTimestampLayout)))
+	require.False(t, isGlueTimestampJSON([]byte(laceworkTimestampLayout)))
+	require.False(t, isGlueTimestampJSON([]byte(fluentdTimestampLayout)))
+	require.True(t, isGlueTimestampJSON([]byte(jsonMarshalLayout)))
 }


### PR DESCRIPTION
## Background

There is currenty an issue with `AWS.CloudTrail` logs that require a lot of memory to process. All log events in each file are in a single line. The current way log parsers work require all events for a log line to be parsed and returned in a single call to `ParseLog`. This PR allows to return a special `error` value that signals the log processor to read results in a streaming function.

## Changes

- Adds `parsers.ResultStream` and `parsers.StreamResultsError` interfaces.
- Adds special handling for `parsers.StreamResultsError` errors in the classifier
- Adds `Stream` field to the `ClassificationResult`
- Handles `Stream` classification results in the log processor
- Adds `awslogs.CloudTrailStreamingParser` to return a stream of `AWS.CloudTrail` results.

## Testing

- mage test:ci
- TODO: unit tests for proper stream handling and parser stats
- TODO: deploy for e2e
