### PR TITLE
Update ops doc with notes on how to configure PagerDuty

### DIFF
--- a/docs/gitbook/operations/ops-home.md
+++ b/docs/gitbook/operations/ops-home.md
@@ -29,6 +29,21 @@ To configure alarms to send to your team, follow the guides below:
 - [SNS Email and SMS Integration](https://docs.aws.amazon.com/sns/latest/dg/sns-user-notifications.html)
 - [PagerDuty Integration](https://support.pagerduty.com/docs/aws-cloudwatch-integration-guide)
 
+    NOTE: As of this writing (August 2020) Pager Duty cannot 
+    [handle composite CloudWatch alarms](https://community.pagerduty.com/forum/t/composite-alarm-in-cloudwatch-not-triggering-pd-integration/1798)
+    which Panther uses to avoid duplicate pages to oncall staff.
+    The work around is to use a [Custom Event Transformer](https://www.pagerduty.com/docs/guides/custom-event-transformer/).
+    Use the below code and configure the SNS topic to use `RawMessageDelivery: true`:
+    ```json
+     var normalized_event = {
+     event_type: PD.Trigger,
+     description: "Cloudwatch",
+     details: JSON.parse(PD.inputRequest.rawBody)
+    };
+    
+    PD.emitGenericEvents([normalized_event]);
+    ```
+
 ### Assessing Data Ingest Volume
 The Panther log analysis CloudWatch dashboard provides deep insight into operationally relevant aspects of log processing.
 In particular, understanding the ingest volume is critically important to forecast the cost of running Panther.

--- a/docs/gitbook/operations/ops-home.md
+++ b/docs/gitbook/operations/ops-home.md
@@ -32,8 +32,9 @@ To configure alarms to send to your team, follow the guides below:
     NOTE: As of this writing (August 2020) Pager Duty cannot 
     [handle composite CloudWatch alarms](https://community.pagerduty.com/forum/t/composite-alarm-in-cloudwatch-not-triggering-pd-integration/1798)
     which Panther uses to avoid duplicate pages to oncall staff.
-    The work around is to use a [Custom Event Transformer](https://www.pagerduty.com/docs/guides/custom-event-transformer/).
-    Follow the instruction to create a `Cusomer Event Transformer` using the below code:
+    The work around is to use a `Cusomer Event Transformer`.
+    Follow the [instructions ](https://www.pagerduty.com/docs/guides/custom-event-transformer/) 
+    to create a  using the below code:
     ```javascript
      var normalized_event = {
      event_type: PD.Trigger,

--- a/docs/gitbook/operations/ops-home.md
+++ b/docs/gitbook/operations/ops-home.md
@@ -33,8 +33,8 @@ To configure alarms to send to your team, follow the guides below:
     [handle composite CloudWatch alarms](https://community.pagerduty.com/forum/t/composite-alarm-in-cloudwatch-not-triggering-pd-integration/1798)
     which Panther uses to avoid duplicate pages to oncall staff.
     The work around is to use a [Custom Event Transformer](https://www.pagerduty.com/docs/guides/custom-event-transformer/).
-    Use the below code and configure the SNS topic to use `RawMessageDelivery: true`:
-    ```json
+    Follow the instruction to create a `Cusomer Event Transformer` using the below code:
+    ```javascript
      var normalized_event = {
      event_type: PD.Trigger,
      description: "Cloudwatch",
@@ -43,6 +43,7 @@ To configure alarms to send to your team, follow the guides below:
     
     PD.emitGenericEvents([normalized_event]);
     ```
+  Configure the SNS topic to use `RawMessageDelivery: true` when creating the Pager Duty subscription.
 
 ### Assessing Data Ingest Volume
 The Panther log analysis CloudWatch dashboard provides deep insight into operationally relevant aspects of log processing.

--- a/docs/gitbook/operations/ops-home.md
+++ b/docs/gitbook/operations/ops-home.md
@@ -33,8 +33,7 @@ To configure alarms to send to your team, follow the guides below:
     [handle composite CloudWatch alarms](https://community.pagerduty.com/forum/t/composite-alarm-in-cloudwatch-not-triggering-pd-integration/1798)
     which Panther uses to avoid duplicate pages to oncall staff.
     The work around is to use a `Cusomer Event Transformer`.
-    Follow the [instructions ](https://www.pagerduty.com/docs/guides/custom-event-transformer/) 
-    to create a  using the below code:
+    Follow the [instructions ](https://www.pagerduty.com/docs/guides/custom-event-transformer/) using the below code:
     ```javascript
      var normalized_event = {
      event_type: PD.Trigger,


### PR DESCRIPTION
## Background
As of this writing (August 2020) Pager Duty cannot [handle composite CloudWatch alarms](https://community.pagerduty.com/forum/t/composite-alarm-in-cloudwatch-not-triggering-pd-integration/1798) which Panther uses to avoid duplicate pages to oncall staff.

This PR documents a work around is to use a [Custom Event Transformer](https://www.pagerduty.com/docs/guides/custom-event-transformer/) in our ops doc.

