### PR TITLE
fix: error extractor does not return capitalized error strings

### DIFF
--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -258,11 +258,11 @@ export const extractErrorMessage = (error: ApolloError | ErrorResponse) => {
   switch (errorType) {
     case '401':
     case '403':
-      return message || 'You are not authorized to perform this request';
+      return capitalize(message) || 'You are not authorized to perform this request';
     case '404':
-      return message || "The resource you requested couldn't be found on our servers";
+      return capitalize(message) || "The resource you requested couldn't be found on our servers";
     default:
-      return message;
+      return capitalize(message);
   }
 };
 


### PR DESCRIPTION
## Background

Errors coming from the backend and directly presented in the frontend are sometimes not capitalized. We should show errors in a more natural way, i.e. capitalizing the first letter of the string or sentence describing an error.

## Changes

- Modified the frontend helper `extractErrorMessage` to return an error string with the first letter capitalized.

## Testing

- tests pass, although this change shouldn't affect testing.
