### PR TITLE
refactor: changed colors for alert statuses

### DIFF
--- a/web/src/components/badges/AlertStatusBadge/AlertStatusBadge.tsx
+++ b/web/src/components/badges/AlertStatusBadge/AlertStatusBadge.tsx
@@ -23,10 +23,10 @@ import { AlertStatusesEnum } from 'Generated/schema';
 const STATUS_COLOR_MAP: {
   [key in StatusBadgeProps['status']]: BadgeProps['color'];
 } = {
-  [AlertStatusesEnum.Open]: 'red-300' as const,
-  [AlertStatusesEnum.Triaged]: 'yellow-500' as const,
-  [AlertStatusesEnum.Closed]: 'navyblue-200' as const,
-  [AlertStatusesEnum.Resolved]: 'navyblue-300' as const,
+  [AlertStatusesEnum.Open]: 'magenta-400' as const,
+  [AlertStatusesEnum.Triaged]: 'purple-500' as const,
+  [AlertStatusesEnum.Closed]: 'navyblue-300' as const,
+  [AlertStatusesEnum.Resolved]: 'indigo-700' as const,
 };
 
 interface StatusBadgeProps {


### PR DESCRIPTION
## Background

Closes #1535 

## Changes

- Changed color attributes of the `AlertStatusBadge`

## Testing

- visually

<img width="185" alt="Screen Shot 2020-09-14 at 11 32 08 AM" src="https://user-images.githubusercontent.com/3663107/93113030-490b2200-f67e-11ea-974a-f62aefc3054b.png">