### PR TITLE
fix: change the license to an acceptable format

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "javascript"
   ],
   "author": "panther-labs",
-  "license": "Apache v2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/panther-labs/panther/issues"
   },


### PR DESCRIPTION
## Background

`npm` complains the license is not in a valid format:
```
license should be a valid SPDX license expression
```

## Changes

- Update the license field from `Apache v2.0` -> `Apache-2.0`

## Testing

- npm i
