### PR TITLE
fix: JSON tree overflow

### DIFF
--- a/web/src/components/JsonViewer/JsonViewer.tsx
+++ b/web/src/components/JsonViewer/JsonViewer.tsx
@@ -37,6 +37,7 @@ const JsonViewer: React.FC<JsonViewerProps> = ({ data, collapsed }) => {
       fontFamily: 'inherit',
       fontSize: remToPx(theme.fontSizes.medium),
       background: 'transparent',
+      wordBreak: 'break-all',
     }),
     [theme]
   );

--- a/web/src/components/JsonViewer/JsonViewer.tsx
+++ b/web/src/components/JsonViewer/JsonViewer.tsx
@@ -37,7 +37,7 @@ const JsonViewer: React.FC<JsonViewerProps> = ({ data, collapsed }) => {
       fontFamily: 'inherit',
       fontSize: remToPx(theme.fontSizes.medium),
       background: 'transparent',
-      wordBreak: 'break-all',
+      wordBreak: 'break-all' as const,
     }),
     [theme]
   );


### PR DESCRIPTION
## Background

When there's a lot of text in a JSON blob, then the text can overflow outside the container.  This PR makes sure that the text is always restricted within the limits of its bounding box.

For more info, check out the reported issue #1542 

Closes #1542 

## Changes

- Add `wordBreak` on `JsonEditor`

## Testing

- Visually
