### PR TITLE
Fix awsretry to initialize with NumMaxRetries

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/clients.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/clients.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"go.uber.org/zap"
@@ -65,8 +66,8 @@ var clientCache = make(map[clientKey]cachedClient)
 
 func Setup() {
 	awsConfig := aws.NewConfig().WithMaxRetries(maxRetries)
-	awsConfig.Retryer = awsretry.NewConnectionErrRetryer()
-	snapshotPollerSession = session.Must(session.NewSession(awsConfig))
+	snapshotPollerSession = session.Must(session.NewSession(request.WithRetryer(awsConfig,
+		awsretry.NewConnectionErrRetryer(*awsConfig.MaxRetries))))
 }
 
 // getClient returns a valid client for a given integration, service, and region using caching.

--- a/internal/log_analysis/log_processor/common/common.go
+++ b/internal/log_analysis/log_processor/common/common.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
@@ -37,7 +38,7 @@ import (
 )
 
 const (
-	MaxRetries     = 25 // setting Max Retries to a high number - we'd like to retry VERY hard before failing.
+	MaxRetries     = 15 // retrying for ~15'
 	EventDelimiter = '\n'
 )
 
@@ -61,8 +62,8 @@ type EnvConfig struct {
 
 func Setup() {
 	awsConfig := aws.NewConfig().WithMaxRetries(MaxRetries)
-	awsConfig.Retryer = awsretry.NewConnectionErrRetryer()
-	Session = session.Must(session.NewSession(awsConfig))
+	Session = session.Must(session.NewSession(request.WithRetryer(awsConfig,
+		awsretry.NewConnectionErrRetryer(*awsConfig.MaxRetries))))
 	LambdaClient = lambda.New(Session)
 	S3Uploader = s3manager.NewUploader(Session)
 	SqsClient = sqs.New(Session)

--- a/pkg/awsretry/connection_retryer.go
+++ b/pkg/awsretry/connection_retryer.go
@@ -25,9 +25,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
-func NewConnectionErrRetryer() *ConnectionErrRetryer {
+func NewConnectionErrRetryer(maxRetries int) *ConnectionErrRetryer {
 	return &ConnectionErrRetryer{
-		DefaultRetryer: client.DefaultRetryer{},
+		DefaultRetryer: client.DefaultRetryer{
+			NumMaxRetries: maxRetries, // MUST be set or all retrying is skipped!
+		},
 	}
 }
 

--- a/pkg/awsretry/connection_retryer_test.go
+++ b/pkg/awsretry/connection_retryer_test.go
@@ -26,24 +26,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConnectionErrRetryerShouldRetry(t *testing.T) {
-	retryer := NewConnectionErrRetryer()
+func TestConnectionErrRetryerShouldRetryThrottledException(t *testing.T) {
+	retryer := NewConnectionErrRetryer(1)
 	sdkRequest := &request.Request{
-		Error: errors.New("read: connection reset by peer"),
+		Error: errors.New("ThrottledException"),
 	}
 	assert.True(t, retryer.ShouldRetry(sdkRequest))
 }
 
-func TestConnectionErrRetryerShouldNotRetryOtherErrors(t *testing.T) {
-	retryer := NewConnectionErrRetryer()
+func TestConnectionErrRetryerShouldRetry(t *testing.T) {
+	retryer := NewConnectionErrRetryer(1)
+	sdkRequest := &request.Request{
+		Error: errors.New("read: connection reset by peer"), // this is the one we added
+	}
+	assert.True(t, retryer.ShouldRetry(sdkRequest))
+}
+
+func TestConnectionErrRetryerShouldRetryOtherErrors(t *testing.T) {
+	retryer := NewConnectionErrRetryer(1)
 	sdkRequest := &request.Request{
 		Error: errors.New("random error"),
 	}
-	assert.False(t, retryer.ShouldRetry(sdkRequest))
+	assert.True(t, retryer.ShouldRetry(sdkRequest))
 }
 
 func TestConnectionErrRetryerShouldNotRetryNoErrors(t *testing.T) {
-	retryer := NewConnectionErrRetryer()
+	retryer := NewConnectionErrRetryer(1)
 	sdkRequest := &request.Request{}
 	assert.False(t, retryer.ShouldRetry(sdkRequest))
 }


### PR DESCRIPTION
## Before

The DefaultRetryer used was not initializing the NumMaxRetries, fix defaulted to 0 and no retries were being attempted.

## After

- Set NumMaxRetries in constructer 
- Set log processor MaxRetries to 15 (reverting previous change from 15 to 25, 25 is uneccessary)
- Used recommended request.WithRetryer() to apply retryer

## Testing

- mage test:ci
- deployed to security account where we have significant activity 
