### PR TITLE
Added Okta & OneLogin documentation

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -76,6 +76,7 @@
   * [Box](log-analysis/log-processing/log-setup/box.md)
   * [GSuite](log-analysis/log-processing/log-setup/gsuite.md)
   * [Okta](log-analysis/log-processing/log-setup/okta.md)
+  * [OneLogin](log-analysis/log-processing/log-setup/onelogin.md)
 * [Standard Fields](log-analysis/panther-fields.md)
 
 ## Cloud Security

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -73,8 +73,9 @@
   * [Syslog](log-analysis/log-processing/supported-logs/Syslog.md)
   * [Zeek](log-analysis/log-processing/supported-logs/Zeek.md)
 * [SaaS Logs Setup]()
-  * [GSuite](log-analysis/log-processing/log-setup/gsuite.md)
   * [Box](log-analysis/log-processing/log-setup/box.md)
+  * [GSuite](log-analysis/log-processing/log-setup/gsuite.md)
+  * [Okta](log-analysis/log-processing/log-setup/okta.md)
 * [Standard Fields](log-analysis/panther-fields.md)
 
 ## Cloud Security

--- a/docs/gitbook/log-analysis/log-processing/log-setup/box.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/box.md
@@ -1,4 +1,4 @@
-# Setup a Box App to access Box admin events from Panther
+# Box Setup
 
 Panther has the ability to fetch events from the [Box Events API](https://developer.box.com/reference/get-events/).
 

--- a/docs/gitbook/log-analysis/log-processing/log-setup/okta.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/okta.md
@@ -1,0 +1,31 @@
+# Okta Setup
+
+Panther has the ability to fetch events from the [Okta System Log API](https://developer.okta.com/docs/reference/api/system-log/).
+
+In order for Panther to access the API you need to create a new API token or use an existing one. Panther will use this token to pull the logs periodically (every 1 minute).
+
+### Create a new API token
+
+{% hint style="info" %}
+To create an API token with permissions to query Okta System Logs,  you will need to be logged in as an administrator that possesses the rights to perform your API call's actions.
+Please refer to [Okta documentation](https://help.okta.com/en/prod/Content/Topics/Security/Administrators.htm?Highlight=administrators) for information on managing Admin roles and their rights.  
+{% endhint %}
+
+1. Log in as Okta administrator
+1. In the Okta Admin Console, navigate to **Security > API**
+1. Click **Create Token**
+1. Enter a name for your token, e.g. `Panther API token`
+1. Document the **Token value** from the screen that appears.
+   **Important**: be sure to document and store the API token value carefully, as it cannot be retrieved later and can present a security risk if used in an unauthorized fashion
+
+### Create a new Okta source in Panther
+
+1. Login to your Panther account
+1. Click **Log analysis** on the sidebar menu
+1. Click **Sources**
+1. Click **Add Source**
+1. Select **Okta** from the list of available types
+1. Enter a friendly name for the source (e.g. `My Okta logs`)
+1. Add your Okta subdomain
+1. Paste the API Token value that you saved earlier. 
+1. Save the source!

--- a/docs/gitbook/log-analysis/log-processing/log-setup/onelogin.md
+++ b/docs/gitbook/log-analysis/log-processing/log-setup/onelogin.md
@@ -1,0 +1,36 @@
+# OneLogin Setup
+
+Panther is able to process OneLogin events through [OneLogin's integration](https://www.onelogin.com/blog/aws-eventbridge-integration) with Amazon EventBridge.
+This allows Panther to process OneLogin logs in a scalable and reliable, low latency manner.  
+
+In order for Panther to process your OneLogin logs, you need to configure your OneLogin account to send data to Amazon EventBridge in Panther AWS account. 
+
+### Configure OneLogin to send data to Amazon EventBridge
+
+1. Log in to OneLogin Administration console
+1. Go to **Developers > Webhooks**
+1. Go to **New Webhook > Event Webhook for Amazon EventBridge**
+1. Add a friendly name e.g. `Panther Integration`
+1. Add the AWS AccountId and AWS region where you have deployed Panther. Click on **Save**
+1. Click on the new integration that got just created.
+
+### Configure Amazon EventBridge in your account
+
+1. Log in to your AWS Console, in the AWS account where you have deployed Panther
+1. Go to **Amazon EventBridge** service in the region where you have deployed Panther
+1. Go to **Events > Partner event sources**
+1. Keep a note of the OneLogin source (will be in the form `aws.partner/onelogin.com/US-142470/bad86aa8d3`) 
+1. Select the OneLogin source, click **Associate with event bus**
+1. In the next page, you don't need to select any of the options. Just click **Associate**
+
+### Create a new OneLogin source in Panther
+
+1. Login to your Panther account
+1. Click **Log analysis** on the sidebar menu
+1. Click **Sources**
+1. Click **Add Source**
+1. Select **Amazon EventBridge** from the list of available types
+1. Enter a friendly name for the source (e.g. `My OneLogin logs`)
+1. Select **OneLogin** as log type
+1. Add the Bus name that you kept note of earlier. 
+1. Save the source!


### PR DESCRIPTION
## Background
Closes #1084 
Added documentation on onboarding Okta and OneLogin logs. 


## Testing

- `mage test:ci`
