### PR TITLE
fix: sns and sqs delivery statuses

### DIFF
--- a/internal/core/alert_delivery/outputs/pagerduty.go
+++ b/internal/core/alert_delivery/outputs/pagerduty.go
@@ -70,6 +70,11 @@ func pantherSeverityToPagerDuty(severity string) (string, *AlertDeliveryResponse
 	case "CRITICAL":
 		return "critical", nil
 	default:
-		return "", &AlertDeliveryResponse{Message: "unknown severity" + severity}
+		return "", &AlertDeliveryResponse{
+			StatusCode: 500,
+			Message:    "unknown severity" + severity,
+			Permanent:  true, // We don't want to retry alert's that don't have a valid severity
+			Success:    false,
+		}
 	}
 }

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -80,8 +80,14 @@ func TestSendSns(t *testing.T) {
 		Subject:          aws.String("Policy Failure: policyName"),
 	}
 
-	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{}, nil)
+	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{MessageId: aws.String("messageId")}, nil)
 	result := outputClient.Sns(alert, snsOutputConfig)
-	assert.Nil(t, result)
+	assert.NotNil(t, result)
+	assert.Equal(t, &AlertDeliveryResponse{
+		Message:    "messageId",
+		StatusCode: 200,
+		Success:    true,
+		Permanent:  false,
+	}, result)
 	client.AssertExpectations(t)
 }

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -65,8 +65,14 @@ func TestSendSqs(t *testing.T) {
 		MessageBody: &expectedSerializedSqsMessage,
 	}
 
-	client.On("SendMessage", expectedSqsSendMessageInput).Return(&sqs.SendMessageOutput{}, nil)
+	client.On("SendMessage", expectedSqsSendMessageInput).Return(&sqs.SendMessageOutput{MessageId: aws.String("messageId")}, nil)
 	result := outputClient.Sqs(alert, sqsOutputConfig)
-	assert.Nil(t, result)
+	assert.NotNil(t, result)
+	assert.Equal(t, &AlertDeliveryResponse{
+		Message:    "messageId",
+		StatusCode: 200,
+		Success:    true,
+		Permanent:  false,
+	}, result)
 	client.AssertExpectations(t)
 }

--- a/internal/core/alert_delivery/outputs/utils.go
+++ b/internal/core/alert_delivery/outputs/utils.go
@@ -1,0 +1,98 @@
+package outputs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+)
+
+func getAlertResponseFromSQSError(err error) *AlertDeliveryResponse {
+	if awsErr, ok := err.(awserr.Error); ok {
+		statusCode := mapSQSSendMessageErrorCodeToStatusCode(awsErr)
+		return getResponse(statusCode, awsErr.Error())
+	}
+	return getResponse(500, err.Error())
+}
+
+func getAlertResponseFromSNSError(err error) *AlertDeliveryResponse {
+	if awsErr, ok := err.(awserr.Error); ok {
+		statusCode := mapSNSPublishErrorCodeToStatusCode(awsErr)
+		return getResponse(statusCode, awsErr.Error())
+	}
+	return getResponse(500, err.Error())
+}
+
+// getResponse - generates a failed response that can be retried
+func getResponse(statusCode int, message string) *AlertDeliveryResponse {
+	return &AlertDeliveryResponse{
+		StatusCode: statusCode,
+		Message:    message,
+		Permanent:  false,
+		Success:    false,
+	}
+}
+
+// Maps SNS.Publish error codes to response status codes
+func mapSNSPublishErrorCodeToStatusCode(awsErr awserr.Error) int {
+	switch awsErr.Code() {
+	case sns.ErrCodeInvalidParameterException:
+		return 400
+	case sns.ErrCodeInvalidParameterValueException:
+		return 400
+	case sns.ErrCodeInternalErrorException:
+		return 500
+	case sns.ErrCodeNotFoundException:
+		return 404
+	case sns.ErrCodeEndpointDisabledException:
+		return 403
+	case sns.ErrCodePlatformApplicationDisabledException:
+		return 403
+	case sns.ErrCodeAuthorizationErrorException:
+		return 401
+	case sns.ErrCodeKMSDisabledException:
+		return 403
+	case sns.ErrCodeKMSInvalidStateException:
+		return 409
+	case sns.ErrCodeKMSNotFoundException:
+		return 404
+	case sns.ErrCodeKMSOptInRequired:
+		return 400
+	case sns.ErrCodeKMSThrottlingException:
+		return 429
+	case sns.ErrCodeKMSAccessDeniedException:
+		return 401
+	case sns.ErrCodeInvalidSecurityException:
+		return 401
+	default:
+		return 500
+	}
+}
+
+// Maps SQS.SendMessage error codes to response status codes
+func mapSQSSendMessageErrorCodeToStatusCode(awsErr awserr.Error) int {
+	switch awsErr.Code() {
+	case sqs.ErrCodeInvalidMessageContents:
+		return 400
+	case sqs.ErrCodeUnsupportedOperation:
+		return 403
+	default:
+		return 500
+	}
+}


### PR DESCRIPTION
## Background

Sync changes #1492 merged into `release` back into `master`.

## Changes

- Return a success delivery response from SNS/SQS payloads

## Testing

- mage test:ci
