### PR TITLE
Fix bug when no permissions where specified for the SQS queue

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -421,7 +421,7 @@ input TestPolicyInput {
 
 type SqsConfig {
   logTypes: [String!]!
-  allowedPrincipals: [String]
+  allowedPrincipalArns: [String]
   allowedSourceArns: [String]
   s3Bucket: String!
   s3Prefix: String
@@ -488,7 +488,7 @@ input AddS3LogIntegrationInput {
 
 input SqsLogConfigInput {
   logTypes: [String!]!
-  allowedPrincipals: [String]!
+  allowedPrincipalArns: [String]!
   allowedSourceArns: [String]!
 }
 

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -97,7 +97,7 @@ type SqsConfig struct {
 	// The log types associated with the source. Needs to be set by UI.
 	LogTypes []string `json:"logTypes" validate:"required,min=1"`
 	// The AWS Principals that are allowed to send data to this source. Needs to be set by UI.
-	AllowedPrincipals []string `json:"allowedPrincipals"`
+	AllowedPrincipalArns []string `json:"allowedPrincipalArns"`
 	// The ARNS (e.g. SNS topic ARNs) that are allowed to send data to this source. Needs to be set by UI.
 	AllowedSourceArns []string `json:"allowedSourceArns"`
 

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -103,7 +103,7 @@ func setupExternalResources(integration *models.SourceIntegration) error {
 			return errors.Wrap(err, "failed to enable subscription for input bucket")
 		}
 		if err := CreateSourceSqsQueue(integration.IntegrationID,
-			integration.SqsConfig.AllowedPrincipals, integration.SqsConfig.AllowedSourceArns); err != nil {
+			integration.SqsConfig.AllowedPrincipalArns, integration.SqsConfig.AllowedSourceArns); err != nil {
 			return errors.Wrap(err, "failed to create input SQS queue")
 		}
 		if err := AddSourceAsLambdaTrigger(integration.IntegrationID); err != nil {
@@ -259,13 +259,13 @@ func generateNewIntegration(input *models.PutIntegrationInput) *models.SourceInt
 		metadata.LogProcessingRole = generateLogProcessingRoleArn(input.AWSAccountID, input.IntegrationLabel)
 	case models.IntegrationTypeSqs:
 		metadata.SqsConfig = &models.SqsConfig{
-			S3Bucket:          env.InputDataBucketName,
-			S3Prefix:          models.SqsS3Prefix,
-			LogProcessingRole: env.InputDataRoleArn,
-			AllowedPrincipals: input.SqsConfig.AllowedPrincipals,
-			AllowedSourceArns: input.SqsConfig.AllowedSourceArns,
-			LogTypes:          input.SqsConfig.LogTypes,
-			QueueURL:          SourceSqsQueueURL(metadata.IntegrationID),
+			S3Bucket:             env.InputDataBucketName,
+			S3Prefix:             models.SqsS3Prefix,
+			LogProcessingRole:    env.InputDataRoleArn,
+			AllowedPrincipalArns: input.SqsConfig.AllowedPrincipalArns,
+			AllowedSourceArns:    input.SqsConfig.AllowedSourceArns,
+			LogTypes:             input.SqsConfig.LogTypes,
+			QueueURL:             SourceSqsQueueURL(metadata.IntegrationID),
 		}
 	}
 	return &models.SourceIntegration{

--- a/internal/core/source_api/api/put_integration_test.go
+++ b/internal/core/source_api/api/put_integration_test.go
@@ -415,9 +415,9 @@ func TestPutSqsIntegration(t *testing.T) {
 			IntegrationLabel: testIntegrationLabel,
 			IntegrationType:  models.IntegrationTypeSqs,
 			SqsConfig: &models.SqsConfig{
-				LogTypes:          []string{"AWS.CloudTrail"},
-				AllowedPrincipals: []string{"arn:aws:iam::123456789012:root"},
-				AllowedSourceArns: []string{"arn:aws:sns:*:415773754570:*"},
+				LogTypes:             []string{"AWS.CloudTrail"},
+				AllowedPrincipalArns: []string{"arn:aws:iam::123456789012:root"},
+				AllowedSourceArns:    []string{"arn:aws:sns:*:415773754570:*"},
 			},
 		},
 	})

--- a/internal/core/source_api/api/sqs_utils.go
+++ b/internal/core/source_api/api/sqs_utils.go
@@ -199,6 +199,9 @@ func AllowInputDataBucketSubscription() error {
 // Generates the Policy for the Source SQS queue that allows the following list of AWS AccountIDs and sourceARNS to send
 // data to the queue
 func createSourceSqsQueuePolicy(allowedPrincipalArns []string, allowedSourceArns []string) *awssqs.SqsPolicy {
+	if len(allowedPrincipalArns) == 0 && len(allowedSourceArns) == 0 {
+		return nil
+	}
 	var statements []awssqs.SqsPolicyStatement
 	for _, allowedArn := range allowedPrincipalArns {
 		statement := awssqs.SqsPolicyStatement{
@@ -225,10 +228,6 @@ func createSourceSqsQueuePolicy(allowedPrincipalArns []string, allowedSourceArns
 			},
 		}
 		statements = append(statements, statement)
-	}
-
-	if len(statements) == 0 {
-		return nil
 	}
 
 	return &awssqs.SqsPolicy{

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -105,11 +105,11 @@ func normalizeIntegration(item *ddb.Integration, input *models.UpdateIntegration
 		item.IntegrationLabel = input.IntegrationLabel
 		item.SqsConfig.LogTypes = input.SqsConfig.LogTypes
 
-		newAllowedPrincipals := input.SqsConfig.AllowedPrincipals
-		newAllowedSourceArns := input.SqsConfig.AllowedSourceArns
-		item.SqsConfig.AllowedSourceArns = newAllowedSourceArns
-		item.SqsConfig.AllowedPrincipals = newAllowedPrincipals
-		if err := UpdateSourceSqsQueue(item.IntegrationID, newAllowedPrincipals, newAllowedSourceArns); err != nil {
+		newAllowedPrincipals := input.SqsConfig.AllowedPrincipalArns
+		newAllowedSources := input.SqsConfig.AllowedSourceArns
+		item.SqsConfig.AllowedSourceArns = newAllowedSources
+		item.SqsConfig.AllowedPrincipalArns = newAllowedPrincipals
+		if err := UpdateSourceSqsQueue(item.IntegrationID, newAllowedPrincipals, newAllowedSources); err != nil {
 			return updateIntegrationInternalError
 		}
 	}

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -56,13 +56,13 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		item.StackName = input.StackName
 	case models.IntegrationTypeSqs:
 		item.SqsConfig = &ddb.SqsConfig{
-			QueueURL:          input.SqsConfig.QueueURL,
-			S3Bucket:          input.SqsConfig.S3Bucket,
-			S3Prefix:          input.SqsConfig.S3Prefix,
-			LogProcessingRole: input.SqsConfig.LogProcessingRole,
-			LogTypes:          input.SqsConfig.LogTypes,
-			AllowedPrincipals: input.SqsConfig.AllowedPrincipals,
-			AllowedSourceArns: input.SqsConfig.AllowedSourceArns,
+			QueueURL:             input.SqsConfig.QueueURL,
+			S3Bucket:             input.SqsConfig.S3Bucket,
+			S3Prefix:             input.SqsConfig.S3Prefix,
+			LogProcessingRole:    input.SqsConfig.LogProcessingRole,
+			LogTypes:             input.SqsConfig.LogTypes,
+			AllowedPrincipalArns: input.SqsConfig.AllowedPrincipalArns,
+			AllowedSourceArns:    input.SqsConfig.AllowedSourceArns,
 		}
 	}
 	return item
@@ -100,13 +100,13 @@ func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 		integration.StackName = item.StackName
 	case models.IntegrationTypeSqs:
 		integration.SqsConfig = &models.SqsConfig{
-			S3Bucket:          item.SqsConfig.S3Bucket,
-			S3Prefix:          item.SqsConfig.S3Prefix,
-			LogProcessingRole: item.SqsConfig.LogProcessingRole,
-			QueueURL:          item.SqsConfig.QueueURL,
-			LogTypes:          item.SqsConfig.LogTypes,
-			AllowedPrincipals: item.SqsConfig.AllowedPrincipals,
-			AllowedSourceArns: item.SqsConfig.AllowedSourceArns,
+			S3Bucket:             item.SqsConfig.S3Bucket,
+			S3Prefix:             item.SqsConfig.S3Prefix,
+			LogProcessingRole:    item.SqsConfig.LogProcessingRole,
+			QueueURL:             item.SqsConfig.QueueURL,
+			LogTypes:             item.SqsConfig.LogTypes,
+			AllowedPrincipalArns: item.SqsConfig.AllowedPrincipalArns,
+			AllowedSourceArns:    item.SqsConfig.AllowedSourceArns,
 		}
 	}
 	return integration

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -55,11 +55,11 @@ type IntegrationStatus struct {
 }
 
 type SqsConfig struct {
-	S3Bucket          string   `json:"s3Bucket,omitempty"`
-	S3Prefix          string   `json:"s3Prefix,omitempty"`
-	LogProcessingRole string   `json:"logProcessingRole,omitempty"`
-	LogTypes          []string `json:"logTypes" dynamodbav:",stringset"`
-	AllowedPrincipals []string `json:"allowedPrincipals" dynamodbav:",stringset"`
-	AllowedSourceArns []string `json:"allowedSourceArns" dynamodbav:",stringset"`
-	QueueURL          string   `json:"queueUrl,omitempty"`
+	S3Bucket             string   `json:"s3Bucket,omitempty"`
+	S3Prefix             string   `json:"s3Prefix,omitempty"`
+	LogProcessingRole    string   `json:"logProcessingRole,omitempty"`
+	LogTypes             []string `json:"logTypes" dynamodbav:",stringset"`
+	AllowedPrincipalArns []string `json:"allowedPrincipalArns" dynamodbav:",stringset"`
+	AllowedSourceArns    []string `json:"allowedSourceArns" dynamodbav:",stringset"`
+	QueueURL             string   `json:"queueUrl,omitempty"`
 }

--- a/pkg/awssqs/permissions.go
+++ b/pkg/awssqs/permissions.go
@@ -73,7 +73,7 @@ func GetQueuePolicy(sqsClient sqsiface.SQSAPI, queueURL string) (*SqsPolicy, err
 
 func SetQueuePolicy(sqsClient sqsiface.SQSAPI, queueURL string, policy *SqsPolicy) (err error) {
 	var marshaledPolicy string
-	if len(policy.Statements) > 0 {
+	if policy != nil && len(policy.Statements) > 0 {
 		marshaledPolicy, err = jsoniter.MarshalToString(policy)
 		if err != nil {
 			return errors.Wrap(err, "failed to serialize policy")

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -1115,7 +1115,7 @@ export enum SortDirEnum {
 export type SqsConfig = {
   __typename?: 'SqsConfig';
   logTypes: Array<Scalars['String']>;
-  allowedPrincipals?: Maybe<Array<Maybe<Scalars['String']>>>;
+  allowedPrincipalArns?: Maybe<Array<Maybe<Scalars['String']>>>;
   allowedSourceArns?: Maybe<Array<Maybe<Scalars['String']>>>;
   s3Bucket: Scalars['String'];
   s3Prefix?: Maybe<Scalars['String']>;
@@ -1134,7 +1134,7 @@ export type SqsDestinationConfig = {
 
 export type SqsLogConfigInput = {
   logTypes: Array<Scalars['String']>;
-  allowedPrincipals: Array<Maybe<Scalars['String']>>;
+  allowedPrincipalArns: Array<Maybe<Scalars['String']>>;
   allowedSourceArns: Array<Maybe<Scalars['String']>>;
 };
 
@@ -2647,7 +2647,7 @@ export type SqsConfigResolvers<
   ParentType extends ResolversParentTypes['SqsConfig'] = ResolversParentTypes['SqsConfig']
 > = {
   logTypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  allowedPrincipals?: Resolver<
+  allowedPrincipalArns?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['String']>>>,
     ParentType,
     ContextType

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -1268,8 +1268,8 @@ export const buildSqsConfig = (overrides: Partial<SqsConfig> = {}): SqsConfig =>
   return {
     __typename: 'SqsConfig',
     logTypes: 'logTypes' in overrides ? overrides.logTypes : ['Direct'],
-    allowedPrincipals:
-      'allowedPrincipals' in overrides ? overrides.allowedPrincipals : ['navigating'],
+    allowedPrincipalArns:
+      'allowedPrincipalArns' in overrides ? overrides.allowedPrincipalArns : ['HTTP'],
     allowedSourceArns:
       'allowedSourceArns' in overrides ? overrides.allowedSourceArns : ['holistic'],
     s3Bucket: 's3Bucket' in overrides ? overrides.s3Bucket : 'Balanced',
@@ -1299,7 +1299,8 @@ export const buildSqsLogConfigInput = (
 ): SqsLogConfigInput => {
   return {
     logTypes: 'logTypes' in overrides ? overrides.logTypes : ['Incredible'],
-    allowedPrincipals: 'allowedPrincipals' in overrides ? overrides.allowedPrincipals : ['Generic'],
+    allowedPrincipalArns:
+      'allowedPrincipalArns' in overrides ? overrides.allowedPrincipalArns : ['Zloty'],
     allowedSourceArns:
       'allowedSourceArns' in overrides ? overrides.allowedSourceArns : ['partnerships'],
   };

--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
@@ -59,7 +59,7 @@ const SqsSourceConfigurationPanel: React.FC = () => {
           <FastField
             as={FormikMultiCombobox}
             label="Allowed AWS Principal ARNs"
-            name="allowedPrincipals"
+            name="allowedPrincipalArns"
             searchable
             allowAdditions
             items={[]}

--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceWizard.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceWizard.tsx
@@ -38,7 +38,7 @@ export interface SqsLogSourceWizardValues {
   integrationId?: string;
   integrationLabel: string;
   logTypes: string[];
-  allowedPrincipals: string[];
+  allowedPrincipalArns: string[];
   allowedSourceArns: string[];
   queueUrl?: string;
 }
@@ -48,7 +48,7 @@ const validationSchema = Yup.object().shape<SqsLogSourceWizardValues>({
   logTypes: Yup.array()
     .of(Yup.string().oneOf((LOG_TYPES as unknown) as string[]))
     .required(),
-  allowedPrincipals: Yup.array().of(Yup.string()),
+  allowedPrincipalArns: Yup.array().of(Yup.string()),
   allowedSourceArns: Yup.array().of(Yup.string()),
 });
 

--- a/web/src/graphql/fragments/SqsLogSourceIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/SqsLogSourceIntegrationDetails.generated.ts
@@ -33,7 +33,7 @@ export type SqsLogSourceIntegrationDetails = Pick<
   sqsConfig: Pick<
     Types.SqsConfig,
     | 'logTypes'
-    | 'allowedPrincipals'
+    | 'allowedPrincipalArns'
     | 'allowedSourceArns'
     | 's3Bucket'
     | 's3Prefix'
@@ -53,7 +53,7 @@ export const SqsLogSourceIntegrationDetails = gql`
     lastEventReceived
     sqsConfig {
       logTypes
-      allowedPrincipals
+      allowedPrincipalArns
       allowedSourceArns
       s3Bucket
       s3Prefix

--- a/web/src/graphql/fragments/SqsLogSourceIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/SqsLogSourceIntegrationDetails.graphql
@@ -7,7 +7,7 @@ fragment SqsLogSourceIntegrationDetails on SqsLogSourceIntegration {
   lastEventReceived
   sqsConfig {
     logTypes
-    allowedPrincipals
+    allowedPrincipalArns
     allowedSourceArns
     s3Bucket
     s3Prefix

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.tsx
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.tsx
@@ -27,7 +27,7 @@ import { useAddSqsLogSource } from './graphql/addSqsLogSource.generated';
 const initialValues = {
   integrationLabel: '',
   logTypes: [],
-  allowedPrincipals: [],
+  allowedPrincipalArns: [],
   allowedSourceArns: [],
 };
 
@@ -57,7 +57,7 @@ const CreateSqsLogSource: React.FC = () => {
               integrationLabel: values.integrationLabel,
               sqsConfig: {
                 logTypes: values.logTypes,
-                allowedPrincipals: values.allowedPrincipals,
+                allowedPrincipalArns: values.allowedPrincipalArns,
                 allowedSourceArns: values.allowedSourceArns,
               },
             },

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/__tests__/CreateSqsLogSource.test.tsx
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/__tests__/CreateSqsLogSource.test.tsx
@@ -26,7 +26,7 @@ test('renders SQS creation wizard', async () => {
     sqsConfig: {
       logTypes: ['AWS.ALB'],
       allowedSourceArns: ['source'],
-      allowedPrincipals: ['principal'],
+      allowedPrincipalArns: ['principal'],
     },
   };
 
@@ -37,21 +37,21 @@ test('renders SQS creation wizard', async () => {
   expect(configurationPanel).toBeTruthy();
   const integrationLabelField = container.querySelector('input[name="integrationLabel"]');
   const logTypesField = container.querySelector('input[name="logTypes"]');
-  const allowedPrincipalsField = container.querySelector('input[name="allowedPrincipals"]');
+  const allowedPrincipalArnsField = container.querySelector('input[name="allowedPrincipalArns"]');
   const allowedSourceArnsField = container.querySelector('input[name="allowedSourceArns"]');
   const nextButton = getByText('Next');
   // Expecting input elements and button to be rendered
   expect(integrationLabelField).not.toBeNull();
   expect(logTypesField).not.toBeNull();
-  expect(allowedPrincipalsField).not.toBeNull();
+  expect(allowedPrincipalArnsField).not.toBeNull();
   expect(allowedSourceArnsField).not.toBeNull();
   expect(nextButton).toBeDisabled();
 
   // Adding input to fields
   fireEvent.change(integrationLabelField, { target: { value: sqsInput.integrationLabel } });
   fireEvent.change(logTypesField, { target: { value: sqsInput.sqsConfig.logTypes } });
-  fireEvent.change(allowedPrincipalsField, {
-    target: { value: sqsInput.sqsConfig.allowedPrincipals },
+  fireEvent.change(allowedPrincipalArnsField, {
+    target: { value: sqsInput.sqsConfig.allowedPrincipalArns },
   });
   fireEvent.change(allowedSourceArnsField, {
     target: { value: sqsInput.sqsConfig.allowedSourceArns },

--- a/web/src/pages/EditSqsLogSource/EditSqsLogSource.tsx
+++ b/web/src/pages/EditSqsLogSource/EditSqsLogSource.tsx
@@ -49,7 +49,7 @@ const EditSqsLogSource: React.FC = () => {
       integrationId: data?.getSqsLogIntegration.integrationId,
       integrationLabel: data?.getSqsLogIntegration?.integrationLabel ?? 'Loading...',
       logTypes: data?.getSqsLogIntegration.sqsConfig.logTypes ?? [],
-      allowedPrincipals: data?.getSqsLogIntegration.sqsConfig.allowedPrincipals ?? [],
+      allowedPrincipalArns: data?.getSqsLogIntegration.sqsConfig.allowedPrincipalArns ?? [],
       allowedSourceArns: data?.getSqsLogIntegration.sqsConfig.allowedSourceArns ?? [],
       queueUrl: data?.getSqsLogIntegration.sqsConfig.queueUrl,
     }),
@@ -74,7 +74,7 @@ const EditSqsLogSource: React.FC = () => {
                 integrationLabel: values.integrationLabel,
                 sqsConfig: {
                   logTypes: values.logTypes,
-                  allowedPrincipals: values.allowedPrincipals,
+                  allowedPrincipalArns: values.allowedPrincipalArns,
                   allowedSourceArns: values.allowedSourceArns,
                 },
               },


### PR DESCRIPTION
## Background

When a user goes through the new SQS source onboarding, Panther will create a new SQS queue for them to send their data to. 
During the onboarding process (and later on during editing of the source) the users can choose which Principal ARNs (IAM roles, users) and which Source ARNS (S3 buckets, SNS Topics) will be allowed to send messages to the SQS queue. 

The user could choose to specify no Principal and source arns - in that case only the principals inside the Panther AWS account could send data to the queue. Current backend code had a bug would result in an error

## Changes

- Renamed `allowedPrincipals` to `allowedPrincipalArns` property to be aligned with `allowedSourceArns` property naming. 
- Fixed bug mentioned above

## Testing

- mage test:ci
- deployed in my account. 
  - Created a new SQS source with no arns specified. Edited the queue to add new permissions. 
  - Created a new SQS source with some arns specified. Edited it to remove the permissions. 
  - Deleted the new SQS source. 
