### PR TITLE
Fix snapshot poller errors

### DIFF
--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -96,8 +96,8 @@ Mappings:
       Memory: 128
       Timeout: 120
     PolicyEngine:
-      Memory: 128
-      Timeout: 60
+      Memory: 256
+      Timeout: 900
     Poller:
       Memory: 512
       Timeout: 900

--- a/internal/compliance/snapshot_poller/pollers/aws/configservice.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/configservice.go
@@ -83,12 +83,11 @@ func getConfigRecorder(svc configserviceiface.ConfigServiceAPI) (*configservice.
 		ConfigurationRecorderNames: []*string{aws.String("default")},
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NoSuchConfigurationRecorderException" {
-				zap.L().Warn("tried to scan non-existent resource",
-					zap.String("resourceType", awsmodels.ConfigServiceSchema))
-				return nil, nil
-			}
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == configservice.ErrCodeNoSuchConfigurationRecorderException {
+			zap.L().Warn("tried to scan non-existent resource",
+				zap.String("resourceType", awsmodels.ConfigServiceSchema))
+			return nil, nil
 		}
 		return nil, errors.Wrap(err, "ConfigService.DescribeConfigurationRecorders")
 	}

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_ami.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_ami.go
@@ -73,13 +73,12 @@ func getAMI(svc ec2iface.EC2API, imageID *string) (*ec2.Image, error) {
 	})
 
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "InvalidAMIID.NotFound" {
-				zap.L().Warn("tried to scan non-existent resource",
-					zap.String("resource", *imageID),
-					zap.String("resourceType", awsmodels.Ec2AmiSchema))
-				return nil, nil
-			}
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == "InvalidAMIID.NotFound" {
+			zap.L().Warn("tried to scan non-existent resource",
+				zap.String("resource", *imageID),
+				zap.String("resourceType", awsmodels.Ec2AmiSchema))
+			return nil, nil
 		}
 		return nil, errors.Wrapf(err, "EC2.DescribeImages: %s", aws.StringValue(imageID))
 	}

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_network_acl.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_network_acl.go
@@ -70,13 +70,12 @@ func getNetworkACL(svc ec2iface.EC2API, networkACLID *string) (*ec2.NetworkAcl, 
 		NetworkAclIds: []*string{networkACLID},
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "InvalidNetworkAclID.NotFound" {
-				zap.L().Warn("tried to scan non-existent resource",
-					zap.String("resource", *networkACLID),
-					zap.String("resourceType", awsmodels.Ec2NetworkAclSchema))
-				return nil, nil
-			}
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == "InvalidNetworkAclID.NotFound" {
+			zap.L().Warn("tried to scan non-existent resource",
+				zap.String("resource", *networkACLID),
+				zap.String("resourceType", awsmodels.Ec2NetworkAclSchema))
+			return nil, nil
 		}
 		return nil, errors.Wrapf(err, "EC2.DescribeNetworkACLs: %s", aws.StringValue(networkACLID))
 	}

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
@@ -81,15 +81,14 @@ func PollIAMUser(
 	}
 	userCredentialReports, err = buildCredentialReport(iamClient)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == throttlingErrorCode {
 			// Check if we got rate limited, happens sometimes when the credential report takes a long time to generate
-			if awsErr.Code() == throttlingErrorCode {
-				zap.L().Debug("credential report lookup rate limited during single user scan", zap.String("resourceId", *scanRequest.ResourceID))
-				err = utils.Requeue(pollermodels.ScanMsg{
-					Entries: []*pollermodels.ScanEntry{scanRequest},
-				}, credentialReportRequeueDelaySeconds)
-				return nil, err
-			}
+			zap.L().Debug("credential report lookup rate limited during single user scan", zap.String("resourceId", *scanRequest.ResourceID))
+			err = utils.Requeue(pollermodels.ScanMsg{
+				Entries: []*pollermodels.ScanEntry{scanRequest},
+			}, credentialReportRequeueDelaySeconds)
+			return nil, err
 		}
 		return nil, err
 	}
@@ -157,13 +156,12 @@ func getUser(svc iamiface.IAMAPI, userName *string) (*iam.User, error) {
 		UserName: userName,
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NoSuchEntity" {
-				zap.L().Warn("tried to scan non-existent resource",
-					zap.String("resource", *userName),
-					zap.String("resourceType", awsmodels.IAMUserSchema))
-				return nil, nil
-			}
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == iam.ErrCodeNoSuchEntityException {
+			zap.L().Warn("tried to scan non-existent resource",
+				zap.String("resource", *userName),
+				zap.String("resourceType", awsmodels.IAMUserSchema))
+			return nil, nil
 		}
 		return nil, errors.Wrapf(err, "IAM.GetUser: %s", aws.StringValue(userName))
 	}
@@ -276,7 +274,8 @@ func buildCredentialReport(
 	// Try to get the credential report
 	credentialReportRaw, err = getCredentialReport(iamSvc)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
 			switch awsErr.Code() {
 			case iam.ErrCodeCredentialReportNotPresentException, iam.ErrCodeCredentialReportExpiredException:
 				zap.L().Debug("no credential report found, generating a new one")
@@ -523,9 +522,12 @@ func PollIAMUsers(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.AddR
 	}
 
 	// Build the credential report for all users
+	// NOTE: the returned error here is *not* wrapped with "errors". If that changes,
+	// be sure
 	userCredentialReports, err = buildCredentialReport(iamSvc)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == throttlingErrorCode {
 			// Check if we got rate limited, which happens sometimes when the credential report takes a long time to generate
 			if awsErr.Code() == throttlingErrorCode {
 				zap.L().Debug(

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
@@ -522,8 +522,6 @@ func PollIAMUsers(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodels.AddR
 	}
 
 	// Build the credential report for all users
-	// NOTE: the returned error here is *not* wrapped with "errors". If that changes,
-	// be sure
 	userCredentialReports, err = buildCredentialReport(iamSvc)
 	if err != nil {
 		var awsErr awserr.Error

--- a/internal/compliance/snapshot_poller/pollers/aws/password_policy.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/password_policy.go
@@ -88,13 +88,11 @@ func PollPasswordPolicy(pollerInput *awsmodels.ResourcePollerInput) ([]*apimodel
 	anyExist := true
 	passwordPolicy, err := getPasswordPolicy(iamSvc)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == iam.ErrCodeNoSuchEntityException {
-				anyExist = false
-			}
-		}
-		// If the error wasn't caused by the password policy not existing, then return it
-		if anyExist {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == iam.ErrCodeNoSuchEntityException {
+			anyExist = false
+		} else {
+			// The error wasn't caused by the password policy not existing: return it
 			return nil, nil, err
 		}
 	}

--- a/internal/compliance/snapshot_poller/pollers/aws/waf_web_acl.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/waf_web_acl.go
@@ -183,7 +183,8 @@ func buildWafWebACLSnapshot(wafSvc wafiface.WAFAPI, webACLID *string) (*awsmodel
 
 	webACL, err := getWebACL(wafSvc, webACLID)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
 			if awsErr.Code() == "WAFNonexistentItemException" {
 				if _, ok := wafSvc.(wafregionaliface.WAFRegionalAPI); ok {
 					zap.L().Warn("tried to scan non-existent resource",

--- a/internal/compliance/snapshot_poller/pollers/utils/logging.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/logging.go
@@ -26,7 +26,8 @@ import (
 
 // LogAWSError logs an AWS error to zap in a digestable format.
 func LogAWSError(apiCall string, err error) {
-	if awsErr, ok := err.(awserr.Error); ok {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
 		zap.L().Error(
 			apiCall,
 			zap.String("errorCode", awsErr.Code()),

--- a/internal/core/alert_delivery/outputs/utils.go
+++ b/internal/core/alert_delivery/outputs/utils.go
@@ -21,10 +21,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/pkg/errors"
 )
 
 func getAlertResponseFromSQSError(err error) *AlertDeliveryResponse {
-	if awsErr, ok := err.(awserr.Error); ok {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
 		statusCode := mapSQSSendMessageErrorCodeToStatusCode(awsErr)
 		return getResponse(statusCode, awsErr.Error())
 	}
@@ -32,7 +34,8 @@ func getAlertResponseFromSQSError(err error) *AlertDeliveryResponse {
 }
 
 func getAlertResponseFromSNSError(err error) *AlertDeliveryResponse {
-	if awsErr, ok := err.(awserr.Error); ok {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
 		statusCode := mapSNSPublishErrorCodeToStatusCode(awsErr)
 		return getResponse(statusCode, awsErr.Error())
 	}

--- a/internal/core/custom_resources/resources/glue.go
+++ b/internal/core/custom_resources/resources/glue.go
@@ -52,9 +52,9 @@ func customUpdateGlueTables(_ context.Context, event cfn.Event) (string, map[str
 		// ensure databases are all there
 		for pantherDatabase, pantherDatabaseDescription := range awsglue.PantherDatabases {
 			zap.L().Info("creating database", zap.String("database", pantherDatabase))
-			_, err := awsglue.CreateDatabase(glueClient, pantherDatabase, pantherDatabaseDescription)
-			if err != nil {
-				if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
+			if _, err := awsglue.CreateDatabase(glueClient, pantherDatabase, pantherDatabaseDescription); err != nil {
+				var awsErr awserr.Error
+				if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
 					zap.L().Info("database exists", zap.String("database", pantherDatabase))
 				} else {
 					return "", nil, errors.Wrapf(err, "failed creating database %s", pantherDatabase)
@@ -100,9 +100,9 @@ func customUpdateGlueTables(_ context.Context, event cfn.Event) (string, map[str
 	case cfn.RequestDelete:
 		for pantherDatabase := range awsglue.PantherDatabases {
 			zap.L().Info("deleting database", zap.String("database", pantherDatabase))
-			_, err := awsglue.DeleteDatabase(glueClient, pantherDatabase)
-			if err != nil {
-				if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
+			if _, err := awsglue.DeleteDatabase(glueClient, pantherDatabase); err != nil {
+				var awsErr awserr.Error
+				if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
 					zap.L().Info("already deleted", zap.String("database", pantherDatabase))
 				} else {
 					return "", nil, errors.Wrapf(err, "failed deleting %s", pantherDatabase)

--- a/internal/core/custom_resources/resources/lambda_metric_filters.go
+++ b/internal/core/custom_resources/resources/lambda_metric_filters.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -153,7 +154,8 @@ func deleteMetricFilterGroup(physicalID string) error {
 		})
 
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
+			var awsErr awserr.Error
+			if errors.As(err, &awsErr) && awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
 				zap.L().Info("metric filter has already been deleted")
 				continue
 			}

--- a/internal/core/custom_resources/resources/panther_teardown.go
+++ b/internal/core/custom_resources/resources/panther_teardown.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -79,7 +80,8 @@ func destroyEcrRepo(repoName string) error {
 		RepositoryName: &repoName,
 	})
 
-	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == ecr.ErrCodeRepositoryNotFoundException {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) && awsErr.Code() == ecr.ErrCodeRepositoryNotFoundException {
 		// repo doesn't exist - that's fine, nothing to do here
 		err = nil
 	}
@@ -163,7 +165,8 @@ func deleteLogGroup(name *string) error {
 	zap.L().Info("deleting log group", zap.String("groupName", *name))
 	_, err := cloudWatchLogsClient.DeleteLogGroup(&cloudwatchlogs.DeleteLogGroupInput{LogGroupName: name})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
 			// log group no longer exists, carry on
 			return nil
 		}

--- a/internal/core/custom_resources/resources/s3_bucket_notification.go
+++ b/internal/core/custom_resources/resources/s3_bucket_notification.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-lambda-go/cfn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/pkg/errors"
 )
 
 type S3BucketNotificationProperties = s3.PutBucketNotificationConfigurationInput
@@ -59,7 +60,8 @@ func customS3BucketNotification(_ context.Context, event cfn.Event) (string, map
 			Bucket:                    &bucketName,
 			NotificationConfiguration: &s3.NotificationConfiguration{},
 		})
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == s3.ErrCodeNoSuchBucket {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == s3.ErrCodeNoSuchBucket {
 			err = nil // bucket already deleted
 		}
 

--- a/internal/core/users_api/cognito/delete_user.go
+++ b/internal/core/users_api/cognito/delete_user.go
@@ -21,6 +21,7 @@ package cognito
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/pkg/genericapi"
@@ -32,7 +33,8 @@ func (g *UsersGateway) DeleteUser(id *string) error {
 		Username:   id,
 		UserPoolId: g.userPoolID,
 	}); err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == provider.ErrCodeUserNotFoundException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == provider.ErrCodeUserNotFoundException {
 			zap.L().Warn("user is already deleted", zap.String("userId", *id))
 			return nil
 		}

--- a/internal/core/users_api/cognito/get_user.go
+++ b/internal/core/users_api/cognito/get_user.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/pkg/errors"
 
 	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
@@ -33,7 +34,8 @@ func (g *UsersGateway) GetUser(id *string) (*models.User, error) {
 	get, err := g.userPoolClient.AdminGetUser(
 		&provider.AdminGetUserInput{Username: id, UserPoolId: g.userPoolID})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == provider.ErrCodeUserNotFoundException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == provider.ErrCodeUserNotFoundException {
 			return nil, &genericapi.DoesNotExistError{Message: "userID=" + *id + " does not exist"}
 		}
 		return nil, &genericapi.AWSError{Method: "cognito.AdminGetUser", Err: err}

--- a/internal/core/users_api/cognito/update_user.go
+++ b/internal/core/users_api/cognito/update_user.go
@@ -21,6 +21,7 @@ package cognito
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	provider "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/pkg/errors"
 
 	"github.com/panther-labs/panther/api/lambda/users/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
@@ -34,7 +35,8 @@ func (g *UsersGateway) UpdateUser(input *models.UpdateUserInput) error {
 		Username:       input.ID,
 	}
 	if _, err := g.userPoolClient.AdminUpdateUserAttributes(cognitoInput); err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == provider.ErrCodeUserNotFoundException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == provider.ErrCodeUserNotFoundException {
 			return &genericapi.DoesNotExistError{Message: "userID=" + *input.ID + " does not exist"}
 		}
 		return &genericapi.AWSError{Method: "cognito.AdminUpdateUserAttributes", Err: err}

--- a/internal/log_analysis/awsglue/integration_test.go
+++ b/internal/log_analysis/awsglue/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -162,7 +163,8 @@ func removeTables(t *testing.T) {
 // Fetches the location of a partition. Return nil it the partition doesn't exist
 func getPartitionLocation(t *testing.T, partitionValues []string) *string {
 	response, err := GetPartition(glueClient, testDB, testTable, aws.StringSlice(partitionValues))
-	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
 		return nil
 	}
 	require.NoError(t, err)

--- a/internal/log_analysis/awsglue/table_metadata.go
+++ b/internal/log_analysis/awsglue/table_metadata.go
@@ -213,7 +213,8 @@ func (gm *GlueTableMetadata) CreateOrUpdateTable(glueClient glueiface.GlueAPI, b
 	}
 	_, err := glueClient.CreateTable(createTableInput)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
 			// need to do an update
 			updateTableInput := &glue.UpdateTableInput{
 				DatabaseName: &gm.databaseName,
@@ -274,7 +275,8 @@ func (gm *GlueTableMetadata) SyncPartitions(glueClient glueiface.GlueAPI, s3Clie
 				getPartitionOutput, err := GetPartition(glueClient, gm.databaseName, gm.tableName, values)
 				if err != nil {
 					// skip time period with no partition UNLESS there is data, then create
-					if awsErr, ok := err.(awserr.Error); !ok || awsErr.Code() != glue.ErrCodeEntityNotFoundException {
+					var awsErr awserr.Error
+					if !errors.As(err, &awsErr) || awsErr.Code() != glue.ErrCodeEntityNotFoundException {
 						failed = true
 						errChan <- err
 					} else { // no partition, check if there is data in S3, if so, create
@@ -364,7 +366,8 @@ func (gm *GlueTableMetadata) createPartition(client glueiface.GlueAPI, t time.Ti
 	_, err = CreatePartition(client, gm.databaseName, gm.tableName, gm.timebin.PartitionValuesFromTime(t),
 		&storageDescriptor, nil)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
 			return false, nil // no error
 		}
 		return false, err
@@ -376,7 +379,8 @@ func (gm *GlueTableMetadata) createPartition(client glueiface.GlueAPI, t time.Ti
 func (gm *GlueTableMetadata) GetPartition(client glueiface.GlueAPI, t time.Time) (output *glue.GetPartitionOutput, err error) {
 	output, err = GetPartition(client, gm.databaseName, gm.tableName, gm.timebin.PartitionValuesFromTime(t))
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
 			return nil, nil // not there, no error
 		}
 		return nil, err

--- a/internal/log_analysis/gluetables/gluetables.go
+++ b/internal/log_analysis/gluetables/gluetables.go
@@ -37,7 +37,8 @@ func DeployedLogTables(glueClient glueiface.GlueAPI) (deployedLogTables []*awsgl
 	for _, gm := range registry.AvailableTables() {
 		_, err := awsglue.GetTable(glueClient, gm.DatabaseName(), gm.TableName())
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
+			var awsErr awserr.Error
+			if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
 				continue
 			} else {
 				return nil, errors.Wrapf(err, "failure checking existence of %s.%s",

--- a/pkg/gatewayapi/router.go
+++ b/pkg/gatewayapi/router.go
@@ -81,7 +81,8 @@ func LambdaProxy(methodHandlers map[string]RequestHandler) func(
 		case result.StatusCode < 400:
 			operation.Stop().LogSuccess(zap.Int("statusCode", result.StatusCode), zap.Int("bodyLength", len(result.Body)))
 		case result.StatusCode < 500:
-			operation.Stop().LogWarn(errors.New("client error"), zap.Int("statusCode", result.StatusCode), zap.String("responseBody", result.Body))
+			operation.Stop().LogNonCriticalError(
+				errors.New("client error"), zap.Int("statusCode", result.StatusCode), zap.String("responseBody", result.Body))
 		default:
 			operation.Stop().LogError(errors.New("server error"), zap.Int("statusCode", result.StatusCode), zap.String("responseBody", result.Body))
 		}

--- a/pkg/oplog/oplog.go
+++ b/pkg/oplog/oplog.go
@@ -184,3 +184,9 @@ func (o *Operation) LogError(err error, fields ...zap.Field) {
 	fields = append(fields, zap.Error(err))
 	zap.L().Error(o.zapMsg(), append(fields, o.fields(Failure)...)...)
 }
+
+// Errors which are good to know about, but do not need to trigger ops alarms from Warn/Error log msgs
+func (o *Operation) LogNonCriticalError(err error, fields ...zap.Field) {
+	fields = append(fields, zap.Error(err))
+	zap.L().Info(o.zapMsg(), append(fields, o.fields(Failure)...)...)
+}


### PR DESCRIPTION
## Background

When deployed to my dev account, the snapshot-poller fails to scan the IAM password policy:

```
IAM.GetAccountPasswordPolicy: NoSuchEntity: The Password Policy with domain name 101802775469 cannot be found.\n\tstatus code: 404
```

But we're specifically checking for that error code and ignoring it:

```go
if awsErr, ok := err.(awserr.Error); ok &&  awsErr.Code() == iam.ErrCodeNoSuchEntityException {
    // this means it does not exist, handle it accordingly...
}
```

So why isn't this triggering? Because the recent snapshot poller refactor (#206 ) made better use of the `errors` package for wrapping errors with context. This unfortunately means that you can no longer use a standard type assertion - a wrapped error is *not* of type `awserr.Error`.

So I've replaced everywhere in the codebase (mostly snapshot poller) `if awsErr, ok := err.(awserr.Error)` with `errors.As(err, &awsErr)`. Using `errors.As` works fine if the err is nil or if it is not wrapped, so it's safer to use this everywhere to prevent the bug from happening again

## Changes

- Use `errors.As` instead of awserr type assertions
- Use aws constants for error codes when possible
- Bump `policy-engine` memory and timeout to match the `rules-engine` (I saw `policy-engine` timeouts in the early stages of some of my test deployments)

## Testing

- Deployed to my dev acct - snapshot errors subsided
- Go playground to ensure I'm using the `errors` pkg correctly - https://play.golang.org/p/g0-iRVZiBl1
