### PR TITLE
Data Catalog updater should ignore partitions for non-existent tables

### DIFF
--- a/internal/log_analysis/awsglue/wrappers.go
+++ b/internal/log_analysis/awsglue/wrappers.go
@@ -49,8 +49,8 @@ func DeleteDatabase(client glueiface.GlueAPI, name string) (*glue.DeleteDatabase
 
 func GetTable(client glueiface.GlueAPI, databaseName, tableName string) (*glue.GetTableOutput, error) {
 	tableInput := &glue.GetTableInput{
-		DatabaseName: aws.String(databaseName),
-		Name:         aws.String(tableName),
+		DatabaseName: &databaseName,
+		Name:         &tableName,
 	}
 	return client.GetTable(tableInput)
 }

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -18,15 +18,6 @@ package awsutils
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/**
- * Copyright (C) 2020 Panther Labs Inc
- *
- * Panther Enterprise is licensed under the terms of a commercial license available from
- * Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.
- * All use, distribution, and/or modification of this software, whether commercial or non-commercial,
- * falls under the Panther Commercial License to the extent it is permitted.
- */
-
 import "github.com/aws/aws-sdk-go/aws/awserr"
 
 // Method returns true if the provided error is an AWS error with any

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -1,0 +1,45 @@
+package awsutils
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * Panther Enterprise is licensed under the terms of a commercial license available from
+ * Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.
+ * All use, distribution, and/or modification of this software, whether commercial or non-commercial,
+ * falls under the Panther Commercial License to the extent it is permitted.
+ */
+
+import "github.com/aws/aws-sdk-go/aws/awserr"
+
+// Method returns true if the provided error is an AWS error with any
+// of the given codes.
+func IsAnyError(err error, codes ...string) bool {
+	awserror, ok := err.(awserr.Error)
+	if !ok {
+		return false
+	}
+	for _, code := range codes {
+		if awserror.Code() == code {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Background

Currently, in case some user send to Panther data of a log type not configured in the Log sources, the Data Catalog updater will fail trying to create partitions for a non-existent table. 
I am modifying this behavior so that the data catalog updater ignores such partitions. 

## Changes

- Added helper method awsutils.IsAnyError to deal with AWS errors
- Small updates in code I saw

## Testing

- unit test
- Deployed in my account. Drop manually an existing table. See data catalog updater ignore partitions for non-existent tables. 

While working on this, I thought maybe another action might be more appropriate - in case a table doesn't exist, create it. I opted for this approach since it seemed easier to develop - and the way our current system is designed, it should work fine as well. 

@rleighton will this approach work in case of historical (compressed) tables?