### PR TITLE
fix: add dynamic width  to profile popup

### DIFF
--- a/web/src/components/Navigation/ProfileIcon/ProfileIcon.tsx
+++ b/web/src/components/Navigation/ProfileIcon/ProfileIcon.tsx
@@ -84,7 +84,7 @@ const ProfileIcon: React.FC = () => {
             {getUserInitials(userInfo).toUpperCase()}
           </DropdownButton>
           <DropdownMenu alignment="right" transform="translate(65px, -65px)">
-            <Box p={6} width={240} backgroundColor="navyblue-400" fontSize="medium">
+            <Box p={6} minWidth={240} backgroundColor="navyblue-400" fontSize="medium">
               <Text>{getUserDisplayName(userInfo)}</Text>
               <Link external href={`mailto:${userInfo.email}`}>
                 {userInfo.email}


### PR DESCRIPTION
## Background

When users have a big email, the  profile settings popup cuts the  email out.

This PR allows the profile popup to have a dynamic width based on its content

## Changes

- Change `width` to `maxWidth`

## Testing

- Visually