### PR TITLE
Backport pantherlog fixes from EE

### DIFF
--- a/internal/log_analysis/log_processor/logtypes/registry.go
+++ b/internal/log_analysis/log_processor/logtypes/registry.go
@@ -149,6 +149,7 @@ type Entry interface {
 	NewParser(params interface{}) (parsers.Interface, error)
 	Schema() interface{}
 	GlueTableMeta() *awsglue.GlueTableMetadata
+	String() string
 }
 
 // Config describes a log event type in a declarative way.
@@ -238,6 +239,11 @@ func newEntry(desc Desc, schema interface{}, fac parsers.Factory) *entry {
 func (e *entry) Describe() Desc {
 	return e.Desc
 }
+
+func (e *entry) String() string {
+	return e.Desc.Name
+}
+
 func (e *entry) Schema() interface{} {
 	return e.schema
 }

--- a/internal/log_analysis/log_processor/pantherlog/jsoniter.go
+++ b/internal/log_analysis/log_processor/pantherlog/jsoniter.go
@@ -21,6 +21,7 @@ package pantherlog
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 	"unsafe"
 
@@ -146,6 +147,7 @@ func (*resultEncoder) writePantherFields(r *Result, stream *jsoniter.Stream) {
 		if !ok {
 			continue
 		}
+		sort.Strings(values)
 		stream.WriteMore()
 		stream.WriteObjectField(fieldName)
 		stream.WriteArrayStart()

--- a/internal/log_analysis/log_processor/pantherlog/jsoniter.go
+++ b/internal/log_analysis/log_processor/pantherlog/jsoniter.go
@@ -282,8 +282,10 @@ func (e *eventTimeEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		return
 	}
 	if result, ok := stream.Attachment.(*Result); ok {
+		// We only override the result event time if the tag was `panther:"event_time,override" or
+		// if we're the first to set the event time. See usage comments on `tagEventTime` const above.
 		if e.override || result.PantherEventTime.IsZero() {
-			result.PantherEventTime = *tm
+			result.PantherEventTime = tm.UTC()
 		}
 	}
 }

--- a/internal/log_analysis/log_processor/pantherlog/jsoniter_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/jsoniter_test.go
@@ -20,6 +20,7 @@ package pantherlog
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -118,4 +119,43 @@ func TestPantherExt_DecorateEncoder(t *testing.T) {
 	require.Equal(t, []string{"ok"}, result.values.Get(kindQuux), "quux")
 	actual := string(stream.Buffer())
 	require.Equal(t, `{"foo":"ok","bar":"ok","baz":"ok","qux":"ok","quux":"ok"}`, actual)
+}
+
+func TestResultEncoder(t *testing.T) {
+	now := time.Now()
+	tm := now.Add(-1 * time.Minute)
+	loc, err := time.LoadLocation(`Europe/Athens`)
+	assert := require.New(t)
+	assert.NoError(err)
+	type T struct {
+		Time     time.Time `json:"tm" panther:"event_time"`
+		RemoteIP string    `json:"remote_ip" panther:"ip"`
+		LocalIP  string    `json:"local_ip" panther:"ip"`
+	}
+	event := T{
+		Time:     tm.In(loc),
+		RemoteIP: "2.2.2.2",
+		LocalIP:  "1.1.1.1",
+	}
+	result := Result{
+		CoreFields: CoreFields{
+			PantherLogType:   "Foo.Bar",
+			PantherRowID:     "id",
+			PantherParseTime: now.UTC(),
+		},
+		Event: &event,
+	}
+	actual, err := jsoniter.MarshalToString(&result)
+	assert.NoError(err)
+	expect := fmt.Sprintf(`{
+		"tm": "%s",
+		"remote_ip":"2.2.2.2",
+		"local_ip":"1.1.1.1",
+		"p_row_id": "id",
+		"p_event_time": "%s",
+		"p_parse_time": "%s",
+		"p_any_ip_addresses": ["1.1.1.1", "2.2.2.2"],
+		"p_log_type": "Foo.Bar"
+	}`, tm.In(loc).Format(time.RFC3339Nano), tm.UTC().Format(time.RFC3339Nano), now.UTC().Format(time.RFC3339Nano))
+	assert.JSONEq(expect, actual)
 }

--- a/internal/log_analysis/log_processor/parsers/gravitationallogs/audit_test.go
+++ b/internal/log_analysis/log_processor/parsers/gravitationallogs/audit_test.go
@@ -175,7 +175,7 @@ func TestTeleportAudit(t *testing.T) {
 					"uid": "9f2bc778-e87e-4536-9c3f-0d4a57955fd0",
 					"user": "kostaspap",
 					"p_event_time": "2020-08-07T07:52:25Z",
-					"p_any_ip_addresses": ["127.0.0.1", "1.1.1.1"],
+				    "p_any_ip_addresses": ["1.1.1.1","127.0.0.1"],
 					"p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
 					"p_log_type": "%s"
 				}`, logTypeTeleportAudit),

--- a/internal/log_analysis/log_processor/parsers/gravitationallogs/audit_test.go
+++ b/internal/log_analysis/log_processor/parsers/gravitationallogs/audit_test.go
@@ -83,7 +83,7 @@ func TestTeleportAudit(t *testing.T) {
 				  "uid": "34bb01d5-8cef-4925-875a-783b2dbee3b6",
 				  "user": "kostaspap",
 				  "p_event_time": "2020-08-07T07:52:09.821Z",
-				  "p_any_ip_addresses": ["127.0.0.1", "1.1.1.1"],
+				  "p_any_ip_addresses": ["1.1.1.1","127.0.0.1"],
 				  "p_any_domain_names": ["ip-172-31-14-137.us-west-2.compute.internal"],
 				  "p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
 				  "p_log_type": "%s"


### PR DESCRIPTION
## Background

These fixes exist in an the crowdstrike parsers branch and should be included in OSS as well

## Changes

- Fix regression on indicator values sorting
- Ensure `panther:"event_time" struct tag sets UTC timestsamp
- Implement `fmt.Stringer` on logtypes entry

## Testing

- maget test:ci
