### PR TITLE
Add ec2:ReleaseAddress to deploy role

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -125,6 +125,7 @@ Resources:
               - ec2:DisassociateSubnetCidrBlock
               - ec2:ModifySubnetAttribute
               - ec2:ModifyVpcAttribute
+              - ec2:ReleaseAddress
               - ec2:ReplaceRoute
               - ec2:ReplaceRouteTableAssociation
               - ec2:RevokeSecurityGroupEgress

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -107,6 +107,7 @@ resource "aws_iam_policy" "deployment" {
         "ec2:DisassociateSubnetCidrBlock",
         "ec2:ModifySubnetAttribute",
         "ec2:ModifyVpcAttribute",
+        "ec2:ReleaseAddress",
         "ec2:ReplaceRoute",
         "ec2:ReplaceRouteTableAssociation",
         "ec2:RevokeSecurityGroupEgress",


### PR DESCRIPTION
## Background

Teardown with the Panther deployment role failed:

> stack panther-bootstrap: AWS::EC2::EIP NatPublicIP DELETE_FAILED: API: ec2:releaseAddress You are not authorized to perform this operation

## Changes

- Add `ec2:ReleaseAddress` to deployment role (CF and TF)

## Testing

- Teardown succeeded with this change
