### PR TITLE
mage master:publish: double-prompt to allow overwriting existing release

### DIFF
--- a/tools/mage/master/publish.go
+++ b/tools/mage/master/publish.go
@@ -20,6 +20,7 @@ package master
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -27,11 +28,11 @@ import (
 
 	"github.com/panther-labs/panther/pkg/awsutils"
 	"github.com/panther-labs/panther/pkg/prompt"
-	"github.com/panther-labs/panther/tools/mage/clean"
 	"github.com/panther-labs/panther/tools/mage/clients"
 	"github.com/panther-labs/panther/tools/mage/deploy"
 	"github.com/panther-labs/panther/tools/mage/logger"
 	"github.com/panther-labs/panther/tools/mage/setup"
+	"github.com/panther-labs/panther/tools/mage/srcfmt"
 	"github.com/panther-labs/panther/tools/mage/util"
 )
 
@@ -47,20 +48,23 @@ func Publish() error {
 		return err
 	}
 
-	log.Infof("Publishing panther-community v%s to %s", version, strings.Join(publishRegions, ","))
-	result := prompt.Read("Are you sure you want to continue? (yes|no) ", prompt.NonemptyValidator)
-	if strings.ToLower(result) != "yes" {
-		return fmt.Errorf("publish aborted")
+	if err = getPublicationApproval(log, version); err != nil {
+		return err
 	}
 
-	// To be safe, always clean and reset the repo before building the assets
-	if err := clean.Clean(); err != nil {
-		return err
+	// To be safe, always reset dependencies, clear build artifacts, and re-generate source files before publishing.
+	// Don't need to do a full 'mage clean', but we do want to remove the `out/` directory
+	log.Info("rm -r out/")
+	if err := os.RemoveAll("out"); err != nil {
+		return fmt.Errorf("failed to remove out/ : %v", err)
 	}
 	if err := setup.Setup(); err != nil {
 		return err
 	}
 	if err := Build(log); err != nil {
+		return err
+	}
+	if err := srcfmt.Fmt(); err != nil { // to avoid dirty repo state after `mage gen` in the previous step
 		return err
 	}
 
@@ -73,25 +77,45 @@ func Publish() error {
 	return nil
 }
 
+func getPublicationApproval(log *zap.SugaredLogger, version string) error {
+	log.Infof("Publishing panther-community v%s to %s", version, strings.Join(publishRegions, ","))
+	result := prompt.Read("Are you sure you want to continue? (yes|no) ", prompt.NonemptyValidator)
+	if strings.ToLower(result) != "yes" {
+		return fmt.Errorf("publish v%s aborted by user", version)
+	}
+
+	// Check if the version already exists in any region - it's easy to forget to update the version
+	// in the template file and we probably don't want to overwrite a previous version.
+	for _, region := range publishRegions {
+		// Override the region for the AWS session and clients.
+		clients.SetRegion(region)
+		bucket, s3Key, s3URL := s3MasterTemplate(version)
+
+		_, err := clients.S3().HeadObject(&s3.HeadObjectInput{Bucket: &bucket, Key: &s3Key})
+		if err == nil {
+			log.Warnf("%s already exists", s3URL)
+			result := prompt.Read("Are you sure you want to overwrite the published release in each region? (yes|no) ",
+				prompt.NonemptyValidator)
+			if strings.ToLower(result) != "yes" {
+				return fmt.Errorf("publish v%s aborted by user", version)
+			}
+			return nil // override approved - don't need to keep checking each region
+		}
+
+		if !awsutils.IsAnyError(err, "NotFound") {
+			// Some error other than 'not found'
+			return fmt.Errorf("failed to describe %s : %v", s3URL, err)
+		}
+	}
+
+	return nil
+}
+
 func publishToRegion(log *zap.SugaredLogger, version, region string) error {
 	log.Infof("publishing to %s", region)
 	// Override the region for the AWS session and clients.
 	clients.SetRegion(region)
-
-	bucket := util.PublicAssetsBucket()
-	s3Key := fmt.Sprintf("v%s/panther.yml", version)
-	s3URL := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", bucket, s3Key)
-
-	// Check if this version already exists - it's easy to forget to update the version
-	// in the template file and we don't want to overwrite a previous version.
-	_, err := clients.S3().HeadObject(&s3.HeadObjectInput{Bucket: &bucket, Key: &s3Key})
-	if err == nil {
-		return fmt.Errorf("%s already exists", s3URL)
-	}
-	if !awsutils.IsAnyError(err, "NotFound") {
-		// Some error other than 'not found'
-		return fmt.Errorf("failed to describe %s : %v", s3URL, err)
-	}
+	bucket, s3Key, s3URL := s3MasterTemplate(version)
 
 	// Publish S3 assets and ECR docker image
 	pkg, err := Package(log, region, bucket, version, fmt.Sprintf(publicImageRepository, region))
@@ -106,4 +130,12 @@ func publishToRegion(log *zap.SugaredLogger, version, region string) error {
 
 	log.Infof("successfully published %s", s3URL)
 	return nil
+}
+
+// Returns bucket name, s3 object key, and S3 URL for the master template in the current region.
+func s3MasterTemplate(version string) (string, string, string) {
+	bucket := util.PublicAssetsBucket()
+	s3Key := fmt.Sprintf("v%s/panther.yml", version)
+	s3URL := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", bucket, s3Key)
+	return bucket, s3Key, s3URL
 }


### PR DESCRIPTION
## Background

We use `mage master:publish` to package the release and publish to our public S3 buckets. I'm generally the only one who has used the command so far, but the v1.8 release cycle revealed some problems that I can quickly fix

## Changes

- Don't do a full `mage clean` before every publish, because it takes quite a long time to reinstall all the `npm` packages from scratch. All we really care about is removing the build artifacts (`out/`). We still update dependencies (`mage setup`), we just don't need to erase them ahead of time - `setup` will automatically update any that are out of date.
- Allow overwriting an existing release with a warning and an additional prompt. Sometimes, there is a tiny bug that can be fixed by just republishing the existing version number (especially for release candidates / beta versions). Prompting the dev is better than asking developers to comment out the `mage` check in the source (which I believe @s0l0ist had to do before)
- Format source files after generating them, to avoid dirty repo state

## Testing

- `mage test:go`
- Trying to publish `v1.8.0-beta` when it already exists:

```
14:01:40	INFO	[master:publish]	Publishing panther-community v1.8.0-beta to us-east-1,us-east-2,us-west-2
Are you sure you want to continue? (yes|no) yes
14:01:43	WARN	[master:publish]	https://panther-community-us-east-1.s3.amazonaws.com/v1.8.0-beta/panther.yml already exists
Are you sure you want to overwrite the published release in each region? (yes|no)
```
