### PR TITLE
Update mage test:cfn with check for S3 bucket ForceSSL statement IDs

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -139,7 +139,6 @@ Mappings:
 
 Conditions:
   ConfigureLogSubscriptions: !Not [!Equals [!Select [0, !Ref LogSubscriptionPrincipals], '']]
-  NotConfigureLogSubscriptions: !Not [Condition: ConfigureLogSubscriptions]
   EnableAccessLogs: !Equals [!Ref EnableS3AccessLogs, true]
   ExternalAccessLogs: !Not [!Equals [!Ref AccessLogsBucket, '']]
   ReplicateData: !Not [!Equals [!Ref DataReplicationBucket, '']]
@@ -466,46 +465,6 @@ Resources:
               Resource: !Sub ${DataReplicationBucket}/*
 
   ProcessedDataPolicy: # read access on processed data bucket for log subscriptions
-    Condition: ConfigureLogSubscriptions
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref ProcessedData
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: ReadBucket
-            Effect: Allow
-            Principal:
-              AWS: !Ref LogSubscriptionPrincipals
-            Action: s3:ListBucket
-            Resource: !GetAtt ProcessedData.Arn
-          - Sid: ReadLogData
-            Effect: Allow
-            Principal:
-              AWS: !Ref LogSubscriptionPrincipals
-            Action:
-              - s3:GetObject
-              - s3:GetObjectVersion
-            Resource: !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/logs/*
-          - Sid: ReadRuleData
-            Effect: Allow
-            Principal:
-              AWS: !Ref LogSubscriptionPrincipals
-            Action:
-              - s3:GetObject
-              - s3:GetObjectVersion
-            Resource: !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/rules/*
-          - Sid: ForceSSL
-            Effect: Deny
-            Principal: '*'
-            Action: s3:GetObject
-            Resource: !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/*
-            Condition:
-              Bool:
-                aws:SecureTransport: false
-
-  ProcessedDataDefaultPolicy: # enforce secure access even if there aren't log subscriptions
-    Condition: NotConfigureLogSubscriptions
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref ProcessedData
@@ -520,6 +479,28 @@ Resources:
             Condition:
               Bool:
                 aws:SecureTransport: false
+          - !If
+            - ConfigureLogSubscriptions
+            - Sid: ReadBucket
+              Effect: Allow
+              Principal:
+                AWS: !Ref LogSubscriptionPrincipals
+              Action: s3:ListBucket
+              Resource: !GetAtt ProcessedData.Arn
+            - !Ref AWS::NoValue
+          - !If
+            - ConfigureLogSubscriptions
+            - Sid: ReadLogAndRuleData
+              Effect: Allow
+              Principal:
+                AWS: !Ref LogSubscriptionPrincipals
+              Action:
+                - s3:GetObject
+                - s3:GetObjectVersion
+              Resource:
+                - !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/logs/*
+                - !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/rules/*
+            - !Ref AWS::NoValue
 
   AthenaResults: # athena query results
     Type: AWS::S3::Bucket


### PR DESCRIPTION
## Background

Some of Panther's buckets were missing the `ForceSSL` bucket policies until the last release, so I've added a check to `mage test:cfn` to flag buckets without the appropriate statement.

It's very simple, just checking for "Sid: ForceSSL" attached to every bucket. It's not actually evaluating the policy, which can get quite complex. But this will catch the most common problem - devs forget to add it to new buckets

Closes: #1421 

## Changes

- `mage test:cfn` fails if an S3 bucket does not have a `ForceSSL` statement attached in the same template
- Collapse the ProcessedData bucket policy into a single resource with conditional statements (rather than two completely separate policy resources). Having two separate resources is harder to check with automation and also more prone to errors when CFN switches between the two - it will create the new bucket policy and then delete the old one. But buckets can only have one policy, so I'm not sure if that would work as we expect. It's simpler and safer to have a single bucket policy at all times - the policy statements can update conditionally, not the resource itself

## Testing

- Deployed - the default processed data bucket still has the correct "ForceSSL" statement only
- Removed ForceSSL statement from a bucket and ran `mage test:cfn`:

```
12:51:22	ERROR	    X cfn-lint failed (1/2): deployments/bootstrap.yml: S3 bucket InputDataBucket needs an associated ForceSSL policy statement ID
```
