### PR TITLE
Sync release bugfix: sns/sqs clients

### DIFF
--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	jsoniter "github.com/json-iterator/go"
@@ -36,7 +37,7 @@ import (
 
 func TestSendSns(t *testing.T) {
 	client := &testutils.SnsMock{}
-	outputClient := &OutputClient{snsClients: map[string]snsiface.SNSAPI{"us-west-2": client}}
+	outputClient := &OutputClient{}
 
 	snsOutputConfig := &outputModels.SnsConfig{
 		TopicArn: "arn:aws:sns:us-west-2:123456789012:test-sns-output",
@@ -81,6 +82,10 @@ func TestSendSns(t *testing.T) {
 	}
 
 	client.On("Publish", expectedSnsPublishInput).Return(&sns.PublishOutput{MessageId: aws.String("messageId")}, nil)
+	getSnsClient = func(*session.Session, string) (snsiface.SNSAPI, error) {
+		return client, nil
+	}
+
 	result := outputClient.Sns(alert, snsOutputConfig)
 	assert.NotNil(t, result)
 	assert.Equal(t, &AlertDeliveryResponse{

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	jsoniter "github.com/json-iterator/go"
@@ -35,7 +36,7 @@ import (
 
 func TestSendSqs(t *testing.T) {
 	client := &testutils.SqsMock{}
-	outputClient := &OutputClient{sqsClients: map[string]sqsiface.SQSAPI{"us-west-2": client}}
+	outputClient := &OutputClient{}
 
 	sqsOutputConfig := &outputModels.SqsConfig{
 		QueueURL: "https://sqs.us-west-2.amazonaws.com/123456789012/test-output",
@@ -66,6 +67,10 @@ func TestSendSqs(t *testing.T) {
 	}
 
 	client.On("SendMessage", expectedSqsSendMessageInput).Return(&sqs.SendMessageOutput{MessageId: aws.String("messageId")}, nil)
+	getSqsClient = func(*session.Session, string) sqsiface.SQSAPI {
+		return client
+	}
+
 	result := outputClient.Sqs(alert, sqsOutputConfig)
 	assert.NotNil(t, result)
 	assert.Equal(t, &AlertDeliveryResponse{


### PR DESCRIPTION
## Background

Syncs #1530 release bugfix to master. All other release bugfixes are already included. This will no longer be necessary after #1546 

This will need to be a standard merge (not a squash)