### PR TITLE
Fix: issue with tooltip on charts

### DIFF
--- a/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
@@ -133,7 +133,6 @@ const TimeSeriesChart: React.FC<TimeSeriesLinesProps> = ({
         }),
         tooltip: {
           trigger: 'axis' as const,
-          position: pt => [(pt[0] as number) + 40, '0%'],
           backgroundColor: theme.colors['navyblue-300'],
           formatter: (params: EChartOption.Tooltip.Format[]) => {
             if (!params || !params.length) {


### PR DESCRIPTION
## Background

On small screens the chart tooltip overflows. This fixes it.

## Problem

![Screen Shot 2020-08-14 at 10 13 55 AM](https://user-images.githubusercontent.com/10436045/90277346-0fbc7800-de6e-11ea-8c38-69d7bf85e946.png)


## Changes

- Remove fixed tooltip positioning. Allow e-charts to handle it internally

## Testing

- Viz
