### PR TITLE
Adds AWS indicator fields

### DIFF
--- a/internal/log_analysis/log_processor/pantherlog/meta.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta.go
@@ -66,6 +66,10 @@ const (
 	FieldSHA1Hash
 	FieldSHA256Hash
 	FieldTraceID
+	FieldAWSAccountID
+	FieldAWSInstanceID
+	FieldAWSARN
+	FieldAWSTag
 )
 
 // ScanValues implements ValueScanner interface
@@ -171,6 +175,26 @@ func init() {
 		Name:        "PantherAnyTraceIDs",
 		NameJSON:    "p_any_trace_ids",
 		Description: "Panther added field with collection of context trace identifiers",
+	})
+	MustRegisterIndicator(FieldAWSAccountID, FieldMeta{
+		Name:        "PantherAnyAWSAccountIDs",
+		NameJSON:    "p_any_aws_account_ids",
+		Description: "Panther added field with collection of AWS account ids associated with the row",
+	})
+	MustRegisterIndicator(FieldAWSInstanceID, FieldMeta{
+		Name:        "PantherAnyAWSInstanceIDs",
+		NameJSON:    "p_any_aws_instance_ids",
+		Description: "Panther added field with collection of AWS instance ids associated with the row",
+	})
+	MustRegisterIndicator(FieldAWSARN, FieldMeta{
+		Name:        "PantherAnyAWSARNs",
+		NameJSON:    "p_any_aws_arns",
+		Description: "Panther added field with collection of AWS ARNs associated with the row",
+	})
+	MustRegisterIndicator(FieldAWSTag, FieldMeta{
+		Name:        "PantherAnyAWSTags",
+		NameJSON:    "p_any_aws_tags",
+		Description: "Panther added field with collection of AWS Tags associated with the row",
 	})
 	MustRegisterScanner("ip", ValueScannerFunc(ScanIPAddress), FieldIPAddress)
 	MustRegisterScanner("domain", FieldDomainName, FieldDomainName)

--- a/internal/log_analysis/log_processor/pantherlog/scanners.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners.go
@@ -51,9 +51,17 @@ type scannerEntry struct {
 	Fields  []FieldID
 }
 
-// RegisterScanner registers a value scanner to be used on string fields with a `panther` struct tag.
+// MustRegisterScanner registers a value scanner to be used on string fields with a `panther` struct tag.
 // It panics in case of a registration error.
 func MustRegisterScanner(name string, scanner ValueScanner, fields ...FieldID) {
+	if err := RegisterScanner(name, scanner, fields...); err != nil {
+		panic(err)
+	}
+}
+
+// MustRegisterScannerFunc registers a value scanner to be used on string fields with a `panther` struct tag.
+// It panics in case of a registration error.
+func MustRegisterScannerFunc(name string, scanner ValueScannerFunc, fields ...FieldID) {
 	if err := RegisterScanner(name, scanner, fields...); err != nil {
 		panic(err)
 	}

--- a/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
@@ -19,10 +19,12 @@ package awslogs
  */
 
 import (
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 	"regexp"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 )
 
 const SizeAccountID = 12

--- a/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
@@ -1,0 +1,105 @@
+package awslogs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+	"regexp"
+	"strings"
+)
+
+const SizeAccountID = 12
+
+var rxAccountID = regexp.MustCompile(`^\d{12}$`)
+
+func init() {
+	pantherlog.MustRegisterScannerFunc("aws_arn", ScanARN,
+		pantherlog.FieldAWSARN,
+		pantherlog.FieldAWSInstanceID,
+		pantherlog.FieldAWSAccountID,
+	)
+	pantherlog.MustRegisterScannerFunc("aws_account_id", ScanAccountID, pantherlog.FieldAWSAccountID)
+	pantherlog.MustRegisterScannerFunc("aws_instance_id", ScanInstanceID, pantherlog.FieldAWSInstanceID)
+	pantherlog.MustRegisterScannerFunc("aws_tag", ScanTag, pantherlog.FieldAWSTag)
+}
+
+func ScanARN(w pantherlog.ValueWriter, input string) {
+	// value based matching
+	if !strings.HasPrefix(input, "arn:") {
+		return
+	}
+	// ARNs may contain an embedded account id as well as interesting resources
+	// See: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+	// Formats:
+	//  arn:partition:service:region:account-id:resource-id
+	//  arn:partition:service:region:account-id:resource-type/resource-id
+	//  arn:partition:service:region:account-id:resource-type:resource-id
+	arn, err := arn.Parse(input)
+	if err != nil {
+		return
+	}
+	w.WriteValues(pantherlog.FieldAWSARN, input)
+	w.WriteValues(pantherlog.FieldAWSAccountID, arn.AccountID)
+	// instanceId: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policy-structure.html#EC2_ARN_Format
+	if !strings.HasPrefix(input, "instance/") {
+		return
+	}
+	if pos := strings.LastIndex(input, "/"); 0 <= pos && pos < len(input) { // not if ends in "/"
+		instanceID := input[pos:]
+		if len(instanceID) > 0 {
+			ScanInstanceID(w, instanceID[1:])
+		}
+	}
+}
+
+func ScanTag(w pantherlog.ValueWriter, input string) {
+	w.WriteValues(pantherlog.FieldAWSTag, input)
+}
+
+func ScanAccountID(w pantherlog.ValueWriter, input string) {
+	if len(input) == SizeAccountID && rxAccountID.MatchString(input) {
+		w.WriteValues(pantherlog.FieldAWSAccountID, input)
+	}
+}
+
+func ScanInstanceID(w pantherlog.ValueWriter, input string) {
+	if strings.HasPrefix(input, "i-") {
+		w.WriteValues(pantherlog.FieldAWSInstanceID, input)
+	}
+}
+
+//type RawMessage []byte
+//
+//func (msg RawMessage) MarshalJSON() ([]byte, error) {
+//	if msg == nil {
+//		return []byte(`null`), nil
+//	}
+//	return []byte(msg), nil
+//}
+//
+//func (msg *RawMessage) UnmarshalJSON(data []byte) error {
+//	*msg = append((*msg)[:0], data...)
+//	return nil
+//}
+//func (msg *RawMessage) WriteValuesTo(w pantherlog.ValueWriter) {
+//	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(*msg))
+//	defer iter.Pool().ReturnIterator(iter)
+//	iter.ReadObjectCB()
+//}

--- a/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
@@ -86,22 +86,3 @@ func ScanInstanceID(w pantherlog.ValueWriter, input string) {
 		w.WriteValues(pantherlog.FieldAWSInstanceID, input)
 	}
 }
-
-//type RawMessage []byte
-//
-//func (msg RawMessage) MarshalJSON() ([]byte, error) {
-//	if msg == nil {
-//		return []byte(`null`), nil
-//	}
-//	return []byte(msg), nil
-//}
-//
-//func (msg *RawMessage) UnmarshalJSON(data []byte) error {
-//	*msg = append((*msg)[:0], data...)
-//	return nil
-//}
-//func (msg *RawMessage) WriteValuesTo(w pantherlog.ValueWriter) {
-//	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(*msg))
-//	defer iter.Pool().ReturnIterator(iter)
-//	iter.ReadObjectCB()
-//}


### PR DESCRIPTION
## Background

The indicator fields for AWS logs where not yet defined, pending the porting of AWS parsers.
This PR adds the indicator fields without modifying any parsers so APIs can query all the available indicator fields.

## Changes

- Defines and registers indicator fields for AWS indicators

## Testing

- mage test:ci
