### PR TITLE
Fix mage master:deploy

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -78,7 +78,7 @@ func Gen() error {
 
 type Master mg.Namespace
 
-// Deploy Deploy single master template (deployments/master.yml) nesting all other stacks
+// Deploy Deploy single master template nesting all other stacks
 func (Master) Deploy() error {
 	return master.Deploy()
 }

--- a/tools/mage/master/build.go
+++ b/tools/mage/master/build.go
@@ -29,6 +29,8 @@ import (
 	"github.com/panther-labs/panther/tools/mage/util"
 )
 
+var masterTemplate = filepath.Join("deployments", "master.yml")
+
 // Get the Panther version indicated in the master template.
 func GetVersion() (string, error) {
 	type template struct {
@@ -42,7 +44,7 @@ func GetVersion() (string, error) {
 	}
 
 	var cfn template
-	err := util.ParseTemplate(filepath.Join("deployments", "master.yml"), &cfn)
+	err := util.ParseTemplate(masterTemplate, &cfn)
 	return cfn.Mappings.Constants.Panther.Version, err
 }
 
@@ -72,7 +74,7 @@ func Package(log *zap.SugaredLogger, region, bucket, pantherVersion, imgRegistry
 		return "", err
 	}
 
-	pkg, err := util.SamPackage(region, "deployments/master.yml", bucket)
+	pkg, err := util.SamPackage(region, masterTemplate, bucket)
 	if err != nil {
 		return "", err
 	}

--- a/tools/mage/master/build.go
+++ b/tools/mage/master/build.go
@@ -68,6 +68,10 @@ func Build(log *zap.SugaredLogger) error {
 //
 // Returns the path to the final generated template.
 func Package(log *zap.SugaredLogger, region, bucket, pantherVersion, imgRegistry string) (string, error) {
+	if err := build.EmbedAPISpec(); err != nil {
+		return "", err
+	}
+
 	pkg, err := util.SamPackage(region, "deployments/master.yml", bucket)
 	if err != nil {
 		return "", err

--- a/tools/mage/master/deploy.go
+++ b/tools/mage/master/deploy.go
@@ -20,12 +20,14 @@ package master
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"go.uber.org/zap"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/s3"
 
+	"github.com/panther-labs/panther/pkg/prompt"
 	"github.com/panther-labs/panther/tools/cfnstacks"
 	"github.com/panther-labs/panther/tools/mage/clients"
 	"github.com/panther-labs/panther/tools/mage/deploy"
@@ -41,15 +43,13 @@ const (
 
 var publishRegions = []string{"us-east-1", "us-east-2", "us-west-2"}
 
-// Deploy single master template (deployments/master.yml) nesting all other stacks
+// Deploy single master template nesting all other stacks.
+//
+// This allows developers to simulate the customer deployment flow and test the master
+// template before publishing a release.
 func Deploy() error {
 	log := logger.Build("[master:deploy]")
-	env, err := masterDeployPreCheck(log)
-	if err != nil {
-		return err
-	}
-
-	if err := Build(log); err != nil {
+	if err := masterDeployPreCheck(); err != nil {
 		return err
 	}
 
@@ -58,29 +58,70 @@ func Deploy() error {
 		return err
 	}
 
-	pkg, err := Package(log, clients.Region(), env.bucketName, version, env.ecrRegistry)
+	log.Infof("deploying %s v%s to %s (%s)", masterTemplate, version, clients.AccountID(), clients.Region())
+	email := prompt.Read("First user email: ", prompt.EmailValidator)
+
+	if err := Build(log); err != nil {
+		return err
+	}
+
+	// Create S3 bucket for staging assets
+	bucket := fmt.Sprintf("panther-dev-%s-master-%s", clients.AccountID(), clients.Region())
+	if _, err := clients.S3().CreateBucket(&s3.CreateBucketInput{Bucket: &bucket}); err != nil {
+		if awsErr := err.(awserr.Error); awsErr.Code() != s3.ErrCodeBucketAlreadyOwnedByYou &&
+			awsErr.Code() != s3.ErrCodeBucketAlreadyExists {
+
+			return fmt.Errorf("failed to create S3 bucket %s: %v", bucket, err)
+		}
+	}
+
+	// Delete packaged assets after a few days
+	if _, err := clients.S3().PutBucketLifecycleConfiguration(&s3.PutBucketLifecycleConfigurationInput{
+		Bucket: &bucket,
+		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+			Rules: []*s3.LifecycleRule{
+				{
+					AbortIncompleteMultipartUpload: &s3.AbortIncompleteMultipartUpload{
+						DaysAfterInitiation: aws.Int64(1),
+					},
+					Expiration: &s3.LifecycleExpiration{
+						Days: aws.Int64(7),
+					},
+					Filter: &s3.LifecycleRuleFilter{
+						Prefix: aws.String(""),
+					},
+					ID:     aws.String("expire-everything"),
+					Status: aws.String("Enabled"),
+				},
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to put S3 bucket lifecycle policy: %v", err)
+	}
+
+	// Create ECR repo
+	const repoName = "panther-dev-master"
+	if _, err := clients.ECR().CreateRepository(&ecr.CreateRepositoryInput{
+		RepositoryName: aws.String(repoName),
+	}); err != nil {
+		if awsErr := err.(awserr.Error); awsErr.Code() != ecr.ErrCodeRepositoryAlreadyExistsException {
+			return fmt.Errorf("failed to create ECR repo %s: %v", repoName, err)
+		}
+	}
+	var registryURI = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", clients.AccountID(), clients.Region(), repoName)
+
+	pkg, err := Package(log, clients.Region(), bucket, version, registryURI)
 	if err != nil {
 		return err
 	}
 
-	return util.SamDeploy(masterStackName, pkg,
-		"FirstUserEmail="+env.firstUserEmail, "ImageRegistry="+env.ecrRegistry)
+	return util.SamDeploy(masterStackName, pkg, "FirstUserEmail="+email, "ImageRegistry="+registryURI)
 }
 
-type masterDeployParams struct {
-	bucketName     string
-	firstUserEmail string
-	ecrRegistry    string
-}
-
-// Ensure environment is configured correctly for the master template.
-//
-// TODO - automatically create bucket and repo
-//
-// Returns bucket, firstUserEmail, ecrRegistry
-func masterDeployPreCheck(log *zap.SugaredLogger) (*masterDeployParams, error) {
+// Stop early if there is a known issue with the dev environment.
+func masterDeployPreCheck() error {
 	if err := deploy.PreCheck(false); err != nil {
-		return nil, err
+		return err
 	}
 
 	_, err := clients.Cfn().DescribeStacks(
@@ -88,23 +129,8 @@ func masterDeployPreCheck(log *zap.SugaredLogger) (*masterDeployParams, error) {
 	if err == nil {
 		// Multiple Panther deployments won't work in the same region in the same account.
 		// Named resources (e.g. IAM roles) will conflict
-		return nil, fmt.Errorf("%s stack already exists, can't deploy master template", cfnstacks.Bootstrap)
+		return fmt.Errorf("%s stack already exists, can't deploy master template", cfnstacks.Bootstrap)
 	}
 
-	params := masterDeployParams{
-		bucketName:     os.Getenv("BUCKET"),
-		firstUserEmail: os.Getenv("EMAIL"),
-		ecrRegistry:    os.Getenv("ECR_REGISTRY"),
-	}
-
-	if params.bucketName == "" || params.firstUserEmail == "" || params.ecrRegistry == "" {
-		log.Error("BUCKET, EMAIL, and ECR_REGISTRY env variables must be defined")
-		log.Info("    BUCKET - S3 bucket for staging assets in the deployment region")
-		log.Info("    EMAIL - email for inviting the first Panther admin user")
-		log.Info("    ECR_REGISTRY - where to push docker images, e.g. " +
-			"111122223333.dkr.ecr.us-west-2.amazonaws.com/panther-web")
-		return nil, fmt.Errorf("invalid environment")
-	}
-
-	return &params, nil
+	return nil
 }

--- a/tools/mage/master/publish.go
+++ b/tools/mage/master/publish.go
@@ -20,6 +20,7 @@ package master
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -27,8 +28,51 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"go.uber.org/zap"
 
+	"github.com/panther-labs/panther/pkg/prompt"
+	"github.com/panther-labs/panther/tools/mage/clean"
+	"github.com/panther-labs/panther/tools/mage/deploy"
+	"github.com/panther-labs/panther/tools/mage/logger"
+	"github.com/panther-labs/panther/tools/mage/setup"
 	"github.com/panther-labs/panther/tools/mage/util"
 )
+
+// Publish a new Panther release (Panther team only)
+func Publish() error {
+	log := logger.Build("[master:publish]")
+	if err := deploy.PreCheck(false); err != nil {
+		return err
+	}
+
+	version, err := GetVersion()
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Publishing panther-community v%s to %s", version, strings.Join(publishRegions, ","))
+	result := prompt.Read("Are you sure you want to continue? (yes|no) ", prompt.NonemptyValidator)
+	if strings.ToLower(result) != "yes" {
+		return fmt.Errorf("publish aborted")
+	}
+
+	// To be safe, always clean and reset the repo before building the assets
+	if err := clean.Clean(); err != nil {
+		return err
+	}
+	if err := setup.Setup(); err != nil {
+		return err
+	}
+	if err := Build(log); err != nil {
+		return err
+	}
+
+	for _, region := range publishRegions {
+		if err := publishToRegion(log, version, region); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func publishToRegion(log *zap.SugaredLogger, version, region string) error {
 	log.Infof("publishing to %s", region)


### PR DESCRIPTION
## Background

After the mage refactor (#1458 ), `master:deploy` fails with:

```
Error: Unable to upload artifact ../out/deployments/embedded.bootstrap_gateway.yml referenced by TemplateURL parameter of BootstrapGateway resource.
TemplateURL parameter of BootstrapGateway resource is invalid. 
```

The problematic template is the one where we directly inject the Swagger specification. After the refactor, the CloudFormation-Swagger build moved to a different place and it just needs to be re-added explicitly.

I also took the opportunity to quickly fix up `master:deploy` so that it's easier to run - it will automatically create an S3 bucket and ECR repo for developers instead of requiring them to be specified as env variables.

## Changes

-`master:deploy` now builds the API gateway template before packaging it
- Fixed TODO: create s3/ecr repo automatically
- Moved `Publish()` function to the correct file

## Testing

- `rm -r out && mage master:deploy`
