### PR TITLE
fix: events threshold appearing on policy form. Closes #1352

### DIFF
--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/BaseRuleFormCoreSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/BaseRuleFormCoreSection.tsx
@@ -141,7 +141,7 @@ const BaseRuleFormCoreSection: React.FC<BaseRuleFormCoreSectionProps> = ({ type 
           placeholder={`Additional context about this ${type}`}
           name="description"
         />
-        <SimpleGrid columns={1} spacing={5} mb={5}>
+        <SimpleGrid columns={1} spacing={5}>
           <FastField
             as={FormikTextArea}
             label="Runbook"
@@ -158,15 +158,17 @@ const BaseRuleFormCoreSection: React.FC<BaseRuleFormCoreSectionProps> = ({ type 
               name="reference"
             />
           </Box>
-          <Box flexGrow={1}>
-            <Field
-              as={FormikNumberInput}
-              label="* Events Threshold"
-              min={0}
-              name="threshold"
-              placeholder="Send an alert only after # events"
-            />
-          </Box>
+          {!isPolicy && (
+            <Box flexGrow={1}>
+              <Field
+                as={FormikNumberInput}
+                label="* Events Threshold"
+                min={0}
+                name="threshold"
+                placeholder="Send an alert only after # events"
+              />
+            </Box>
+          )}
         </Flex>
       </SimpleGrid>
       <SimpleGrid columns={4} spacing={5}>


### PR DESCRIPTION
## Background

Make  sure that events threshold doesn't appear on policy form page


Closes #1352 

## Changes

- Exclude `events threshold` from policy form screen

## Testing

- Visual. No need to write a  test case for that
