### PR TITLE
Fix SNS subscription

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -1069,6 +1069,15 @@ Resources:
           STREAM_NAME: !Ref MessageForwarderFirehose
       Tracing: !If [TracingEnabled, !Ref TracingMode, !Ref 'AWS::NoValue']
       Policies:
+        - Id: ConfirmSnsSubscriptions
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              # This policy allows the message forwarder to confirm SNS->SQS subscriptions to SQS source queues.
+              # Note that by default SQS queue policy blocks all accounts from subscribing to it.
+              # When a user onboards an SQS log source, they whitelist the SNS topics that can send messages to their SQS queue.
+              Action: sns:ConfirmSubscription
+              Resource: '*'
         - Id: ReadFromSqs
           Version: 2012-10-17
           Statement:

--- a/internal/log_analysis/message_forwarder/config/config.go
+++ b/internal/log_analysis/message_forwarder/config/config.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	Env            EnvConfig
-	awsSession     *session.Session
+	AwsSession     *session.Session
 	FirehoseClient firehoseiface.FirehoseAPI
 	LambdaClient   lambdaiface.LambdaAPI
 )
@@ -47,8 +47,8 @@ type EnvConfig struct {
 // Setup parses the environment and builds the AWS and http clients.
 func Setup() {
 	envconfig.MustProcess("", &Env)
-	awsSession = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(MaxRetries)))
+	AwsSession = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(MaxRetries)))
 
-	FirehoseClient = firehose.New(awsSession)
-	LambdaClient = lambda.New(awsSession)
+	FirehoseClient = firehose.New(AwsSession)
+	LambdaClient = lambda.New(AwsSession)
 }

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder.go
@@ -26,8 +26,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 
 	sourcemodels "github.com/panther-labs/panther/api/lambda/source/models"
@@ -44,7 +47,10 @@ type Message struct {
 
 const RecordDelimiter = '\n'
 
-var sourcesCache = cache.New(getSourceInfo)
+var (
+	sourcesCache = cache.New(getSourceInfo)
+	getSnsClientFunc = getSnsClient
+)
 
 func Handle(ctx context.Context, event *events.SQSEvent) error {
 	var firehoseRecords []*firehose.Record
@@ -59,6 +65,15 @@ func Handle(ctx context.Context, event *events.SQSEvent) error {
 		}
 		integrationID := cacheValue.(string)
 		zap.L().Debug("Found integration", zap.String("integrationId", integrationID))
+		isSubscriptionMsg, err := confirmIfSnsSubscriptionMessage(record.Body)
+		if isSubscriptionMsg {
+			if err != nil {
+				// best effort - just log warning
+				zap.L().Warn("failed to confirm subscription", zap.Error(err))
+			}
+			continue
+		}
+
 		message := Message{
 			Payload:             record.Body,
 			SourceIntegrationID: integrationID,
@@ -117,4 +132,43 @@ func getQueueNameFromURL(queueURL string) string {
 		panic("failed to parse queue URL")
 	}
 	return urlParts[len(urlParts)-1]
+}
+
+// Tries to identify if message is an SNS topic subscription message
+func confirmIfSnsSubscriptionMessage(message string) (bool, error) {
+	msgType := gjson.Get(message, "Type")
+	if !msgType.Exists() {
+		return false, nil
+	}
+	if msgType.String() != "SubscriptionConfirmation" {
+		return false, nil
+	}
+	topicArn := gjson.Get(message, "TopicArn")
+	if !topicArn.Exists() {
+		return false, nil
+	}
+	token := gjson.Get(message, "Token")
+	if !token.Exists() {
+		return false, nil
+	}
+	parsedTopicArn, err := arn.Parse(topicArn.String())
+	if err != nil {
+		return false, nil
+	}
+
+	snsClient := getSnsClientFunc(parsedTopicArn.Region)
+	subscriptionConfiguration := &sns.ConfirmSubscriptionInput{
+		Token:    aws.String(token.String()),
+		TopicArn: aws.String(topicArn.String()),
+	}
+	_, err = snsClient.ConfirmSubscription(subscriptionConfiguration)
+	if err != nil {
+		return true, errors.Wrapf(err, "failed to confirm subscription for: %s", topicArn.String())
+	}
+	return true, nil
+}
+
+
+func getSnsClient(region string) snsiface.SNSAPI {
+	return sns.New(config.AwsSession, aws.NewConfig().WithRegion(region))
 }

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder.go
@@ -48,7 +48,7 @@ type Message struct {
 const RecordDelimiter = '\n'
 
 var (
-	sourcesCache = cache.New(getSourceInfo)
+	sourcesCache     = cache.New(getSourceInfo)
 	getSnsClientFunc = getSnsClient
 )
 
@@ -167,7 +167,6 @@ func confirmIfSnsSubscriptionMessage(message string) (bool, error) {
 	}
 	return true, nil
 }
-
 
 func getSnsClient(region string) snsiface.SNSAPI {
 	return sns.New(config.AwsSession, aws.NewConfig().WithRegion(region))

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
@@ -292,7 +292,6 @@ func TestShouldConfirmSnsSubscriptionMessage(t *testing.T) {
 	mockSns.AssertExpectations(t)
 }
 
-
 func resetCache() {
 	sourcesCache = cache.New(getSourceInfo)
 }

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/sns"
+	snsiface "github.com/aws/aws-sdk-go/service/sns/snsiface"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
@@ -244,6 +246,52 @@ func TestShouldFailIfFailureToPutRecord(t *testing.T) {
 	mockLambda.AssertExpectations(t)
 	mockFirehose.AssertExpectations(t)
 }
+
+func TestShouldConfirmSnsSubscriptionMessage(t *testing.T) {
+	mockLambda := &testutils.LambdaMock{}
+	config.LambdaClient = mockLambda
+	mockFirehose := &testutils.FirehoseMock{}
+	config.FirehoseClient = mockFirehose
+	config.Env.StreamName = "testStreamName"
+	resetCache()
+	mockSns := &testutils.SnsMock{}
+	getSnsClientFunc = func(region string) snsiface.SNSAPI {
+		return mockSns
+	}
+
+	// nolint: lll
+	snsConfirmationMsg := "{\"Type\" : \"SubscriptionConfirmation\",\n  \"MessageId\" : \"5d694afe-8598-422b-8a8b-578333d50df9\",\n  \"Token\" : \"2336412f37fb687f5d51e6e2425f004ae15784e4195f44c480796e9181756a3bf7e81188d3e842a98\",\n  \"TopicArn\" : \"arn:aws:sns:us-east-1:123456789012:testing-stuff\",\n  \"Message\" : \"You have chosen to subscribe to the topic arn:aws:sns:us-east-1:123456789012:testing-stuff.\\nTo confirm the subscription, visit the SubscribeURL included in this message.\",\n  \"SubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription\u0026TopicArn=arn:aws:sns:us-east-1:012345678912:testing-stuff\u0026Token=213412412342134\",\n  \"Timestamp\" : \"2020-08-19T12:13:24.717Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"oEsP+\",\n  \"SigningCertURL\" : \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem\"\n}"
+	sqsEvent := &events.SQSEvent{
+		Records: []events.SQSMessage{
+			{
+				EventSourceARN: "arn:aws:sqs:eu-west-2:123456789012:test-queue-1",
+				Body:           snsConfirmationMsg,
+			},
+		},
+	}
+
+	marshaledSources, err := jsoniter.Marshal(availableSqsSources)
+	require.NoError(t, err)
+
+	mockLambda.On("Invoke", mock.Anything).Return(
+		&lambda.InvokeOutput{
+			Payload:    marshaledSources,
+			StatusCode: aws.Int64(http.StatusOK),
+		}, nil)
+
+	expectedSnsConfirmation := &sns.ConfirmSubscriptionInput{
+		TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:testing-stuff"),
+		Token:    aws.String("2336412f37fb687f5d51e6e2425f004ae15784e4195f44c480796e9181756a3bf7e81188d3e842a98"),
+	}
+	mockSns.On("ConfirmSubscription", expectedSnsConfirmation).Return(&sns.ConfirmSubscriptionOutput{}, nil)
+
+	require.NoError(t, Handle(context.TODO(), sqsEvent))
+
+	mockLambda.AssertExpectations(t)
+	mockFirehose.AssertExpectations(t)
+	mockSns.AssertExpectations(t)
+}
+
 
 func resetCache() {
 	sourcesCache = cache.New(getSourceInfo)

--- a/pkg/awsbatch/kinesisbatch/put_records_test.go
+++ b/pkg/awsbatch/kinesisbatch/put_records_test.go
@@ -20,6 +20,7 @@ package kinesisbatch
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -53,7 +54,7 @@ func (m *mockKinesis) PutRecords(input *kinesis.PutRecordsInput) (*kinesis.PutRe
 		if i == 0 || !m.unprocessedItems {
 			// Success if this is first record or failure not requested
 			result.Records = append(result.Records, &kinesis.PutRecordsResultEntry{
-				SequenceNumber: aws.String(string(i)),
+				SequenceNumber: aws.String(strconv.Itoa(i)),
 				ShardId:        aws.String("shard-id"),
 			})
 		} else {

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -292,6 +292,11 @@ func (m *SnsMock) Publish(input *sns.PublishInput) (*sns.PublishOutput, error) {
 	return args.Get(0).(*sns.PublishOutput), args.Error(1)
 }
 
+func (m *SnsMock) ConfirmSubscription(input *sns.ConfirmSubscriptionInput) (*sns.ConfirmSubscriptionOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sns.ConfirmSubscriptionOutput), args.Error(1)
+}
+
 type FirehoseMock struct {
 	firehoseiface.FirehoseAPI
 	mock.Mock


### PR DESCRIPTION
## Background

As part of 1.7 we have introduced SQS source. 
One usecase is that users can forward messages to Panther making use of SNS->SQS subscription. 
However, if the SNS topic is in a different account than SQS, a confirmation message is sent. We need to confirm that message for the SNS topic to be able to forward messages to SQS. 

## Changes

- Message Forwarder Lambda now confirms SNS->SQS subscription messages

## Testing

- unit test
- deployed and verified cross-account subscription confirmation
