### PR TITLE
Factor user prompt code from mage to pkg/prompt

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -4,9 +4,17 @@ Standalone go utilities shared by multiple projects. See each module for details
 
 - [`awsathena`](awsathena) - query support and utilities for using AWS Athena
 - [`awsbatch`](awsbatch) - backoff/paging/retry for AWS batch operations
+- [`awsretry`](retry) - helper that wraps the AWS retryer interface for cases not handled by SDK
+- [`awssqs`](awssqs) - wrappers for commmon sqs patterns
+- [`box`](box) - boxing helpers
+- [`encryption`](encryption) - encryption helpers
 - [`extract`](extract) - utility using gjson to walk parse tree to extract elements
 - [`gatewayapi`](gatewayapi) - utilities for developing Gateway API Lambda proxies
-- [`genericapi`](genericapi) - _DEPRECATED_ - provides router for API-style Lambda functions
+- [`genericapi`](genericapi) - provides router for API-style Lambda functions
 - [`lambdalogger`](lambdalogger) - installs global zap logger with lambda request ID
+- [`mertics`](metrics) - helpers to use the AWS embedded metric format
 - [`oplog`](oplog) - standardized logging for operations (events with start/stop/status)
+- [`shutil`](shutil) - FIXME: likely should be renamed to ziputil
+- [`prompt`](prompt) - util functions to read user input from terminal
 - [`testutils`](testutils) - helper functions for integration tests
+- [`unbox`](unbox) - un-boxing helpers

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -1,0 +1,90 @@
+package prompt
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+/*
+ Utility package to read input from terminal
+*/
+
+// Read will prompt the user for a string input.
+func Read(prompt string, validator func(string) error) string {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print(prompt)
+		result, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("read string failed: %v\n", err)
+			continue
+		}
+
+		result = strings.TrimSpace(result)
+		if validator != nil {
+			if err := validator(result); err != nil {
+				fmt.Println(err)
+				continue
+			}
+		}
+
+		return result
+	}
+}
+
+// Ensure non-empty strings.
+func NonemptyValidator(input string) error {
+	if len(input) == 0 {
+		return errors.New("input is blank, please try again")
+	}
+	return nil
+}
+
+// Very simple email validation to prevent obvious mistakes.
+func EmailValidator(email string) error {
+	if len(email) >= 4 && strings.Contains(email, "@") && strings.Contains(email, ".") {
+		return nil
+	}
+	return errors.New("invalid email: must be at least 4 characters and contain '@' and '.'")
+}
+
+func RegexValidator(text string) error {
+	if _, err := regexp.Compile(text); err != nil {
+		return fmt.Errorf("invalid regex: %v", err)
+	}
+	return nil
+}
+
+func DateValidator(text string) error {
+	if len(text) == 0 { // allow no date
+		return nil
+	}
+	if _, err := time.Parse("2006-01-02", text); err != nil {
+		return fmt.Errorf("invalid date: %v", err)
+	}
+	return nil
+}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -1,3 +1,6 @@
+/*
+Utility package to read input from terminal.
+*/
 package prompt
 
 /**
@@ -20,18 +23,13 @@ package prompt
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
-
-/*
- Utility package to read input from terminal
-*/
 
 // Read will prompt the user for a string input.
 func Read(prompt string, validator func(string) error) string {

--- a/tools/mage/deploy.go
+++ b/tools/mage/deploy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/internal/log_analysis/gluetables"
 	"github.com/panther-labs/panther/pkg/genericapi"
+	"github.com/panther-labs/panther/pkg/prompt"
 	"github.com/panther-labs/panther/pkg/shutil"
 	"github.com/panther-labs/panther/tools/config"
 )
@@ -215,9 +216,9 @@ func setFirstUser(settings *config.PantherConfig) {
 
 	// If there is no setting and no existing user, we have to prompt.
 	fmt.Println("Who will be the initial Panther admin user?")
-	firstName := promptUser("First name: ", nonemptyValidator)
-	lastName := promptUser("Last name: ", nonemptyValidator)
-	email := promptUser("Email: ", emailValidator)
+	firstName := prompt.Read("First name: ", prompt.NonemptyValidator)
+	lastName := prompt.Read("Last name: ", prompt.NonemptyValidator)
+	email := prompt.Read("Email: ", prompt.EmailValidator)
 	settings.Setup.FirstUser = config.FirstUser{
 		GivenName:  firstName,
 		FamilyName: lastName,

--- a/tools/mage/glue_namespace.go
+++ b/tools/mage/glue_namespace.go
@@ -35,6 +35,7 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/awsglue"
 	"github.com/panther-labs/panther/internal/log_analysis/gluetables"
 	"github.com/panther-labs/panther/pkg/genericapi"
+	"github.com/panther-labs/panther/pkg/prompt"
 )
 
 // targets for managing Glue tables
@@ -46,11 +47,13 @@ func (t Glue) Sync() {
 	glueClient := glue.New(awsSession)
 	s3Client := s3.New(awsSession)
 
-	enteredText := promptUser("Enter regex to select a subset of tables (or <enter> for all tables): ", regexValidator)
+	enteredText := prompt.Read("Enter regex to select a subset of tables (or <enter> for all tables): ",
+		prompt.RegexValidator)
 	matchTableName, _ := regexp.Compile(enteredText) // no error check already validated
 
 	var startDate time.Time
-	startDateText := promptUser("Enter a day as YYYY-MM-DD to start update (or <enter> to use create date on tables): ", dateValidator)
+	startDateText := prompt.Read("Enter a day as YYYY-MM-DD to start update (or <enter> to use create date on tables): ",
+		prompt.DateValidator)
 	if startDateText != "" {
 		startDate, _ = time.Parse("2006-01-02", startDateText) // no error check already validated
 	}

--- a/tools/mage/master_namespace.go
+++ b/tools/mage/master_namespace.go
@@ -32,6 +32,7 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 
+	"github.com/panther-labs/panther/pkg/prompt"
 	"github.com/panther-labs/panther/tools/cfnparse"
 	"github.com/panther-labs/panther/tools/config"
 )
@@ -103,7 +104,7 @@ func (Master) Publish() {
 	version := getMasterVersion()
 
 	logger.Infof("Publishing panther-community v%s to %s", version, strings.Join(publishRegions, ","))
-	result := promptUser("Are you sure you want to continue? (yes|no) ", nonemptyValidator)
+	result := prompt.Read("Are you sure you want to continue? (yes|no) ", prompt.NonemptyValidator)
 	if strings.ToLower(result) != "yes" {
 		logger.Fatal("publish aborted")
 	}

--- a/tools/mage/teardown.go
+++ b/tools/mage/teardown.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/panther-labs/panther/pkg/awsbatch/s3batch"
+	"github.com/panther-labs/panther/pkg/prompt"
 )
 
 const (
@@ -73,7 +74,7 @@ func teardownConfirmation() string {
 	}
 
 	logger.Warnf(template, args...)
-	result := promptUser("Are you sure you want to continue? (yes|no) ", nonemptyValidator)
+	result := prompt.Read("Are you sure you want to continue? (yes|no) ", prompt.NonemptyValidator)
 	if strings.ToLower(result) != "yes" {
 		logger.Fatal("teardown aborted")
 	}

--- a/tools/mage/test_namespace.go
+++ b/tools/mage/test_namespace.go
@@ -31,6 +31,7 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 
+	"github.com/panther-labs/panther/pkg/prompt"
 	"github.com/panther-labs/panther/tools/cfnparse"
 )
 
@@ -482,7 +483,7 @@ func (t Test) Integration() {
 
 	logger.Warnf("Integration tests will erase all Panther data in account %s (%s)",
 		getAccountID(), *awsSession.Config.Region)
-	result := promptUser("Are you sure you want to continue? (yes|no) ", nonemptyValidator)
+	result := prompt.Read("Are you sure you want to continue? (yes|no) ", prompt.NonemptyValidator)
 	if strings.ToLower(result) != "yes" {
 		logger.Fatal("integration tests aborted")
 	}


### PR DESCRIPTION
## Background
I will be moving `mage gluesync` into an ops tool so it can be more easily shared with customers.
This change factors our the user prompt code in `mage` as a package in `pkg`

## Changes

- Factor out prompt code
- Bring README.md current

## Testing

- mage test:ci
