### PR TITLE
Fix issue with form General Setting's form initial values

### DIFF
--- a/web/src/apollo/typePolicies.ts
+++ b/web/src/apollo/typePolicies.ts
@@ -128,7 +128,7 @@ const typePolicies: TypePolicies = {
     keyFields: ['integrationId'],
   },
   GeneralSettings: {
-    keyFields: ['email'],
+    keyFields: ['__typename'],
     fields: {
       errorReportingConsent: {
         merge(_, incoming) {


### PR DESCRIPTION
## Background

Due to an issue with Apollo keyfields, whenever a user updated the GeneralSettings form's email, the form was failing to set the new initial values to the updated ones (it thought the initial values where the ones before the update).

This caused issues forcing the users to refresh in order to see the "disabled" button as "enabled"

## Changes

- Add static non-modifiable key field for GraphQL types that are singletons (only one instance of them is present)

## Testing

- Visually
