### PR TITLE
Simplify pantherlog Result handling and schema generation

### DIFF
--- a/internal/log_analysis/log_processor/classification/classifier_test.go
+++ b/internal/log_analysis/log_processor/classification/classifier_test.go
@@ -43,7 +43,6 @@ func TestClassifyRespectsPriorityOfParsers(t *testing.T) {
 	logLine := "log"
 	tm := time.Now().UTC()
 	expectResult := &parsers.Result{
-		Meta: pantherlog.DefaultFields(),
 		CoreFields: pantherlog.CoreFields{
 			PantherLogType:   "success",
 			PantherEventTime: tm,

--- a/internal/log_analysis/log_processor/pantherlog/jsoniter_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/jsoniter_test.go
@@ -51,27 +51,27 @@ var (
 )
 
 func init() {
-	MustRegisterField(kindFoo, FieldMeta{
+	MustRegisterIndicator(kindFoo, FieldMeta{
 		Name:        "PantherFoo",
 		NameJSON:    "p_any_foo",
 		Description: "Foo data",
 	})
-	MustRegisterField(kindBar, FieldMeta{
+	MustRegisterIndicator(kindBar, FieldMeta{
 		Name:        "PantherBar",
 		NameJSON:    "p_any_bar",
 		Description: "Bar data",
 	})
-	MustRegisterField(kindBaz, FieldMeta{
+	MustRegisterIndicator(kindBaz, FieldMeta{
 		Name:        "PantherBaz",
 		NameJSON:    "p_any_baz",
 		Description: "Baz data",
 	})
-	MustRegisterField(kindQux, FieldMeta{
+	MustRegisterIndicator(kindQux, FieldMeta{
 		Name:        "PantherQux",
 		NameJSON:    "p_any_qux",
 		Description: "Qux data",
 	})
-	MustRegisterField(kindQuux, FieldMeta{
+	MustRegisterIndicator(kindQuux, FieldMeta{
 		Name:        "PantherQuux",
 		NameJSON:    "p_any_quux",
 		Description: "Quux data",
@@ -106,16 +106,16 @@ func TestPantherExt_DecorateEncoder(t *testing.T) {
 	}
 
 	result := Result{
-		Values: new(ValueBuffer),
+		values: new(ValueBuffer),
 	}
 	stream := jsoniter.ConfigDefault.BorrowStream(nil)
 	stream.Attachment = &result
 	stream.WriteVal(&v)
-	require.Equal(t, []string{"ok"}, result.Values.Get(kindFoo), "foo")
-	require.Equal(t, []string{"ok"}, result.Values.Get(kindBar), "bar")
-	require.Equal(t, []string{"ok"}, result.Values.Get(kindBaz), "baz")
-	require.Equal(t, []string{"ok"}, result.Values.Get(kindQux), "qux")
-	require.Equal(t, []string{"ok"}, result.Values.Get(kindQuux), "quux")
+	require.Equal(t, []string{"ok"}, result.values.Get(kindFoo), "foo")
+	require.Equal(t, []string{"ok"}, result.values.Get(kindBar), "bar")
+	require.Equal(t, []string{"ok"}, result.values.Get(kindBaz), "baz")
+	require.Equal(t, []string{"ok"}, result.values.Get(kindQux), "qux")
+	require.Equal(t, []string{"ok"}, result.values.Get(kindQuux), "quux")
 	actual := string(stream.Buffer())
 	require.Equal(t, `{"foo":"ok","bar":"ok","baz":"ok","qux":"ok","quux":"ok"}`, actual)
 }

--- a/internal/log_analysis/log_processor/pantherlog/result.go
+++ b/internal/log_analysis/log_processor/pantherlog/result.go
@@ -19,9 +19,8 @@ package pantherlog
  */
 
 import (
+	"errors"
 	"time"
-
-	jsoniter "github.com/json-iterator/go"
 
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog/rowid"
 )
@@ -30,51 +29,58 @@ import (
 type Result struct {
 	// Result extends all core panther fields
 	CoreFields
-	// Panther fields needed to render this Result as JSON
-	Meta []FieldID
 	// The underlying event
 	Event interface{}
-	// Values for this result. These are normally nil throughout the lifetime of results.
-	// If they are found to be nil when the result is encoded as JSON they are overridden temporarily
-	// with a ValueBuffer borrowed from a pool.
-	// The field is kept public so tests can pre-define the values for a result in mocks without having to serialize
-	// the result.
-	Values *ValueBuffer
 	// Used for log events that embed parsers.PantherLog. This is a low-overhead, temporary work-around
 	// to avoid duplicate panther fields in resulting JSON.
-	RawEvent interface{}
+	// FIXME: Remove this field once all parsers are ported to the new method.
+	EventIncludesPantherFields bool
+	// Collected indicator values for this result.
+	// This field is normally nil throughout the lifetime of results.
+	// It is populated temporarily by the custom jsoniter encoder for *Result to collect all indicator field values.
+	values *ValueBuffer
 }
 
 // WriteValues implements ValueWriter interface
 func (r *Result) WriteValues(kind FieldID, values ...string) {
-	if r.Values == nil {
-		r.Values = &ValueBuffer{}
+	if r.values == nil {
+		r.values = &ValueBuffer{}
 	}
-	r.Values.WriteValues(kind, values...)
+	r.values.WriteValues(kind, values...)
 }
 
 // ResultBuilder builds new results filling out result fields.
 type ResultBuilder struct {
-	// The log type to use for the results
-	LogType string
-	// Field ids to ad to the result
-	Meta []FieldID
 	// Override this to have static row ids for tests
 	NextRowID func() string
 	// Override this to have static parse time for tests
 	Now func() time.Time
 }
 
-// BuildResult builds a new result for an event
-func (b *ResultBuilder) BuildResult(event interface{}) (*Result, error) {
+// EventTimer returns the event timestamp.
+// ResultBuilder checks for events that implement this interface and uses the appropriate timestamp as the event time.
+// Events that require custom logic to decide their timestamp should implement this interface.
+type EventTimer interface {
+	PantherEventTime() time.Time
+}
+
+// BuildResult builds a new result for an event.
+// Log type is passed as an argument so that a single result builder can be reused for producing results of different
+// log types.
+func (b *ResultBuilder) BuildResult(logType string, event interface{}) (*Result, error) {
+	var eventTime time.Time
+	if e, ok := event.(EventTimer); ok {
+		eventTime = e.PantherEventTime()
+	}
+
 	return &Result{
 		CoreFields: CoreFields{
-			PantherLogType:   b.LogType,
+			PantherLogType:   logType,
 			PantherRowID:     b.nextRowID(),
 			PantherParseTime: b.now(),
+			PantherEventTime: eventTime,
 		},
 		Event: event,
-		Meta:  b.meta(),
 	}, nil
 }
 
@@ -91,13 +97,6 @@ func (b *ResultBuilder) nextRowID() string {
 	return rowid.Next()
 }
 
-func (b *ResultBuilder) meta() []FieldID {
-	if b.Meta != nil {
-		return b.Meta
-	}
-	return defaultMetaFields
-}
-
 // StaticRowID returns a function to be used as ResultBuilder.NextRowID to always set the RowID to a specific value
 func StaticRowID(id string) func() string {
 	return func() string {
@@ -112,9 +111,14 @@ func StaticNow(now time.Time) func() time.Time {
 	}
 }
 
+var (
+	errJSONMarshal   = errors.New(`result can only be marshaled with jsoniter`)
+	errJSONUnmarshal = errors.New(`result can only be unmarshaled with jsoniter`)
+)
+
 func (r *Result) MarshalJSON() ([]byte, error) {
-	return jsoniter.Marshal(r)
+	return nil, errJSONMarshal
 }
-func (r *Result) UnmarshalJSON(data []byte) error {
-	return jsoniter.Unmarshal(data, r)
+func (r *Result) UnmarshalJSON(_ []byte) error {
+	return errJSONUnmarshal
 }

--- a/internal/log_analysis/log_processor/pantherlog/scanners.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners.go
@@ -34,13 +34,13 @@ type ValueScanner interface {
 	ScanValues(w ValueWriter, input string)
 }
 
-// ScannerFunc is a function implementing ValueScanner interface
-type ScannerFunc func(dest ValueWriter, value string)
+// ValueScannerFunc is a function implementing ValueScanner interface
+type ValueScannerFunc func(dest ValueWriter, value string)
 
-var _ ValueScanner = (ScannerFunc)(nil)
+var _ ValueScanner = (ValueScannerFunc)(nil)
 
 // ScanValues implements ValueScanner interface
-func (f ScannerFunc) ScanValues(dest ValueWriter, value string) {
+func (f ValueScannerFunc) ScanValues(dest ValueWriter, value string) {
 	f(dest, value)
 }
 
@@ -99,7 +99,7 @@ func checkFields(fields []FieldID) error {
 	return nil
 }
 
-// LookupScanner finds a registere scanner and field ids by name.
+// LookupScanner finds a registered scanner and field ids by name.
 func LookupScanner(name string) (scanner ValueScanner, fields []FieldID) {
 	if entry, ok := registeredScanners[name]; ok {
 		scanner = entry.Scanner

--- a/internal/log_analysis/log_processor/pantherlog/values.go
+++ b/internal/log_analysis/log_processor/pantherlog/values.go
@@ -25,7 +25,7 @@ import (
 
 // ValueWriter provides the interface to write field values
 type ValueWriter interface {
-	WriteValues(kind FieldID, values ...string)
+	WriteValues(field FieldID, values ...string)
 }
 
 // ValueWriterTo can write field values to a ValueWriter
@@ -158,9 +158,9 @@ func (b *ValueBuffer) Fields() []FieldID {
 		return nil
 	}
 	ids := make([]FieldID, 0, len(b.index))
-	for kind, values := range b.index {
+	for id, values := range b.index {
 		if len(values) > 0 {
-			ids = append(ids, kind)
+			ids = append(ids, id)
 		}
 	}
 	sort.Slice(ids, func(i, j int) bool {

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -243,8 +243,6 @@ func (pl *PantherLog) AppendAnySHA256HashesPtr(values ...*string) {
 	}
 }
 
-var defaultMeta = pantherlog.DefaultFields()
-
 func AppendAnyString(any *PantherAnyString, values ...string) {
 	// add new if not present
 	for _, v := range values {
@@ -271,9 +269,9 @@ func (pl *PantherLog) Result() *Result {
 		eventTime = parseTime
 	}
 	return &pantherlog.Result{
-		// Use RawEvent so that our custom ValEncoder for Result knows to not duplicate Panther added fields
-		RawEvent: event,
-		Meta:     defaultMeta,
+		// Use EventIncludesPantherFields so that our custom ValEncoder for Result knows to not duplicate Panther added fields
+		EventIncludesPantherFields: true,
+		Event:                      event,
 		CoreFields: pantherlog.CoreFields{
 			PantherLogType:   unbox.String(pl.PantherLogType),
 			PantherRowID:     unbox.String(pl.PantherRowID),


### PR DESCRIPTION
## Background

These changes result from observations when using the `pantherlog` module to define parsers and from the requirements of some new parsers regarding timestamp handling. The changes where collected in a single PR to avoid scattering these in multiple PRs lumped together with parser definitions. 

## Changes

- Removes `Meta` field from `Result` since it's use restricted the `ResultBuilder` to a single log type without real benefits.
- Pass log type as an argument to `ResultBuilder` since it was restricting a `ResultBuilder` to a single log type.
- Add `EventTimer` interface for custom event time requirements
- Add `Result.EventIncludesPantherFields` for better workaround visibility
- Add `pantherlog.FieldSet` to handle sets of fields when building the event schema
- Fix bug with embedded structs in `BuildEventSchema` et al.
- Adds `override` option to `panther` struct tag for `event_time` handling.

## Testing

- mage test:ci
