### PR TITLE
Add proper grid alignment for rows in rule details

### DIFF
--- a/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
+++ b/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
@@ -75,68 +75,126 @@ const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, rule, alertD
       )}
       <Card variant="dark" as="section" p={4}>
         <SimpleGrid columns={2} spacing={5} fontSize="small-medium">
-          {rule ? (
-            <Flex spacing={5}>
-              <Flex direction="column" spacing={2} color="navyblue-100" flexShrink={0}>
-                <Box aria-describedby="rule-link">Rule</Box>
-                <Box aria-describedby="threshold">Rule Threshold</Box>
-                <Box aria-describedby="deduplication-period">Deduplication Period</Box>
-                <Box aria-describedby="deduplication-string">Deduplication String</Box>
-                <Box aria-describedby="tags-list">Tags</Box>
-              </Flex>
-              <Flex direction="column" spacing={2}>
-                <Link id="rule-link" as={RRLink} to={urls.logAnalysis.rules.details(rule.id)}>
-                  {rule.displayName || rule.id}
-                </Link>
-                <Box id="threshold">{minutesToString(rule.threshold)}</Box>
-                <Box id="deduplication-period">
-                  {rule.dedupPeriodMinutes
-                    ? minutesToString(rule.dedupPeriodMinutes)
-                    : 'Not specified'}
-                </Box>
-                <Box id="deduplication-string">{alert.dedupString}</Box>
-                {rule.tags.length > 0 ? (
-                  <Box id="tags-list">
-                    {rule.tags.map((tag, index) => (
-                      <Link
-                        key={tag}
-                        as={RRLink}
-                        to={`${urls.logAnalysis.rules.list()}?page=1&tags[]=${tag}`}
-                      >
-                        {tag}
-                        {index !== rule.tags.length - 1 ? ', ' : null}
-                      </Link>
-                    ))}
+          <Box>
+            <SimpleGrid gap={2} columns={8} spacing={2}>
+              {rule ? (
+                <>
+                  <Box color="navyblue-100" gridColumn="1/3" aria-describedby="rule-link">
+                    Rule
                   </Box>
-                ) : (
-                  <Box fontStyle="italic" color="navyblue-100" id="tags-list">
-                    This rule has no tags
+
+                  <Link
+                    id="rule-link"
+                    gridColumn="3/8"
+                    as={RRLink}
+                    to={urls.logAnalysis.rules.details(rule.id)}
+                  >
+                    {rule.displayName || rule.id}
+                  </Link>
+
+                  <Box color="navyblue-100" gridColumn="1/3" aria-describedby="threshold">
+                    Rule Threshold
                   </Box>
-                )}
-              </Flex>
-            </Flex>
-          ) : (
-            <Flex spacing={5}>
-              <Flex direction="column" spacing={2} color="navyblue-100" flexShrink={0}>
-                <Box aria-describedby="rule-link">Rule</Box>
-                <Box aria-describedby="deduplication-string">Deduplication String</Box>
-              </Flex>
-              <Flex direction="column" spacing={2}>
-                <Box color="red-300">Associated rule has been deleted</Box>
-                <Box id="deduplication-string">{alert.dedupString}</Box>
-              </Flex>
-            </Flex>
-          )}
-          <Flex spacing={60}>
-            <Flex direction="column" color="navyblue-100" spacing={2}>
-              <Box aria-describedby="created-at">Created</Box>
-              <Box aria-describedby="last-matched-at">Last Matched</Box>
-              <Box aria-describedby="destinations">Destinations</Box>
-            </Flex>
-            <Flex direction="column" spacing={2}>
-              <Box id="created-at">{formatDatetime(alert.creationTime)}</Box>
-              <Box id="last-matched-at">{formatDatetime(alert.updateTime)}</Box>
-              <Box id="destinations">
+
+                  <Box id="threshold" gridColumn="3/8">
+                    {minutesToString(rule.threshold)}
+                  </Box>
+
+                  <Box
+                    color="navyblue-100"
+                    gridColumn="1/3"
+                    aria-describedby="deduplication-period"
+                  >
+                    Deduplication Period
+                  </Box>
+
+                  <Box id="deduplication-period" gridColumn="3/8">
+                    {rule.dedupPeriodMinutes
+                      ? minutesToString(rule.dedupPeriodMinutes)
+                      : 'Not specified'}
+                  </Box>
+
+                  <Box
+                    color="navyblue-100"
+                    gridColumn="1/3"
+                    aria-describedby="deduplication-string"
+                  >
+                    Deduplication String
+                  </Box>
+
+                  <Box id="deduplication-string" gridColumn="3/8">
+                    {alert.dedupString}
+                  </Box>
+
+                  <Box color="navyblue-100" gridColumn="1/3" aria-describedby="tags-list">
+                    Tags
+                  </Box>
+
+                  {rule.tags.length > 0 ? (
+                    <Box id="tags-list" gridColumn="3/8">
+                      {rule.tags.map((tag, index) => (
+                        <Link
+                          key={tag}
+                          as={RRLink}
+                          to={`${urls.logAnalysis.rules.list()}?page=1&tags[]=${tag}`}
+                        >
+                          {tag}
+                          {index !== rule.tags.length - 1 ? ', ' : null}
+                        </Link>
+                      ))}
+                    </Box>
+                  ) : (
+                    <Box fontStyle="italic" color="navyblue-100" id="tags-list" gridColumn="3/8">
+                      This rule has no tags
+                    </Box>
+                  )}
+                </>
+              ) : (
+                <>
+                  <Box color="navyblue-100" gridColumn="1/3" aria-describedby="rule-link">
+                    Rule
+                  </Box>
+                  <Box gridColumn="3/8" color="red-300">
+                    Associated rule has been deleted
+                  </Box>
+
+                  <Box
+                    color="navyblue-100"
+                    gridColumn="1/3"
+                    aria-describedby="deduplication-string"
+                  >
+                    Deduplication String
+                  </Box>
+                  <Box gridColumn="3/8" id="deduplication-string">
+                    {alert.dedupString}
+                  </Box>
+                </>
+              )}
+            </SimpleGrid>
+          </Box>
+
+          <Box>
+            <SimpleGrid gap={2} columns={8} spacing={2}>
+              <Box color="navyblue-100" gridColumn="1/3" aria-describedby="created-at">
+                Created
+              </Box>
+
+              <Box id="created-at" gridColumn="3/8">
+                {formatDatetime(alert.creationTime)}
+              </Box>
+
+              <Box color="navyblue-100" gridColumn="1/3" aria-describedby="last-matched-at">
+                Last Matched
+              </Box>
+              <Box gridColumn="3/8" id="last-matched-at">
+                {formatDatetime(alert.updateTime)}
+              </Box>
+
+              <Box color="navyblue-100" gridColumn="1/3" aria-describedby="destinations">
+                Destinations
+              </Box>
+
+              <Box id="destinations" gridColumn="3/8">
                 {alertDestinations.map(destination => (
                   <Flex key={destination.outputId} align="center" mb={2}>
                     <Img
@@ -150,8 +208,8 @@ const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, rule, alertD
                   </Flex>
                 ))}
               </Box>
-            </Flex>
-          </Flex>
+            </SimpleGrid>
+          </Box>
         </SimpleGrid>
       </Card>
       <Card variant="dark" as="section" p={4}>

--- a/web/src/pages/PolicyDetails/PolicyDetailsInfo/PolicyDetailsInfo.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsInfo/PolicyDetailsInfo.tsx
@@ -172,14 +172,13 @@ const PolicyDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ policy }) => {
         </Card>
         <Card variant="dark" as="section" p={4}>
           <SimpleGrid columns={2} spacing={5} fontSize="small-medium">
-            <Flex spacing={5}>
-              <Flex direction="column" spacing={2} color="navyblue-100" flexShrink={0}>
-                <Box aria-describedby="tags-list">Tags</Box>
-                <Box aria-describedby="ignore-patterns-list">Ignore Pattens</Box>
-              </Flex>
-              <Flex direction="column" spacing={2}>
+            <Box>
+              <SimpleGrid gap={2} columns={8} spacing={2}>
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="tags-list">
+                  Tags
+                </Box>
                 {policy.tags.length > 0 ? (
-                  <Box id="tags-list">
+                  <Box gridColumn="3/8" id="tags-list">
                     {policy.tags.map((tag, index) => (
                       <Link
                         key={tag}
@@ -192,34 +191,45 @@ const PolicyDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ policy }) => {
                     ))}
                   </Box>
                 ) : (
-                  <Box fontStyle="italic" color="navyblue-100" id="tags-list">
+                  <Box fontStyle="italic" color="navyblue-100" gridColumn="3/8" id="tags-list">
                     This policy has no tags
                   </Box>
                 )}
+
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="ignore-patterns-list">
+                  Ignore Pattens
+                </Box>
                 {policy.suppressions.length > 0 ? (
-                  <Box id="ignore-patterns-list">
+                  <Box gridColumn="3/8" id="ignore-patterns-list">
                     {policy.suppressions.map(
                       (suppression, index) =>
                         `${suppression}${index !== policy.suppressions.length - 1 ? ', ' : null}`
                     )}
                   </Box>
                 ) : (
-                  <Box id="ignore-patterns-list">
+                  <Box gridColumn="3/8" id="ignore-patterns-list">
                     No particular resource is ignored for this policy
                   </Box>
                 )}
-              </Flex>
-            </Flex>
-            <Flex spacing={60}>
-              <Flex direction="column" color="navyblue-100" spacing={2}>
-                <Box aria-describedby="created-at">Created</Box>
-                <Box aria-describedby="updated-at">Modified</Box>
-              </Flex>
-              <Flex direction="column" spacing={2}>
-                <Box id="created-at">{formatDatetime(policy.createdAt)}</Box>
-                <Box id="updated-at">{formatDatetime(policy.lastModified)}</Box>
-              </Flex>
-            </Flex>
+              </SimpleGrid>
+            </Box>
+            <Box>
+              <SimpleGrid gap={2} columns={8} spacing={2}>
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="created-at">
+                  Created
+                </Box>
+                <Box gridColumn="3/8" id="created-at">
+                  {formatDatetime(policy.createdAt)}
+                </Box>
+
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="updated-at">
+                  Modified
+                </Box>
+                <Box gridColumn="3/8" id="updated-at">
+                  {formatDatetime(policy.lastModified)}
+                </Box>
+              </SimpleGrid>
+            </Box>
           </SimpleGrid>
         </Card>
       </Card>

--- a/web/src/pages/RuleDetails/RuleDetailsInfo/RuleDetailsInfo.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsInfo/RuleDetailsInfo.tsx
@@ -128,15 +128,13 @@ const RuleDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ rule }) => {
         </Card>
         <Card variant="dark" as="section" p={4}>
           <SimpleGrid columns={2} spacing={5} fontSize="small-medium">
-            <Flex spacing={5}>
-              <Flex direction="column" spacing={2} color="navyblue-100" flexShrink={0}>
-                <Box aria-describedby="tags-list">Tags</Box>
-                <Box aria-describedby="deduplication-period">Deduplication Period</Box>
-                <Box aria-describedby="threshold">Threshold</Box>
-              </Flex>
-              <Flex direction="column" spacing={2}>
+            <Box>
+              <SimpleGrid gap={2} columns={8} spacing={2}>
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="tags-list">
+                  Tags
+                </Box>
                 {rule.tags.length > 0 ? (
-                  <Box id="tags-list">
+                  <Box id="tags-list" gridColumn="3/8">
                     {rule.tags.map((tag, index) => (
                       <Link
                         key={tag}
@@ -149,24 +147,43 @@ const RuleDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ rule }) => {
                     ))}
                   </Box>
                 ) : (
-                  <Box fontStyle="italic" color="navyblue-100" id="tags-list">
+                  <Box gridColumn="3/8" fontStyle="italic" color="navyblue-100" id="tags-list">
                     This rule has no tags
                   </Box>
                 )}
-                <Box id="deduplication-period">{minutesToString(rule.dedupPeriodMinutes)}</Box>
-                <Box id="threshold">{formatNumber(rule.threshold)}</Box>
-              </Flex>
-            </Flex>
-            <Flex spacing={60}>
-              <Flex direction="column" color="navyblue-100" spacing={2}>
-                <Box aria-describedby="created-at">Created</Box>
-                <Box aria-describedby="updated-at">Modified</Box>
-              </Flex>
-              <Flex direction="column" spacing={2}>
-                <Box id="created-at">{formatDatetime(rule.createdAt)}</Box>
-                <Box id="updated-at">{formatDatetime(rule.lastModified)}</Box>
-              </Flex>
-            </Flex>
+
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="deduplication-period">
+                  Deduplication Period
+                </Box>
+                <Box gridColumn="3/8" id="deduplication-period">
+                  {minutesToString(rule.dedupPeriodMinutes)}
+                </Box>
+
+                <Box gridColumn="1/3" color="navyblue-100" aria-describedby="threshold">
+                  Threshold
+                </Box>
+                <Box gridColumn="3/8" id="threshold">
+                  {formatNumber(rule.threshold)}
+                </Box>
+              </SimpleGrid>
+            </Box>
+            <Box>
+              <SimpleGrid gap={2} columns={8} spacing={2}>
+                <Box color="navyblue-100" gridColumn="1/3" aria-describedby="created-at">
+                  Created
+                </Box>
+                <Box gridColumn="3/8" id="created-at">
+                  {formatDatetime(rule.createdAt)}
+                </Box>
+
+                <Box color="navyblue-100" gridColumn="1/3" aria-describedby="updated-at">
+                  Modified
+                </Box>
+                <Box gridColumn="3/8" id="updated-at">
+                  {formatDatetime(rule.lastModified)}
+                </Box>
+              </SimpleGrid>
+            </Box>
           </SimpleGrid>
         </Card>
       </Card>


### PR DESCRIPTION
## Description

This one fixes some alignment issues regarding the threshold values. Tags may get quite lengthy breaking the lines between the columns, thus a grid is required in order to create a more structured way for displaying the rule details.

### Screenshots:

#### Before:
![Screenshot 2020-09-14 at 1 43 44 PM](https://user-images.githubusercontent.com/1022166/93079758-49fb7e00-f695-11ea-8e05-9bb068d440de.png)

#### After:
![Screenshot 2020-09-15 at 12 27 04 PM](https://user-images.githubusercontent.com/1022166/93192872-d027cb00-f74e-11ea-9e5a-5a72e30dcc3e.png)

### Checklist:

- [x] Make sure you give an high-level overview of the problem & the solution
- [x] Make sure the related issue is referenced
- [x] Make sure screenshots are added if the UI is changed in any way
