### PR TITLE
Re-fetch alerts on every rule page visit

### DIFF
--- a/web/src/pages/RuleDetails/RuleDetails.tsx
+++ b/web/src/pages/RuleDetails/RuleDetails.tsx
@@ -57,6 +57,7 @@ const RuleDetailsPage = () => {
     fetchMore,
     variables,
   } = useListAlertsForRule({
+    fetchPolicy: 'cache-and-network',
     variables: {
       input: {
         ruleId: match.params.id,


### PR DESCRIPTION
## Background

When re-visiting a rule  that you have visited  in the past, the page won't attempt to re-fetch the previously fetched alerts. This might cause inconsistencies, since more  alerts might have fired since then.

The solution up until now, was to refresh the page. This fix makes that not required

## Changes

- Add `cache-and-network` to alert-related  queries

## Testing

- Locally