### PR TITLE
Remove cached sns/sqs clients from alert-delivery

### DIFF
--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	jsoniter "github.com/json-iterator/go"
@@ -36,7 +37,7 @@ import (
 
 func TestSendSns(t *testing.T) {
 	client := &testutils.SnsMock{}
-	outputClient := &OutputClient{snsClients: map[string]snsiface.SNSAPI{"us-west-2": client}}
+	outputClient := &OutputClient{}
 
 	snsOutputConfig := &outputModels.SnsConfig{
 		TopicArn: "arn:aws:sns:us-west-2:123456789012:test-sns-output",
@@ -81,6 +82,10 @@ func TestSendSns(t *testing.T) {
 	}
 
 	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{MessageId: aws.String("messageId")}, nil)
+	getSnsClient = func(*session.Session, string) (snsiface.SNSAPI, error) {
+		return client, nil
+	}
+
 	result := outputClient.Sns(alert, snsOutputConfig)
 	assert.NotNil(t, result)
 	assert.Equal(t, &AlertDeliveryResponse{

--- a/internal/core/alert_delivery/outputs/sqs.go
+++ b/internal/core/alert_delivery/outputs/sqs.go
@@ -92,6 +92,10 @@ func (client *OutputClient) Sqs(alert *alertModels.Alert, config *outputModels.S
 
 func buildSqsClient(awsSession *session.Session, queueURL string) sqsiface.SQSAPI {
 	// Queue URL is like "https://sqs.us-west-2.amazonaws.com/123456789012/panther-alert-queue"
+	parts := strings.Split(queueURL, ".")
+	if len(parts) == 1 {
+		panic("expected queueURL with periods, found none: " + queueURL)
+	}
 	region := strings.Split(queueURL, ".")[1]
 	return sqs.New(awsSession, aws.NewConfig().WithRegion(region))
 }

--- a/internal/core/alert_delivery/outputs/sqs.go
+++ b/internal/core/alert_delivery/outputs/sqs.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	jsoniter "github.com/json-iterator/go"
@@ -30,6 +31,9 @@ import (
 	alertModels "github.com/panther-labs/panther/api/lambda/delivery/models"
 	outputModels "github.com/panther-labs/panther/api/lambda/outputs/models"
 )
+
+// Tests can replace this with a mock implementation
+var getSqsClient = buildSqsClient
 
 // Sqs sends an alert to an SQS Queue.
 // nolint: dupl
@@ -52,7 +56,7 @@ func (client *OutputClient) Sqs(alert *alertModels.Alert, config *outputModels.S
 		MessageBody: aws.String(serializedMessage),
 	}
 
-	sqsClient := client.getSqsClient(config.QueueURL)
+	sqsClient := getSqsClient(client.session, config.QueueURL)
 
 	response, err := sqsClient.SendMessage(sqsSendMessageInput)
 	if err != nil {
@@ -86,13 +90,8 @@ func (client *OutputClient) Sqs(alert *alertModels.Alert, config *outputModels.S
 	}
 }
 
-func (client *OutputClient) getSqsClient(queueURL string) sqsiface.SQSAPI {
+func buildSqsClient(awsSession *session.Session, queueURL string) sqsiface.SQSAPI {
 	// Queue URL is like "https://sqs.us-west-2.amazonaws.com/123456789012/panther-alert-queue"
 	region := strings.Split(queueURL, ".")[1]
-	sqsClient, ok := client.sqsClients[region]
-	if !ok {
-		sqsClient = sqs.New(client.session, aws.NewConfig().WithRegion(region))
-		client.sqsClients[region] = sqsClient
-	}
-	return sqsClient
+	return sqs.New(awsSession, aws.NewConfig().WithRegion(region))
 }

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	jsoniter "github.com/json-iterator/go"
@@ -35,7 +36,7 @@ import (
 
 func TestSendSqs(t *testing.T) {
 	client := &testutils.SqsMock{}
-	outputClient := &OutputClient{sqsClients: map[string]sqsiface.SQSAPI{"us-west-2": client}}
+	outputClient := &OutputClient{}
 
 	sqsOutputConfig := &outputModels.SqsConfig{
 		QueueURL: "https://sqs.us-west-2.amazonaws.com/123456789012/test-output",
@@ -66,6 +67,10 @@ func TestSendSqs(t *testing.T) {
 	}
 
 	client.On("SendMessage", expectedSqsSendMessageInput).Return(&sqs.SendMessageOutput{MessageId: aws.String("messageId")}, nil)
+	getSqsClient = func(*session.Session, string) sqsiface.SQSAPI {
+		return client
+	}
+
 	result := outputClient.Sqs(alert, sqsOutputConfig)
 	assert.NotNil(t, result)
 	assert.Equal(t, &AlertDeliveryResponse{


### PR DESCRIPTION
## Background

SNS/SQS alert deliveries will fail if there is more than one SNS/SQS destination in a single alert. This is because we have a map caching clients by region, but we access that map from each goroutine which delivers alerts in parallel:

```
  | 2020-09-11T14:04:55.167-07:00 | fatal error: concurrent map writes
  | 2020-09-11T14:04:55.206-07:00 | goroutine 12 [running]:
  | 2020-09-11T14:04:55.206-07:00 | runtime.throw(0xe3965d, 0x15)
  | 2020-09-11T14:04:55.206-07:00 | /usr/local/Cellar/go/1.14/libexec/src/runtime/panic.go:1112 +0x72 fp=0xc0005d97b8 sp=0xc0005d9788 pc=0x4332f2
  | 2020-09-11T14:04:55.206-07:00 | runtime.mapassign_faststr(0xd1f7e0, 0xc000606f00, 0xc0001000fc, 0x9, 0x1)
  | 2020-09-11T14:04:55.206-07:00 | /usr/local/Cellar/go/1.14/libexec/src/runtime/map_faststr.go:291 +0x3de fp=0xc0005d9820 sp=0xc0005d97b8 pc=0x412f3e
  | 2020-09-11T14:04:55.206-07:00 | github.com/panther-labs/panther/internal/core/alert_delivery/outputs.(*OutputClient).getSqsClient(0xc000606f60, 0xc0001000f0, 0x41, 0xc000af4900, 0x2e1)
  | 2020-09-11T14:04:55.206-07:00 | /Users/nhakmiller/go/src/github.com/panther-labs/panther-enterprise/internal/core/alert_delivery/outputs/sqs.go:86 +0x1ec fp=0xc0005d98a0 sp=0xc0005d9820 pc=0xbb7fec
  | 2020-09-11T14:04:55.206-07:00 | github.com/panther-labs/panther/internal/core/alert_delivery/outputs.(*OutputClient).Sqs(0xc000606f60, 0xc0005aa240, 0xc00075b0e0, 0x456767444151424c)
  | 2020-09-11T14:04:55.206-07:00 | /Users/nhakmiller/go/src/github.com/panther-labs/panther-enterprise/internal/core/alert_delivery/outputs/sqs.go:46 +0x435 fp=0xc0005d9bf8 sp=0xc0005d98a0 pc=0xbb79d5
  | 2020-09-11T14:04:55.206-07:00 | github.com/panther-labs/panther/internal/core/alert_delivery/api.sendAlert(0xc0005aa240, 0xc00006ea80, 0x79577f3, 0xed6eddd77, 0x0, 0xc00003c0c0)
  | 2020-09-11T14:04:55.206-07:00 | /Users/nhakmiller/go/src/github.com/panther-labs/panther-enterprise/internal/core/alert_delivery/api/send.go:103 +0x60f fp=0xc0005d9fb0 sp=0xc0005d9bf8 pc=0xc4033f
```

We could add a mutex around the map, but we really don't need to cache clients at all, they are created very quickly (< 50 ns) in Go.

Closes: #1529 

## Changes

- Add warning comment about shared global state
- Remove SNS/SQS client caches from alert-delivery

## Testing

- Updated unit tests
- @s0l0ist to test the deployed fix
