### PR TITLE
Improve flag default behavior for requeue

### DIFF
--- a/cmd/opstools/gluesync/gluesync/main.go
+++ b/cmd/opstools/gluesync/gluesync/main.go
@@ -74,15 +74,17 @@ func usage() {
 
 func init() {
 	flag.Usage = usage
+}
 
+func logInit() {
 	config := zap.NewDevelopmentConfig() // DEBUG by default
 	if !*VERBOSE {
-		// In normal mode, hide DEBUG messages and file/line numbers
-		config.DisableCaller = true
+		// In normal mode, hide DEBUG messages
 		config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	}
 
-	// Always disable error traces and use color-coded log levels and short timestamps
+	// Always disable and file/line numbers, error traces and use color-coded log levels and short timestamps
+	config.DisableCaller = true
 	config.DisableStacktrace = true
 	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 
@@ -96,6 +98,8 @@ func init() {
 
 func main() {
 	flag.Parse()
+
+	logInit() // must be done after parsing flags
 
 	sess, err := session.NewSession()
 	if err != nil {

--- a/cmd/opstools/requeue/requeue/main.go
+++ b/cmd/opstools/requeue/requeue/main.go
@@ -6,10 +6,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/panther-labs/panther/cmd/opstools/requeue"
 	"github.com/panther-labs/panther/pkg/prompt"
@@ -21,9 +24,12 @@ const (
 
 var (
 	REGION      = flag.String("region", "", "The AWS region where the queues exists (optional, defaults to session env vars)")
-	FROMQ       = flag.String("from.q", "", "The name of the queue to copy from")
+	FROMQ       = flag.String("from.q", "", "The name of the queue to copy from (defaults to -to.q value with '-dlq' appended)")
 	TOQ         = flag.String("to.q", "", "The name of the queue to copy to")
 	INTERACTIVE = flag.Bool("interactive", true, "If true, prompt for required flags if not set")
+	VERBOSE     = flag.Bool("verbose", false, "Enable verbose logging")
+
+	logger *zap.SugaredLogger
 )
 
 func usage() {
@@ -37,8 +43,30 @@ func init() {
 	flag.Usage = usage
 }
 
+func logInit() {
+	config := zap.NewDevelopmentConfig() // DEBUG by default
+	if !*VERBOSE {
+		// In normal mode, hide DEBUG messages
+		config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	}
+
+	// Always disable and file/line numbers, error traces and use color-coded log levels and short timestamps
+	config.DisableCaller = true
+	config.DisableStacktrace = true
+	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+
+	rawLogger, err := config.Build()
+	if err != nil {
+		log.Fatalf("failed to build logger: %s", err)
+	}
+	zap.ReplaceGlobals(rawLogger)
+	logger = rawLogger.Sugar()
+}
+
 func main() {
 	flag.Parse()
+
+	logInit() // must be done after parsing flags
 
 	sess, err := session.NewSession()
 	if err != nil {
@@ -64,12 +92,9 @@ func promptFlags() {
 		return
 	}
 
-	if *FROMQ == "" {
-		*FROMQ = prompt.Read("Please enter queue name to read from: ", prompt.NonemptyValidator)
-	}
-
 	if *TOQ == "" {
-		*TOQ = prompt.Read("Please enter queue name to copy into: ", prompt.NonemptyValidator)
+		*TOQ = prompt.Read("Please enter target queue name to requeue events from associated dead letter queue: ",
+			prompt.NonemptyValidator)
 	}
 }
 
@@ -83,12 +108,27 @@ func validateFlags() {
 		}
 	}()
 
-	if *FROMQ == "" {
-		err = errors.New("-from.q not set")
-		return
-	}
 	if *TOQ == "" {
 		err = errors.New("-to.q not set")
 		return
+	}
+
+	if *FROMQ == "" {
+		/*
+		  default to our dlq naming convention where:
+		    - a queue is <queue prefix>-queue
+		    - the associated dlq is <queue prefix>-dlq
+		*/
+		queuePrefix := strings.Replace(*TOQ, "-queue", "", 1)
+		if strings.HasSuffix(*TOQ, ".fifo") { // these must end in fifo
+			baseQueueName := strings.Split(queuePrefix, ".")[0]
+			*FROMQ = baseQueueName + "-dlq.fifo"
+		} else {
+			*FROMQ = queuePrefix + "-dlq"
+		}
+
+		if *VERBOSE || *INTERACTIVE {
+			logger.Infof("setting -from.q to default: %s", *FROMQ)
+		}
 	}
 }

--- a/cmd/opstools/s3queue/integration_test.go
+++ b/cmd/opstools/s3queue/integration_test.go
@@ -66,7 +66,7 @@ func TestIntegrationS3queue(t *testing.T) {
 	require.NoError(t, err)
 
 	stats := &Stats{}
-	err = S3Queue(awsSession, fakeAccountID, s3Path, s3Region, toq, concurrency, numberOfFiles, false, stats)
+	err = S3Queue(awsSession, fakeAccountID, s3Path, s3Region, toq, concurrency, numberOfFiles, stats)
 	require.NoError(t, err)
 	assert.Equal(t, numberOfFiles, (int)(stats.NumFiles))
 

--- a/cmd/opstools/s3queue/s3queue/main.go
+++ b/cmd/opstools/s3queue/s3queue/main.go
@@ -122,7 +122,7 @@ func main() {
 			caught, stats.NumFiles, float32(stats.NumBytes)/(1024.0*1024.0), *TOQ, time.Since(startTime))
 	}()
 
-	err = s3queue.S3Queue(sess, *ACCOUNT, *S3PATH, s3Region, *TOQ, *CONCURRENCY, *LIMIT, *VERBOSE, stats)
+	err = s3queue.S3Queue(sess, *ACCOUNT, *S3PATH, s3Region, *TOQ, *CONCURRENCY, *LIMIT, stats)
 	if err != nil {
 		logger.Fatal(err)
 	} else {

--- a/cmd/opstools/s3queue/s3queue/main.go
+++ b/cmd/opstools/s3queue/s3queue/main.go
@@ -50,15 +50,17 @@ func usage() {
 
 func init() {
 	flag.Usage = usage
+}
 
+func logInit() {
 	config := zap.NewDevelopmentConfig() // DEBUG by default
 	if !*VERBOSE {
-		// In normal mode, hide DEBUG messages and file/line numbers
-		config.DisableCaller = true
+		// In normal mode, hide DEBUG messages
 		config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	}
 
-	// Always disable error traces and use color-coded log levels and short timestamps
+	// Always disable and file/line numbers, error traces and use color-coded log levels and short timestamps
+	config.DisableCaller = true
 	config.DisableStacktrace = true
 	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 
@@ -72,6 +74,8 @@ func init() {
 
 func main() {
 	flag.Parse()
+
+	logInit() // must be done after parsing flags
 
 	sess, err := session.NewSession()
 	if err != nil {

--- a/cmd/opstools/s3queue/s3queue_test.go
+++ b/cmd/opstools/s3queue/s3queue_test.go
@@ -37,7 +37,7 @@ func TestS3Queue(t *testing.T) {
 	sqsClient.On("SendMessageBatch", mock.Anything).Return(&sqs.SendMessageBatchOutput{}, nil).Once()
 
 	stats := &Stats{}
-	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, 0, false, stats)
+	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, 0, stats)
 	require.NoError(t, err)
 	s3Client.AssertExpectations(t)
 	sqsClient.AssertExpectations(t)
@@ -65,7 +65,7 @@ func TestS3QueueLimit(t *testing.T) {
 	sqsClient.On("SendMessageBatch", mock.Anything).Return(&sqs.SendMessageBatchOutput{}, nil).Once()
 
 	stats := &Stats{}
-	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, 1, false, stats)
+	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, 1, stats)
 	require.NoError(t, err)
 	s3Client.AssertExpectations(t)
 	sqsClient.AssertExpectations(t)
@@ -90,7 +90,7 @@ func TestS3QueueBatch(t *testing.T) {
 	sqsClient.On("SendMessageBatch", mock.Anything).Return(&sqs.SendMessageBatchOutput{}, nil).Times(3)
 
 	stats := &Stats{}
-	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, 0, false, stats)
+	err := s3Queue(s3Client, sqsClient, testAccount, testS3Path, testQueueName, 1, 0, stats)
 	require.NoError(t, err)
 	s3Client.AssertExpectations(t)
 	sqsClient.AssertExpectations(t)

--- a/docs/gitbook/operations/ops-home.md
+++ b/docs/gitbook/operations/ops-home.md
@@ -57,17 +57,23 @@ The steps to view the dashboard:
 ## Tools
 Panther comes with some operational tools useful for managing the Panther infrastructure. These are statically compiled
 executables for linux, mac (aka darwin) and windows. They can be copied/installed onto operational support hosts. 
-To build from source:
-
-```yaml
-mage build:tools
-```
-
-They are also available pre-compiled for each release as assets associated with the github release.
 
 * **compact**: a tool to back fill JSON to Parquet conversion of log data (used when upgrading to Panther Enterprise)
 * **gluesync**: a tool to update glue table and partition schemas
 * **requeue**: a tool to copy messages from a dead letter queue back to the originating queue for reprocessing
 * **s3queue**: a tool to list files under an S3 path and send to the log processor input queue for processing (useful for back fill of data)
 
-To see usage, execute the tool with the `-h` flag.
+These tools require that the [AWS credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) 
+be set in the environment. We recommend a tool to manage these securely 
+such as [AWS Vault](https://github.com/99designs/aws-vault).
+
+Running these commands with a `-h` flag will explain usage.
+
+To build from source:
+
+```yaml
+mage build:tools
+```
+
+These tools are also available pre-compiled for each release as assets associated with the github release.
+


### PR DESCRIPTION
## Before
The `requeue` opstool forced a user to enter both the `-from.q` and the `to.q`. 

## After
Since Panther has a naming convention for associating a dlq, make the that default if `-from.q` if not specified.

## Changes

- applied our naming convention as default for `-from.q` flag for `requeue`
- enhanced logging in `requeue`
- fixed logger initialization in all opstools to respect the `-verbose` flag
- updated user docs with more context

## Testing

- mage test:ci
- ran integration test
- ran manually against a q with dlq entries
- ran manually against a fifo
