### PR TITLE
Fix mage master:publish

### DIFF
--- a/tools/mage/master_namespace.go
+++ b/tools/mage/master_namespace.go
@@ -72,7 +72,7 @@ func (Master) Deploy() {
 //
 // Returns bucket, firstUserEmail, ecrRegistry
 func masterDeployPreCheck() (string, string, string) {
-	deployPreCheck(*awsSession.Config.Region)
+	deployPreCheck(*awsSession.Config.Region, false)
 
 	_, err := cloudformation.New(awsSession).DescribeStacks(
 		&cloudformation.DescribeStacksInput{StackName: aws.String(bootstrapStack)})
@@ -99,7 +99,7 @@ func masterDeployPreCheck() (string, string, string) {
 
 // Publish Publish a new Panther release (Panther team only)
 func (Master) Publish() {
-	deployPreCheck("us-east-1")
+	deployPreCheck("us-east-1", false)
 	version := getMasterVersion()
 
 	logger.Infof("Publishing panther-community v%s to %s", version, strings.Join(publishRegions, ","))


### PR DESCRIPTION
## Background

I went to publish the release: `mage master:publish`, and got a nil pointer panic.

Turns out that's because `master:publish` runs the same pre-checks as a standard `deploy`, which includes checking for old stack versions that may need special migrations. That stack check was failing because there was no aws session initialized.

We don't need that check when publishing the release, so I just made it optional

## Changes

- add parameter to `deployPreCheck()` to control whether the old version check runs

## Testing

- `mage master:publish`
