### PR TITLE
Add missing pantherlog.RegisteredFieldNamesJSON helper

### DIFF
--- a/internal/log_analysis/log_processor/pantherlog/meta.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta.go
@@ -124,6 +124,17 @@ func FieldNameJSON(kind FieldID) string {
 	return registeredFieldNamesJSON[kind]
 }
 
+// RegisteredFieldNamesJSON returns the JSON field names for registered indicator fields
+func RegisteredFieldNamesJSON() (names []string) {
+	for id, name := range registeredFieldNamesJSON {
+		if id.IsCore() {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
 func init() {
 	MustRegisterIndicator(FieldIPAddress, FieldMeta{
 		Name:        "PantherAnyIPAddresses",


### PR DESCRIPTION
## Background

The helper got dropped somewhere along the way

## Changes

- Adds `pantherlog.RegisteredFieldNamesJSON` helper

