### PR TITLE
Fix bug with log processor destination S3 object key

### DIFF
--- a/cmd/devtools/logprocessor/logprocessor/main.go
+++ b/cmd/devtools/logprocessor/logprocessor/main.go
@@ -114,8 +114,14 @@ func main() {
 		log.Fatal("failed to build zap logger: " + err.Error())
 	}
 	zap.ReplaceGlobals(logger)
+	// Use a properly configured JSON instance with AWS Glue quirks
+	jsonAPI := common.BuildJSON()
+	// Use the global registry
+	logTypes := registry.Default()
 
-	err = processor.Process(streamChan, destinations.CreateS3Destination(registry.Default()))
+	dest := destinations.CreateS3Destination(logTypes, jsonAPI)
+
+	err = processor.Process(streamChan, dest)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -379,9 +379,10 @@ func (bs *s3EventBufferSet) getBuffer(event *parsers.Result) *s3EventBuffer {
 	eventTime := event.PantherEventTime
 	if eventTime.IsZero() {
 		eventTime = event.PantherParseTime
-	}
-	if eventTime.IsZero() {
-		eventTime = time.Now()
+		if eventTime.IsZero() {
+			zap.L().Warn(`parsed result has zero parse time`, zap.String(`logType`, event.PantherLogType))
+			eventTime = time.Now()
+		}
 	}
 	// bin by hour (this is our partition size)
 	// We convert to UTC here so truncation does not affect the partition in the weird half-hour timezones if for

--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -310,8 +310,9 @@ func (destination *S3Destination) getS3ObjectKey(logType string, timestamp time.
 		return "", errors.Errorf(`unknown log type %q`, logType)
 	}
 	meta := typ.GlueTableMeta()
+	timestamp = timestamp.UTC()
 	return fmt.Sprintf(s3ObjectKeyFormat,
-		meta.GetPartitionPrefix(timestamp.UTC()), // get the path to store the data in S3
+		meta.GetPartitionPrefix(timestamp), // get the path to store the data in S3
 		timestamp.Format(S3ObjectTimestampFormat),
 		uuid.New().String(),
 	), nil

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -21,6 +21,8 @@ package destinations
 import (
 	"bytes"
 	"compress/gzip"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog/null"
 	"io/ioutil"
 	"strings"
 	"sync"
@@ -59,6 +61,12 @@ var (
 	// same as above plus 1 hour
 	refTimePlusHour   = (timestamp.RFC3339)((time.Time)(refTime).Add(time.Hour))
 	expectedS3Prefix2 = "logs/testlogtype/year=2020/month=01/day=01/hour=01/20200101T010000Z"
+
+	refParseTime  = time.Now()
+	resultBuilder = pantherlog.ResultBuilder{
+		NextRowID: pantherlog.StaticRowID("row_id"),
+		Now:       pantherlog.StaticNow(refParseTime),
+	}
 )
 
 type mockParser struct {
@@ -101,6 +109,24 @@ type mockSns struct {
 type testEvent struct {
 	Data string
 	parsers.PantherLog
+}
+
+type fooEvent struct {
+	Time time.Time   `json:"ts" tcodec:"rfc3339" panther:"event_time" description:"ts"`
+	Foo  null.String `json:"foo" description:"foo"`
+}
+
+var refEvent = &fooEvent{
+	Time: time.Time(refTime),
+	Foo:  null.FromString("bar"),
+}
+
+func newTestResult(event interface{}) *parsers.Result {
+	if event == nil {
+		event = refEvent
+	}
+	result, _ := resultBuilder.BuildResult(testLogType, event)
+	return result
 }
 
 func newSimpleTestEvent() *parsers.PantherLog {
@@ -179,8 +205,7 @@ func TestSendDataToS3BeforeTerminating(t *testing.T) {
 	destination := newS3Destination()
 	eventChannel := make(chan *parsers.Result, 1)
 
-	testEvent := newSimpleTestEvent()
-	testResult := testEvent.Result()
+	testResult := newTestResult(nil)
 
 	// Gzipping the test event
 	// Do that now so that the event release does not affect output
@@ -248,8 +273,10 @@ func TestSendDataIfTotalMemSizeLimitHasBeenReached(t *testing.T) {
 	destination := newS3Destination()
 	eventChannel := make(chan *parsers.Result, 2)
 
-	testEvent := newSimpleTestEvent()
-	testResult := testEvent.Result()
+	// Use 1 result with `panther:"event_time"` struct tag
+	testResult1 := newTestResult(nil)
+	// Use 1 result with embedded panther log
+	testResult2 := newSimpleTestEvent().Result()
 
 	// wire it up
 	destination.maxBufferedMemBytes = 0 // this will cause each event to trigger a send
@@ -257,8 +284,8 @@ func TestSendDataIfTotalMemSizeLimitHasBeenReached(t *testing.T) {
 	// sending 2 events to buffered channel
 	// The second should already cause the S3 object size limits to be exceeded
 	// so we expect two objects to be written to s3
-	eventChannel <- testResult
-	eventChannel <- testResult
+	eventChannel <- testResult1
+	eventChannel <- testResult2
 
 	destination.mockS3Uploader.On("Upload", mock.Anything, mock.Anything).Return(&s3manager.UploadOutput{}, nil).Twice()
 	destination.mockSns.On("Publish", mock.Anything).Return(&sns.PublishOutput{}, nil).Twice()
@@ -267,6 +294,12 @@ func TestSendDataIfTotalMemSizeLimitHasBeenReached(t *testing.T) {
 
 	destination.mockS3Uploader.AssertExpectations(t)
 	destination.mockSns.AssertExpectations(t)
+
+	// Verify proper buckets were used for both events
+	key1 := destination.mockS3Uploader.Calls[0].Arguments.Get(0).(*s3manager.UploadInput).Key
+	require.Equal(t, expectedS3Prefix, aws.StringValue(key1)[:len(expectedS3Prefix)])
+	key2 := destination.mockS3Uploader.Calls[1].Arguments.Get(0).(*s3manager.UploadInput).Key
+	require.Equal(t, expectedS3Prefix, aws.StringValue(key2)[:len(expectedS3Prefix)])
 }
 
 func TestSendDataIfBufferSizeLimitHasBeenReached(t *testing.T) {

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -21,8 +21,6 @@ package destinations
 import (
 	"bytes"
 	"compress/gzip"
-	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
-	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog/null"
 	"io/ioutil"
 	"strings"
 	"sync"
@@ -43,6 +41,8 @@ import (
 	"github.com/panther-labs/panther/api/lambda/core/log_analysis/log_processor/models"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/common"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/logtypes"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog/null"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/testutil"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/timestamp"

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -144,6 +144,7 @@ func newS3Destination(logTypes ...string) *testS3Destination {
 			maxBufferedMemBytes: 10 * 1024 * 1024, // an arbitrary amount enough to hold default test data
 			maxDuration:         maxDuration,
 			registry:            newRegistry(logTypes...),
+			jsonAPI:             common.BuildJSON(),
 		},
 		mockSns:        mockSns,
 		mockS3Uploader: mockS3Uploader,
@@ -464,7 +465,7 @@ func TestSendDataFailsIfSnsFails(t *testing.T) {
 func TestBufferSetLargest(t *testing.T) {
 	const size = 100
 	event := newTestEvent(testLogType, refTime)
-	bs := newS3EventBufferSet()
+	bs := newS3EventBufferSet(common.BuildJSON())
 	result := event.Result()
 	expectedLargest := bs.getBuffer(result)
 	expectedLargest.bytes = size

--- a/internal/log_analysis/log_processor/processor/stream.go
+++ b/internal/log_analysis/log_processor/processor/stream.go
@@ -144,8 +144,11 @@ func streamEvents(sqsClient sqsiface.SQSAPI, deadlineTime time.Time, event event
 		}
 	}()
 
+	// Use a properly configured JSON API for Athena quirks
+	jsonAPI := common.BuildJSON()
+	registeredLogTypes := registry.Default()
 	// process streamChan until closed (blocks)
-	err = processFunc(streamChan, destinations.CreateS3Destination(registry.Default()))
+	err = processFunc(streamChan, destinations.CreateS3Destination(registeredLogTypes, jsonAPI))
 	if err != nil { // prefer Process() error to readEventError
 		return 0, err
 	}


### PR DESCRIPTION
## Background

There was a bug introduced when writing `pantherlog.Result` in S3 where all results were placed in a zero timestamp S3 object when the event being written specified the event time via a struct tag. 

## Changes

- Serialize the event *before* picking a bucket to put it into
- Pass the `jsoniter.API` to use as an argument in `CreateS3Destination`
- Adds `s3BufferSet.writeEvent(event *pathnerlog.Result) (*s3Buffer, error)` method to handle the writing of events.

## Testing

- mage test:ci
- e2e tests with mage:deploy and verified query results + bucket tree
