### PR TITLE
Small ops improvements

### DIFF
--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -99,7 +99,7 @@ Mappings:
       Memory: 128
       Timeout: 60
     Poller:
-      Memory: 128
+      Memory: 512
       Timeout: 900
     Remediation:
       Memory: 128

--- a/internal/core/custom_resources/resources/alarms_api_gateway.go
+++ b/internal/core/custom_resources/resources/alarms_api_gateway.go
@@ -40,8 +40,10 @@ type APIGatewayAlarmProperties struct {
 }
 
 func customAPIGatewayAlarms(_ context.Context, event cfn.Event) (string, map[string]interface{}, error) {
-	const defaultGatewayLatencyThresholdMs = 1000
-	const defaultGatewayErrorThreshold = 5
+	const (
+		defaultErrorThreshold = 1
+		defaultLatencyThresholdMs = 1000
+	)
 
 	switch event.RequestType {
 	case cfn.RequestCreate, cfn.RequestUpdate:
@@ -51,10 +53,10 @@ func customAPIGatewayAlarms(_ context.Context, event cfn.Event) (string, map[str
 		}
 
 		if props.ErrorThreshold == nil {
-			props.ErrorThreshold = aws.Int64(defaultGatewayErrorThreshold)
+			props.ErrorThreshold = aws.Int64(defaultErrorThreshold)
 		}
 		if props.LatencyThresholdMs == 0 {
-			props.LatencyThresholdMs = defaultGatewayLatencyThresholdMs
+			props.LatencyThresholdMs = defaultLatencyThresholdMs
 		}
 
 		return "custom:alarms:api:" + props.APIName, nil, putGatewayAlarmGroup(props)

--- a/internal/core/custom_resources/resources/alarms_api_gateway.go
+++ b/internal/core/custom_resources/resources/alarms_api_gateway.go
@@ -81,10 +81,10 @@ func putGatewayAlarmGroup(props APIGatewayAlarmProperties) error {
 		Dimensions: []*cloudwatch.Dimension{
 			{Name: aws.String("ApiName"), Value: &props.APIName},
 		},
-		EvaluationPeriods: aws.Int64(1),
+		EvaluationPeriods: aws.Int64(5),
 		MetricName:        aws.String("IntegrationLatency"),
 		Namespace:         aws.String("AWS/ApiGateway"),
-		Period:            aws.Int64(300),
+		Period:            aws.Int64(60),
 		Statistic:         aws.String(cloudwatch.StatisticMaximum),
 		Threshold:         &props.LatencyThresholdMs,
 		Unit:              aws.String(cloudwatch.StandardUnitMilliseconds),

--- a/internal/core/custom_resources/resources/alarms_lambda.go
+++ b/internal/core/custom_resources/resources/alarms_lambda.go
@@ -60,13 +60,13 @@ func customLambdaAlarms(_ context.Context, event cfn.Event) (string, map[string]
 
 		// Set defaults
 		if props.LoggedErrorThreshold == nil {
-			props.LoggedErrorThreshold = aws.Int(1)
+			props.LoggedErrorThreshold = aws.Int(0)
 		}
 		if props.LoggedWarnThreshold == nil {
 			props.LoggedWarnThreshold = aws.Int(25)
 		}
 		if props.ExecutionErrorThreshold == nil {
-			props.ExecutionErrorThreshold = aws.Int(1)
+			props.ExecutionErrorThreshold = aws.Int(0)
 		}
 		if props.ThrottleThreshold == nil {
 			props.ThrottleThreshold = aws.Int(5)

--- a/internal/core/custom_resources/resources/alarms_lambda.go
+++ b/internal/core/custom_resources/resources/alarms_lambda.go
@@ -60,13 +60,13 @@ func customLambdaAlarms(_ context.Context, event cfn.Event) (string, map[string]
 
 		// Set defaults
 		if props.LoggedErrorThreshold == nil {
-			props.LoggedErrorThreshold = aws.Int(0)
+			props.LoggedErrorThreshold = aws.Int(1)
 		}
 		if props.LoggedWarnThreshold == nil {
 			props.LoggedWarnThreshold = aws.Int(25)
 		}
 		if props.ExecutionErrorThreshold == nil {
-			props.ExecutionErrorThreshold = aws.Int(0)
+			props.ExecutionErrorThreshold = aws.Int(1)
 		}
 		if props.ThrottleThreshold == nil {
 			props.ThrottleThreshold = aws.Int(5)

--- a/internal/core/users_api/cognito/create_user.go
+++ b/internal/core/users_api/cognito/create_user.go
@@ -36,8 +36,10 @@ func (g *UsersGateway) CreateUser(input *models.InviteUserInput) (*models.User, 
 		DesiredDeliveryMediums: []*string{aws.String("EMAIL")},
 		MessageAction:          input.MessageAction,
 		UserAttributes:         userAttributes(input.GivenName, input.FamilyName, input.Email),
-		Username:               aws.String(strings.ToLower(*input.Email)),
-		UserPoolId:             g.userPoolID,
+		// Cognito is case-sensitive for emails - it will allow multiple users with the same email
+		// address if they have different casing. For that reason, we lowercase the email here.
+		Username:   aws.String(strings.ToLower(*input.Email)),
+		UserPoolId: g.userPoolID,
 	})
 	if err != nil {
 		return nil, &genericapi.AWSError{Method: "cognito.AdminCreateUser", Err: err}

--- a/tools/mage/master/deploy.go
+++ b/tools/mage/master/deploy.go
@@ -20,6 +20,7 @@ package master
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -38,7 +39,7 @@ import (
 const (
 	// The region will be interpolated in these names
 	publicImageRepository = "349240696275.dkr.ecr.%s.amazonaws.com/panther-community"
-	masterStackName       = "panther"
+	defaultStackName      = "panther"
 )
 
 var publishRegions = []string{"us-east-1", "us-east-2", "us-west-2"}
@@ -58,7 +59,12 @@ func Deploy() error {
 		return err
 	}
 
-	log.Infof("deploying %s v%s to %s (%s)", masterTemplate, version, clients.AccountID(), clients.Region())
+	var stack string
+	if stack = os.Getenv("STACK"); stack == "" {
+		stack = defaultStackName
+	}
+
+	log.Infof("deploying %s v%s to %s (%s) as stack '%s'", masterTemplate, version, clients.AccountID(), clients.Region(), stack)
 	email := prompt.Read("First user email: ", prompt.EmailValidator)
 
 	if err := Build(log); err != nil {
@@ -115,7 +121,7 @@ func Deploy() error {
 		return err
 	}
 
-	return util.SamDeploy(masterStackName, pkg, "FirstUserEmail="+email, "ImageRegistry="+registryURI)
+	return util.SamDeploy(defaultStackName, pkg, "FirstUserEmail="+email, "ImageRegistry="+registryURI)
 }
 
 // Stop early if there is a known issue with the dev environment.


### PR DESCRIPTION
## Background

A few small bugfixes based on observed problems in existing deployments.

## Changes

- Bump snapshot-poller memory from 128 to 512 MB. One of our deployments is running out of memory, and this is a critical piece of infra that needs more cpu/network at all times anyway (just like the log processor). The extra monetary cost is typically negligible compared to log processing.
- Add a comment about why we lowercase emails in Cognito (@alxarch )
- Allow `mage master:deploy` with an optional `STACK` env variable - this way, you can deploy the pre-packaged version on top of any stack name. We already support `STACK=name mage teardown`, so this is a natural extension.

## Testing

- CI; will deploy to release env after merged internally
