### PR TITLE
Fix Sync automation milestone issue

### DIFF
--- a/build/actions/pr_sync/dist/index.js
+++ b/build/actions/pr_sync/dist/index.js
@@ -1,3 +1,21 @@
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 module.exports = /******/ (function (modules, runtime) {
   // webpackBootstrap
   /******/ 'use strict'; // The module cache

--- a/build/actions/pr_sync/dist/index.js
+++ b/build/actions/pr_sync/dist/index.js
@@ -1,21 +1,3 @@
-/**
- * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 module.exports = /******/ (function (modules, runtime) {
   // webpackBootstrap
   /******/ 'use strict'; // The module cache
@@ -795,10 +777,19 @@ module.exports = /******/ (function (modules, runtime) {
           // https://developer.github.com/v3/issues/#update-an-issue
           core.debug('Setting assignees, labels & milestone...');
           try {
+            let milestoneId;
+            if (srcPullRequest.milestone) {
+              const destMilestones = await octokit.request(`GET /repos/${repo}/milestones`);
+              const matchingMilestone = destMilestones.find(
+                milestone => milestone.title === srcPullRequest.milestone.title
+              );
+              milestoneId = matchingMilestone ? matchingMilestone.number : null;
+            }
+
             await octokit.request(`PATCH /repos/${repo}/issues/${destPullRequest.number}`, {
               assignees: srcPullRequest.assignees.map(assignee => assignee.login),
               labels: srcPullRequest.labels.map(label => label.name),
-              milestone: srcPullRequest.milestone ? srcPullRequest.milestone.number : null,
+              milestone: milestoneId,
             });
           } catch (error) {
             core.debug(error.message);

--- a/build/actions/pr_sync/dist/index.js
+++ b/build/actions/pr_sync/dist/index.js
@@ -779,7 +779,9 @@ module.exports = /******/ (function (modules, runtime) {
           try {
             let milestoneId;
             if (srcPullRequest.milestone) {
-              const destMilestones = await octokit.request(`GET /repos/${repo}/milestones`);
+              const { data: destMilestones } = await octokit.request(
+                `GET /repos/${repo}/milestones`
+              );
               const matchingMilestone = destMilestones.find(
                 milestone => milestone.title === srcPullRequest.milestone.title
               );

--- a/build/actions/pr_sync/index.js
+++ b/build/actions/pr_sync/index.js
@@ -48,7 +48,7 @@ const main = async () => {
     try {
       let milestoneId;
       if (srcPullRequest.milestone) {
-        const destMilestones = await octokit.request(`GET /repos/${repo}/milestones`);
+        const { data: destMilestones } = await octokit.request(`GET /repos/${repo}/milestones`);
         const matchingMilestone = destMilestones.find(
           milestone => milestone.title === srcPullRequest.milestone.title
         );

--- a/build/actions/pr_sync/index.js
+++ b/build/actions/pr_sync/index.js
@@ -46,10 +46,19 @@ const main = async () => {
     // https://developer.github.com/v3/issues/#update-an-issue
     core.debug('Setting assignees, labels & milestone...');
     try {
+      let milestoneId;
+      if (srcPullRequest.milestone) {
+        const destMilestones = await octokit.request(`GET /repos/${repo}/milestones`);
+        const matchingMilestone = destMilestones.find(
+          milestone => milestone.title === srcPullRequest.milestone.title
+        );
+        milestoneId = matchingMilestone ? matchingMilestone.number : null;
+      }
+
       await octokit.request(`PATCH /repos/${repo}/issues/${destPullRequest.number}`, {
         assignees: srcPullRequest.assignees.map(assignee => assignee.login),
         labels: srcPullRequest.labels.map(label => label.name),
-        milestone: srcPullRequest.milestone ? srcPullRequest.milestone.number : null,
+        milestone: milestoneId,
       });
     } catch (error) {
       core.debug(error.message);


### PR DESCRIPTION
## Background

There was an issue in our sync automation where milestones were not cloned correctly. The issue was that milestones have different IDs across different repos.

This PR fixes that by comparing the "names" of milestones when choosing which one to assign

## Changes

- Attempt to clone milestone based on name

## Testing

- Verified in forked repos
