### PR TITLE
Firing Max Duration alarm only in case a problem persists

### DIFF
--- a/internal/core/custom_resources/resources/alarms_lambda.go
+++ b/internal/core/custom_resources/resources/alarms_lambda.go
@@ -206,6 +206,7 @@ func putLambdaAlarmGroup(props LambdaAlarmProperties) error {
 	input.Statistic = aws.String(cloudwatch.StatisticMaximum)
 	input.Threshold = aws.Float64(float64(props.FunctionTimeoutSec) * 1000 * 0.9)
 	input.Unit = aws.String(cloudwatch.StandardUnitMilliseconds)
+	input.EvaluationPeriods = aws.Int64(3)
 	if err := putMetricAlarm(input); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Background

Currently we will trigger an CW Alarm in case one AWS Lambda invocation runs for more than 90% of its configured timeout. 
Updating the alarm to fire only if this happens for 3 consecutive evaluation periods - if the problem persists. Many times a lambda could timeout due to some network hiccup. 
