### PR TITLE
fix: return a success response for sqs and sns

### DIFF
--- a/internal/core/alert_delivery/outputs/pagerduty.go
+++ b/internal/core/alert_delivery/outputs/pagerduty.go
@@ -70,6 +70,11 @@ func pantherSeverityToPagerDuty(severity string) (string, *AlertDeliveryResponse
 	case "CRITICAL":
 		return "critical", nil
 	default:
-		return "", &AlertDeliveryResponse{Message: "unknown severity" + severity}
+		return "", &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "unknown severity" + severity,
+			Permanent:  true, // We don't want to retry alert's that don't have a valid severity
+			Success:    false,
+		}
 	}
 }

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -45,7 +45,12 @@ func (client *OutputClient) Sns(alert *alertModels.Alert, config *outputModels.S
 	if err != nil {
 		errorMsg := "Failed to serialize default message"
 		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
-		return &AlertDeliveryResponse{Message: errorMsg, Permanent: true}
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    errorMsg,
+			Permanent:  true,
+			Success:    false,
+		}
 	}
 
 	outputMessage := &snsMessage{
@@ -57,7 +62,12 @@ func (client *OutputClient) Sns(alert *alertModels.Alert, config *outputModels.S
 	if err != nil {
 		errorMsg := "Failed to serialize message"
 		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
-		return &AlertDeliveryResponse{Message: errorMsg, Permanent: true}
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    errorMsg,
+			Permanent:  true,
+			Success:    false,
+		}
 	}
 
 	snsMessageInput := &sns.PublishInput{
@@ -72,16 +82,50 @@ func (client *OutputClient) Sns(alert *alertModels.Alert, config *outputModels.S
 	if err != nil {
 		errorMsg := "Failed to create SNS client for topic"
 		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
-		return &AlertDeliveryResponse{Message: errorMsg, Permanent: true}
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    errorMsg,
+			Permanent:  true,
+			Success:    false,
+		}
 	}
 
-	_, err = snsClient.Publish(snsMessageInput)
+	response, err := snsClient.Publish(snsMessageInput)
 	if err != nil {
 		errorMsg := "Failed to send message to SNS topic"
 		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
-		return &AlertDeliveryResponse{Message: errorMsg}
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    errorMsg,
+			Permanent:  false,
+			Success:    false,
+		}
 	}
-	return nil
+
+	if response == nil {
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "sns response was nil",
+			Permanent:  false,
+			Success:    false,
+		}
+	}
+
+	if response.MessageId == nil {
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "sns messageId was nil",
+			Permanent:  false,
+			Success:    false,
+		}
+	}
+
+	return &AlertDeliveryResponse{
+		StatusCode: 200,
+		Message:    aws.StringValue(response.MessageId),
+		Permanent:  false,
+		Success:    true,
+	}
 }
 
 func (client *OutputClient) getSnsClient(topicArn string) (snsiface.SNSAPI, error) {

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -92,14 +92,8 @@ func (client *OutputClient) Sns(alert *alertModels.Alert, config *outputModels.S
 
 	response, err := snsClient.Publish(snsMessageInput)
 	if err != nil {
-		errorMsg := "Failed to send message to SNS topic"
-		zap.L().Error(errorMsg, zap.Error(errors.WithStack(err)))
-		return &AlertDeliveryResponse{
-			StatusCode: 500,
-			Message:    errorMsg,
-			Permanent:  false,
-			Success:    false,
-		}
+		zap.L().Error("Failed to send message to SNS topic", zap.Error(err))
+		return getAlertResponseFromSNSError(err)
 	}
 
 	if response == nil {

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -80,8 +80,14 @@ func TestSendSns(t *testing.T) {
 		Subject:          aws.String("Policy Failure: policyName"),
 	}
 
-	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{}, nil)
+	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{MessageId: aws.String("messageId")}, nil)
 	result := outputClient.Sns(alert, snsOutputConfig)
-	assert.Nil(t, result)
+	assert.NotNil(t, result)
+	assert.Equal(t, &AlertDeliveryResponse{
+		Message:    "messageId",
+		StatusCode: 200,
+		Success:    true,
+		Permanent:  false,
+	}, result)
 	client.AssertExpectations(t)
 }

--- a/internal/core/alert_delivery/outputs/sqs.go
+++ b/internal/core/alert_delivery/outputs/sqs.go
@@ -39,7 +39,12 @@ func (client *OutputClient) Sqs(alert *alertModels.Alert, config *outputModels.S
 	serializedMessage, err := jsoniter.MarshalToString(notification)
 	if err != nil {
 		zap.L().Error("Failed to serialize message", zap.Error(err))
-		return &AlertDeliveryResponse{Message: "Failed to serialize message"}
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "Failed to serialize message",
+			Permanent:  true,
+			Success:    false,
+		}
 	}
 
 	sqsSendMessageInput := &sqs.SendMessageInput{
@@ -49,12 +54,41 @@ func (client *OutputClient) Sqs(alert *alertModels.Alert, config *outputModels.S
 
 	sqsClient := client.getSqsClient(config.QueueURL)
 
-	_, err = sqsClient.SendMessage(sqsSendMessageInput)
+	response, err := sqsClient.SendMessage(sqsSendMessageInput)
 	if err != nil {
 		zap.L().Error("Failed to send message to SQS queue", zap.Error(err))
-		return &AlertDeliveryResponse{Message: "Failed to send message to SQS queue"}
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "Failed to send message to SQS queue",
+			Permanent:  false,
+			Success:    false,
+		}
 	}
-	return nil
+
+	if response == nil {
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "sqs response was nil",
+			Permanent:  false,
+			Success:    false,
+		}
+	}
+
+	if response.MessageId == nil {
+		return &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "sqs messageId was nil",
+			Permanent:  false,
+			Success:    false,
+		}
+	}
+
+	return &AlertDeliveryResponse{
+		StatusCode: 200,
+		Message:    aws.StringValue(response.MessageId),
+		Permanent:  false,
+		Success:    true,
+	}
 }
 
 func (client *OutputClient) getSqsClient(queueURL string) sqsiface.SQSAPI {

--- a/internal/core/alert_delivery/outputs/sqs.go
+++ b/internal/core/alert_delivery/outputs/sqs.go
@@ -57,12 +57,7 @@ func (client *OutputClient) Sqs(alert *alertModels.Alert, config *outputModels.S
 	response, err := sqsClient.SendMessage(sqsSendMessageInput)
 	if err != nil {
 		zap.L().Error("Failed to send message to SQS queue", zap.Error(err))
-		return &AlertDeliveryResponse{
-			StatusCode: 500,
-			Message:    "Failed to send message to SQS queue",
-			Permanent:  false,
-			Success:    false,
-		}
+		return getAlertResponseFromSQSError(err)
 	}
 
 	if response == nil {

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -65,8 +65,14 @@ func TestSendSqs(t *testing.T) {
 		MessageBody: &expectedSerializedSqsMessage,
 	}
 
-	client.On("SendMessage", expectedSqsSendMessageInput).Return(&sqs.SendMessageOutput{}, nil)
+	client.On("SendMessage", expectedSqsSendMessageInput).Return(&sqs.SendMessageOutput{MessageId: aws.String("messageId")}, nil)
 	result := outputClient.Sqs(alert, sqsOutputConfig)
-	assert.Nil(t, result)
+	assert.NotNil(t, result)
+	assert.Equal(t, &AlertDeliveryResponse{
+		Message:    "messageId",
+		StatusCode: 200,
+		Success:    true,
+		Permanent:  false,
+	}, result)
 	client.AssertExpectations(t)
 }

--- a/internal/core/alert_delivery/outputs/utils.go
+++ b/internal/core/alert_delivery/outputs/utils.go
@@ -1,0 +1,98 @@
+package outputs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+)
+
+func getAlertResponseFromSQSError(err error) *AlertDeliveryResponse {
+	if awsErr, ok := err.(awserr.Error); ok {
+		statusCode := mapSQSSendMessageErrorCodeToStatusCode(awsErr)
+		return getResponse(statusCode, awsErr.Error())
+	}
+	return getResponse(500, err.Error())
+}
+
+func getAlertResponseFromSNSError(err error) *AlertDeliveryResponse {
+	if awsErr, ok := err.(awserr.Error); ok {
+		statusCode := mapSNSPublishErrorCodeToStatusCode(awsErr)
+		return getResponse(statusCode, awsErr.Error())
+	}
+	return getResponse(500, err.Error())
+}
+
+// getResponse - generates a failed response that can be retried
+func getResponse(statusCode int, message string) *AlertDeliveryResponse {
+	return &AlertDeliveryResponse{
+		StatusCode: statusCode,
+		Message:    message,
+		Permanent:  false,
+		Success:    false,
+	}
+}
+
+// Maps SNS.Publish error codes to response status codes
+func mapSNSPublishErrorCodeToStatusCode(awsErr awserr.Error) int {
+	switch awsErr.Code() {
+	case sns.ErrCodeInvalidParameterException:
+		return 400
+	case sns.ErrCodeInvalidParameterValueException:
+		return 400
+	case sns.ErrCodeInternalErrorException:
+		return 500
+	case sns.ErrCodeNotFoundException:
+		return 404
+	case sns.ErrCodeEndpointDisabledException:
+		return 403
+	case sns.ErrCodePlatformApplicationDisabledException:
+		return 403
+	case sns.ErrCodeAuthorizationErrorException:
+		return 401
+	case sns.ErrCodeKMSDisabledException:
+		return 403
+	case sns.ErrCodeKMSInvalidStateException:
+		return 409
+	case sns.ErrCodeKMSNotFoundException:
+		return 404
+	case sns.ErrCodeKMSOptInRequired:
+		return 400
+	case sns.ErrCodeKMSThrottlingException:
+		return 429
+	case sns.ErrCodeKMSAccessDeniedException:
+		return 401
+	case sns.ErrCodeInvalidSecurityException:
+		return 401
+	default:
+		return 500
+	}
+}
+
+// Maps SQS.SendMessage error codes to response status codes
+func mapSQSSendMessageErrorCodeToStatusCode(awsErr awserr.Error) int {
+	switch awsErr.Code() {
+	case sqs.ErrCodeInvalidMessageContents:
+		return 400
+	case sqs.ErrCodeUnsupportedOperation:
+		return 403
+	default:
+		return 500
+	}
+}


### PR DESCRIPTION
## Background

Closes #1486 

## Changes

- Returns a response status for SQS and SNS destinations
- Return more descriptive error payloads

## Testing

- mage test:ci
