### PR TITLE
Group disabled policies together when sorting by status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,56 +6,75 @@ executors:
     docker:
       - image: pantherlabs/panther-buildpack:1.2.0
 
-# The pool of jobs that that our CI will be able to run
-jobs:
-  mage_test_ci:
-    executor: panther-buildpack
-    resource_class: xlarge
+commands:
+  restore_go_modules_from_cache:
+    description: 'Restores all Golang modules that were installed & cached in previous executions'
     steps:
-      - checkout
       - restore_cache:
           name: 'Restore cache: go modules'
           keys:
             - gomod2-{{ checksum "go.mod" }}
+
+      # Start compiling mage in the background while other caches are restoring
       - run:
-          # Start compiling mage in the background while other caches are restoring
           name: Compile mage (background)
           command: mage
           background: true
+
+  restore_node_modules_from_cache:
+    description: 'Restores all Node modules that were installed & cached in previous executions'
+    steps:
       - restore_cache:
           name: 'Restore cache: npm'
           keys:
             - npm-{{ checksum "package-lock.json" }}
+
+  restore_python_modules_from_cache:
+    description: 'Restores all Python modules that were installed & cached in previous executions'
+    steps:
       - restore_cache:
           name: 'Restore cache: python env'
           keys:
             - venv-{{ checksum "requirements.txt" }}
+
+  restore_binaries_from_cache:
+    description: 'Restores all binaries that were installed & cached in previous executions'
+    steps:
       - restore_cache:
           name: 'Restore cache: .setup binaries'
           keys:
             - setup-{{ checksum "tools/mage/setup.go" }}
 
-      - run:
-          # By this point, mage is compiled and all dependencies have been restored from the cache.
-          # "mage setup" will be a no-op unless new dependencies have been introduced.
-          name: Install new dependencies
-          command: mage setup
-
+  persist_go_modules_to_cache:
+    description: Saves all currently installed Golang modules to the cache, to be used by future jobs
+    steps:
       - save_cache:
           name: 'Save cache: go modules'
           key: gomod2-{{ checksum "go.mod" }}
           paths:
             - /go/pkg/mod
+
+  persist_node_modules_to_cache:
+    description: Saves all currently installed Node modules to the cache, to be used by future jobs
+    steps:
       - save_cache:
           name: 'Save cache: npm'
           key: npm-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+
+  persist_python_modules_to_cache:
+    description: Saves all currently installed Python modules to the cache, to be used by future jobs
+    steps:
       - save_cache:
           name: 'Save cache: python env'
           key: venv-{{ checksum "requirements.txt" }}
           paths:
             - .setup/venv
+
+  persist_binaries_to_cache:
+    description: Saves all currently installed binaries to the cache, to be used by future jobs
+    steps:
       - save_cache:
           name: 'Save cache: .setup binaries'
           key: setup-{{ checksum "tools/mage/setup.go" }}
@@ -64,6 +83,47 @@ jobs:
             - .setup/swagger
             - .setup/terraform
 
+  setup_dependencies:
+    description: 'Installs all dependencies of the project'
+    steps:
+      - restore_modules_from_cache
+      - run:
+          # By this point, mage is compiled and all dependencies have been restored from the cache.
+          # "mage setup" will be a no-op unless new dependencies have been introduced.
+          name: Install new dependencies
+          command: mage setup
+
+# The pool of jobs that that our CI will be able to run
+jobs:
+  mage_test_ci:
+    executor: panther-buildpack
+    resource_class: xlarge
+    steps:
+      - checkout
+      - restore_go_modules_from_cache
+      - restore_node_modules_from_cache
+      - restore_python_modules_from_cache
+      - restore_binaries_from_cache
+      - run:
+          # By this point, mage is compiled and all dependencies have been restored from the cache.
+          # "mage setup" will be a no-op unless new dependencies have been introduced.
+          name: Install new dependencies
+          command: mage setup
+      - persist_go_modules_to_cache
+      - persist_node_modules_to_cache
+      - persist_python_modules_to_cache
+      - persist_binaries_to_cache
+      - run:
+          name: Run test suite
+          command: mage fmt doc
+      - run:
+          name: Push `mage fmt doc` changes to remote ref (optional - only if `mage fmt doc` produces changes)
+          command: |
+            git config --global user.email "github-service-account@runpanther.io"
+            git config --global user.name "panther-bot"
+            git add -A .
+            git commit -m "ci: mage fmt doc" || true
+            git push origin $CIRCLE_BRANCH
       - run:
           name: Run test suite
           command: mage test:ci
@@ -81,15 +141,11 @@ jobs:
     executor: panther-buildpack
     steps:
       - checkout
-      - restore_cache:
-          name: 'Restore cache: npm'
-          keys:
-            - npm-{{ checksum "package-lock.json" }}
-
+      - restore_node_modules_from_cache
       - run:
           name: Install NPM dependencies
           command: npm i
-
+      - persist_node_modules_to_cache
       - run:
           name: Check bundle size
           command: npm run bundlesize
@@ -109,7 +165,10 @@ workflows:
   version: 2
   pipeline:
     jobs:
-      - mage_test_ci
+      - mage_test_ci:
+          filters:
+            branches:
+              ignore: master
       - npm_audit
       - bundlesize
       - fossa_upload

--- a/internal/core/analysis_api/handlers/list.go
+++ b/internal/core/analysis_api/handlers/list.go
@@ -400,7 +400,9 @@ func sortByStatus(policies []*models.PolicySummary, ascending bool, policyStatus
 
 		// Group all disabled policies together at the end.
 		// Technically, disabled policies still have a pass/fail status,
-		// we just don't show it yet in the web app. They are all shown with status "disabled"
+		// we just don't show it yet in the web app.
+		// The "disabled" status overrides the "pass/fail" status
+		// TODO - remove this block once enabled/disabled status is shown separately (ETA v1.9)
 		//
 		// So the sort order is essentially:
 		//     PASS < FAIL < ERROR < PASS/DISABLED < FAIL/DISABLED < ERROR/DISABLED

--- a/internal/core/analysis_api/handlers/list.go
+++ b/internal/core/analysis_api/handlers/list.go
@@ -397,15 +397,32 @@ func sortPolicies(policies []*models.PolicySummary, sortBy string, ascending boo
 func sortByStatus(policies []*models.PolicySummary, ascending bool, policyStatus map[models.ID]*complianceStatus) {
 	sort.Slice(policies, func(i, j int) bool {
 		left, right := policies[i], policies[j]
+
+		// Group all disabled policies together at the end.
+		// Technically, disabled policies still have a pass/fail status,
+		// we just don't show it yet in the web app. They are all shown with status "disabled"
+		//
+		// So the sort order is essentially:
+		//     PASS < FAIL < ERROR < PASS/DISABLED < FAIL/DISABLED < ERROR/DISABLED
+		// Which will appear to the user as:
+		//     PASS < FAIL < ERROR < DISABLED
+		if left.Enabled != right.Enabled {
+			// Same logic as sortByEnabled()
+			if left.Enabled && !right.Enabled {
+				return ascending
+			}
+			return !ascending
+		}
+
+		// Group by compliance status (pass/fail/error)
 		if left.ComplianceStatus != right.ComplianceStatus {
-			// Group first by compliance status
 			if ascending {
 				return statusSortPriority[left.ComplianceStatus] < statusSortPriority[right.ComplianceStatus]
 			}
 			return statusSortPriority[left.ComplianceStatus] > statusSortPriority[right.ComplianceStatus]
 		}
 
-		// Same pass/fail status: use sort index for ERROR and FAIL
+		// Same pass/fail and enabled status: use sort index for ERROR and FAIL
 		// This will sort by "top failing": the most failures in order of severity
 		if left.ComplianceStatus == models.ComplianceStatusERROR || left.ComplianceStatus == models.ComplianceStatusFAIL {
 			// The status cache has already been populated, we can access it directly
@@ -426,13 +443,13 @@ func sortByEnabled(policies []*models.PolicySummary, ascending bool) {
 	sort.Slice(policies, func(i, j int) bool {
 		left, right := policies[i], policies[j]
 		if left.Enabled && !right.Enabled {
-			// ascending: true > false
-			return !ascending
+			// when ascending (default): enabled < disabled
+			return ascending
 		}
 
 		if !left.Enabled && right.Enabled {
-			// ascending: false < true
-			return ascending
+			// when ascending: disabled > enabled
+			return !ascending
 		}
 
 		// Same enabled status: sort by ID ascending


### PR DESCRIPTION
## Background

When sorting compliance policies by status, they do not appear to be grouped correctly:

![Screen Shot 2020-08-26 at 1 04 21 PM](https://user-images.githubusercontent.com/3608925/91357277-d35e1580-e7a5-11ea-98fb-e50fd7cee93c.png)

The "Disabled" status shows up among the "Pass" status - this is because even disabled policies are still evaluated, we just don't yet show its underlying status to the user (we should eventually).

Until then, the backend will first sort by enabled/disabled status so that the column sorts as you would expect

Closes: #1179 

## Changes

- When sorting policies by status, sort first by enabled/disabled (to group all disabled policies together at the end)
- Add some clarifying comments

## Testing

- After applying the change and sorting on the column:

![Screen Shot 2020-08-26 at 1 10 57 PM](https://user-images.githubusercontent.com/3608925/91357417-0d2f1c00-e7a6-11ea-8431-8cb0f1e531bb.png)

- `PKG=./internal/core/analysis_api/main dev -- mage test:integration`
