### PR TITLE
Remove unused model field from the alert

### DIFF
--- a/internal/core/alert_delivery/api/deliver_alert.go
+++ b/internal/core/alert_delivery/api/deliver_alert.go
@@ -125,7 +125,7 @@ func populateAlertData(alertItem *alertTable.AlertItem) (*deliveryModels.Alert, 
 		Type:                deliveryModels.RuleType,
 		CreatedAt:           alertItem.CreationTime,
 		Severity:            alertItem.Severity,
-		OutputIds:           alertItem.OutputIds,
+		OutputIds:           []string{}, // We do not pay attention to this field
 		AnalysisDescription: aws.String(string(rule.Description)),
 		AnalysisName:        aws.String(string(rule.DisplayName)),
 		Version:             &alertItem.RuleVersion,

--- a/internal/core/alert_delivery/api/deliver_alert_test.go
+++ b/internal/core/alert_delivery/api/deliver_alert_test.go
@@ -84,7 +84,6 @@ func TestGetAlert(t *testing.T) {
 		FirstEventMatchTime: timeNow,
 		CreationTime:        timeNow,
 		DeliveryResponses:   []*alertModels.DeliveryResponse{{}},
-		OutputIds:           alert.OutputIds,
 		Severity:            alert.Severity,
 	}
 
@@ -127,7 +126,6 @@ func TestPopulateAlert(t *testing.T) {
 
 	alertID := aws.String("alert-id")
 	timeNow := time.Now().UTC()
-	outputIds := []string{"output-id-1", "output-id-2", "output-id-3"}
 	versionID := "version"
 	analysisDisplayName := aws.String("Test Analysis Name")
 	description := "A test aler"
@@ -146,7 +144,7 @@ func TestPopulateAlert(t *testing.T) {
 		RetryCount:          0,
 		Tags:                tags,
 		Type:                deliveryModels.RuleType,
-		OutputIds:           outputIds,
+		OutputIds:           []string{},
 		Severity:            severity,
 		CreatedAt:           timeNow,
 		Version:             aws.String(versionID),
@@ -163,7 +161,6 @@ func TestPopulateAlert(t *testing.T) {
 		FirstEventMatchTime: timeNow,
 		CreationTime:        timeNow,
 		DeliveryResponses:   []*alertModels.DeliveryResponse{{}},
-		OutputIds:           alert.OutputIds,
 		Severity:            alert.Severity,
 	}
 
@@ -215,7 +212,7 @@ func TestGetAlertOutputMapping(t *testing.T) {
 		RetryCount:          0,
 		Tags:                []string{"test", "alert"},
 		Type:                deliveryModels.RuleType,
-		OutputIds:           outputIds,
+		OutputIds:           []string{},
 		Severity:            "INFO",
 		CreatedAt:           time.Now().UTC(),
 		Version:             aws.String("abc"),
@@ -282,7 +279,7 @@ func TestGetAlertOutputMappingError(t *testing.T) {
 		RetryCount:          0,
 		Tags:                []string{"test", "alert"},
 		Type:                deliveryModels.RuleType,
-		OutputIds:           outputIds,
+		OutputIds:           []string{},
 		Severity:            "INFO",
 		CreatedAt:           time.Now().UTC(),
 		Version:             aws.String("abc"),
@@ -326,7 +323,7 @@ func TestGetAlertOutputMappingInvalidOutputIds(t *testing.T) {
 		RetryCount:          0,
 		Tags:                []string{"test", "alert"},
 		Type:                deliveryModels.RuleType,
-		OutputIds:           outputIds,
+		OutputIds:           []string{},
 		Severity:            "INFO",
 		CreatedAt:           time.Now().UTC(),
 		Version:             aws.String("abc"),
@@ -425,7 +422,7 @@ func TestReturnIfFailedSuccess(t *testing.T) {
 		RetryCount:          0,
 		Tags:                []string{"test", "alert"},
 		Type:                deliveryModels.RuleType,
-		OutputIds:           outputIds,
+		OutputIds:           []string{},
 		Severity:            "INFO",
 		CreatedAt:           timeNow,
 		Version:             aws.String("abc"),
@@ -469,7 +466,7 @@ func TestReturnIfFailed(t *testing.T) {
 		RetryCount:          0,
 		Tags:                []string{"test", "alert"},
 		Type:                deliveryModels.RuleType,
-		OutputIds:           outputIds,
+		OutputIds:           []string{},
 		Severity:            "INFO",
 		CreatedAt:           timeNow,
 		Version:             aws.String("abc"),

--- a/internal/log_analysis/alerts_api/table/table.go
+++ b/internal/log_analysis/alerts_api/table/table.go
@@ -76,7 +76,6 @@ type AlertItem struct {
 	FirstEventMatchTime time.Time                  `json:"firstEventMatchTime"`
 	CreationTime        time.Time                  `json:"creationTime"`
 	DeliveryResponses   []*models.DeliveryResponse `json:"deliveryResponses"`
-	OutputIds           []string                   `json:"outputIds"`
 	// UpdateTime - stores the timestamp from an update from a dedup event
 	UpdateTime time.Time `json:"updateTime"`
 	Severity   string    `json:"severity"`


### PR DESCRIPTION
## Background

The alert model for DDB contained an unused field `OutputIds` which is not stored in DDB nor used in the application.

This issue did not cause any bugs, it is superfluous and is being removed.

## Changes

- removed `OutputIds` from the model
- updated tests to reflect the change
- updated application code where this field was being set

## Testing

- mage test:go
- mage test:ci
