### PR TITLE
Updated logged error to include more information

### DIFF
--- a/internal/compliance/alert_processor/models/api.go
+++ b/internal/compliance/alert_processor/models/api.go
@@ -29,17 +29,17 @@ type ComplianceNotification struct {
 	OutputIds []string `json:"outputIds"`
 
 	// PolicyID is the id of the policy that triggered
-	PolicyID *string `json:"policyId" validate:"required,min=1"`
+	PolicyID string `json:"policyId" validate:"required,min=1"`
 
 	// PolicyVersionID is the version of policy when the alert triggered
-	PolicyVersionID *string `json:"policyVersionId"`
+	PolicyVersionID string `json:"policyVersionId"`
 
 	// ResourceID is the ID specific to the resource
-	ResourceID *string `json:"resourceId" validate:"required,min=1"`
+	ResourceID string `json:"resourceId" validate:"required,min=1"`
 
 	// ShouldAlert indicates whether this notification should cause an alert to be send to the customer
-	ShouldAlert *bool `json:"shouldAlert"`
+	ShouldAlert bool `json:"shouldAlert"`
 
 	// Timestamp indicates when the policy was actually evaluated
-	Timestamp *time.Time `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 }

--- a/internal/compliance/alert_processor/processor/processor.go
+++ b/internal/compliance/alert_processor/processor/processor.go
@@ -82,14 +82,14 @@ var (
 // If the resource is not compliant, it will trigger an auto-remediation action
 // and an alert - if alerting is not suppressed
 func Handle(event *models.ComplianceNotification) error {
-	zap.L().Debug("received new event", zap.String("resourceId", *event.ResourceID))
+	zap.L().Debug("received new event", zap.String("resourceId", event.ResourceID))
 
 	triggerActions, err := shouldTriggerActions(event)
 	if err != nil {
 		return err
 	}
 	if !triggerActions {
-		zap.L().Debug("no action needed for resources", zap.String("resourceId", *event.ResourceID))
+		zap.L().Debug("no action needed for resources", zap.String("resourceId", event.ResourceID))
 		return nil
 	}
 
@@ -104,39 +104,40 @@ func Handle(event *models.ComplianceNotification) error {
 		}
 	}
 
-	zap.L().Debug("finished processing event", zap.String("resourceId", *event.ResourceID))
+	zap.L().Debug("finished processing event", zap.String("resourceId", event.ResourceID))
 	return nil
 }
 
 // We should trigger actions on resource if the resource is failing for a policy
 func shouldTriggerActions(event *models.ComplianceNotification) (bool, error) {
 	zap.L().Debug("getting resource status",
-		zap.String("policyId", *event.PolicyID),
-		zap.String("resourceId", *event.ResourceID))
+		zap.String("policyId", event.PolicyID),
+		zap.String("resourceId", event.ResourceID))
 	response, err := complianceClient.Operations.GetStatus(
 		&complianceoperations.GetStatusParams{
-			PolicyID:   *event.PolicyID,
-			ResourceID: *event.ResourceID,
+			PolicyID:   event.PolicyID,
+			ResourceID: event.ResourceID,
 			HTTPClient: httpClient,
 		})
 	if err != nil {
 		if _, ok := err.(*complianceoperations.GetStatusNotFound); ok {
 			return false, nil
 		}
-		return false, err
+		return false, errors.Wrapf(err, "failed to get compliance status for policyID %s and resource %s",
+			event.PolicyID, event.ResourceID)
 	}
 
 	zap.L().Debug("got resource status",
-		zap.String("policyId", *event.PolicyID),
-		zap.String("resourceId", *event.ResourceID),
+		zap.String("policyId", event.PolicyID),
+		zap.String("resourceId", event.ResourceID),
 		zap.String("status", string(response.Payload.Status)))
 
 	return response.Payload.Status == compliancemodels.StatusFAIL, nil
 }
 
 func triggerAlert(event *models.ComplianceNotification) (canRemediate bool, err error) {
-	if !aws.BoolValue(event.ShouldAlert) {
-		zap.L().Debug("skipping alert notification", zap.String("policyId", *event.PolicyID))
+	if !event.ShouldAlert {
+		zap.L().Debug("skipping alert notification", zap.String("policyId", event.PolicyID))
 		return false, nil
 	}
 	timeNow := time.Now().Unix()
@@ -145,12 +146,12 @@ func triggerAlert(event *models.ComplianceNotification) (canRemediate bool, err 
 	var alertConfig *alertmodel.Alert
 	alertConfig, canRemediate, err = getAlertConfigPolicy(event)
 	if err != nil {
-		return false, errors.Wrapf(err, "encountered issue when getting policy: %s", *event.PolicyID)
+		return false, errors.Wrapf(err, "encountered issue when getting policy: %s", event.PolicyID)
 	}
 
 	marshalledAlertConfig, err := jsoniter.Marshal(alertConfig)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to marshal alerting config for policy %s", *event.PolicyID)
+		return false, errors.Wrapf(err, "failed to marshal alerting config for policy %s", event.PolicyID)
 	}
 
 	updateExpression := expression.
@@ -168,13 +169,13 @@ func triggerAlert(event *models.ComplianceNotification) (canRemediate bool, err 
 		WithCondition(conditionExpression).
 		Build()
 	if err != nil {
-		return false, errors.Wrapf(err, "could not build ddb expression for policy: %s", *event.PolicyID)
+		return false, errors.Wrapf(err, "could not build ddb expression for policy: %s", event.PolicyID)
 	}
 
 	input := &dynamodb.UpdateItemInput{
 		TableName: aws.String(ddbTable),
 		Key: map[string]*dynamodb.AttributeValue{
-			"policyId": {S: event.PolicyID},
+			"policyId": {S: &event.PolicyID},
 		},
 		UpdateExpression:          combinedExpression.Update(),
 		ConditionExpression:       combinedExpression.Condition(),
@@ -182,7 +183,7 @@ func triggerAlert(event *models.ComplianceNotification) (canRemediate bool, err 
 		ExpressionAttributeValues: combinedExpression.Values(),
 	}
 
-	zap.L().Debug("updating recent alerts table", zap.String("policyId", *event.PolicyID))
+	zap.L().Debug("updating recent alerts table", zap.String("policyId", event.PolicyID))
 	_, err = ddbClient.UpdateItem(input)
 	if err != nil {
 		aerr, ok := err.(awserr.Error)
@@ -190,29 +191,29 @@ func triggerAlert(event *models.ComplianceNotification) (canRemediate bool, err 
 			zap.L().Debug("update on ddb failed on condition, we will not trigger an alert")
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "experienced issue while updating ddb table for policy: %s", *event.PolicyID)
+		return false, errors.Wrapf(err, "experienced issue while updating ddb table for policy: %s", event.PolicyID)
 	}
 	return canRemediate, nil
 }
 
 func triggerRemediation(event *models.ComplianceNotification) error {
 	zap.L().Debug("Triggering auto-remediation",
-		zap.String("policyId", *event.PolicyID),
-		zap.String("resourceId", *event.ResourceID),
+		zap.String("policyId", event.PolicyID),
+		zap.String("resourceId", event.ResourceID),
 	)
 
 	_, err := remediationClient.Operations.RemediateResourceAsync(
 		&remediationoperations.RemediateResourceAsyncParams{
 			Body: &remediationmodels.RemediateResource{
-				PolicyID:   remediationmodels.PolicyID(*event.PolicyID),
-				ResourceID: remediationmodels.ResourceID(*event.ResourceID),
+				PolicyID:   remediationmodels.PolicyID(event.PolicyID),
+				ResourceID: remediationmodels.ResourceID(event.ResourceID),
 			},
 			HTTPClient: httpClient,
 		})
 
 	if err != nil {
 		return errors.Wrapf(err, "failed to trigger remediation on policy %s for resource %s",
-			*event.PolicyID, *event.ResourceID)
+			event.PolicyID, event.ResourceID)
 	}
 
 	zap.L().Debug("successfully triggered auto-remediation action")
@@ -221,7 +222,7 @@ func triggerRemediation(event *models.ComplianceNotification) error {
 
 func getAlertConfigPolicy(event *models.ComplianceNotification) (*alertmodel.Alert, bool, error) {
 	policy, err := policyClient.Operations.GetPolicy(&analysisoperations.GetPolicyParams{
-		PolicyID:   *event.PolicyID,
+		PolicyID:   event.PolicyID,
 		HTTPClient: httpClient,
 	})
 
@@ -231,15 +232,15 @@ func getAlertConfigPolicy(event *models.ComplianceNotification) (*alertmodel.Ale
 
 	return &alertmodel.Alert{
 			AnalysisDescription: aws.String(string(policy.Payload.Description)),
-			AnalysisID:          *event.PolicyID,
+			AnalysisID:          event.PolicyID,
 			AnalysisName:        aws.String(string(policy.Payload.DisplayName)),
-			CreatedAt:           *event.Timestamp,
+			CreatedAt:           event.Timestamp,
 			OutputIds:           event.OutputIds,
 			Runbook:             aws.String(string(policy.Payload.Runbook)),
 			Severity:            string(policy.Payload.Severity),
 			Tags:                policy.Payload.Tags,
 			Type:                alertmodel.PolicyType,
-			Version:             event.PolicyVersionID,
+			Version:             &event.PolicyVersionID,
 		},
 		policy.Payload.AutoRemediationID != "", // means we can remediate
 		nil

--- a/internal/compliance/alert_processor/processor/processor.go
+++ b/internal/compliance/alert_processor/processor/processor.go
@@ -227,7 +227,7 @@ func getAlertConfigPolicy(event *models.ComplianceNotification) (*alertmodel.Ale
 	})
 
 	if err != nil {
-		return nil, false, err
+		return nil, false, errors.Wrapf(err, "encountered issue when getting policy: %s", event.PolicyID)
 	}
 
 	return &alertmodel.Alert{

--- a/internal/compliance/alert_processor/processor/processor_test.go
+++ b/internal/compliance/alert_processor/processor/processor_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
@@ -55,11 +54,11 @@ func TestHandleEventWithAlert(t *testing.T) {
 	httpClient = &http.Client{Transport: mockRoundTripper}
 
 	input := &models.ComplianceNotification{
-		ResourceID:      aws.String("test-resource"),
-		PolicyID:        aws.String("test-policy"),
-		PolicyVersionID: aws.String("test-version"),
-		ShouldAlert:     aws.Bool(true),
-		Timestamp:       aws.Time(time.Now()),
+		ResourceID:      "test-resource",
+		PolicyID:        "test-policy",
+		PolicyVersionID: "test-version",
+		ShouldAlert:     true,
+		Timestamp:       time.Now(),
 	}
 
 	complianceResponse := &compliancemodels.ComplianceStatus{
@@ -101,11 +100,11 @@ func TestHandleEventWithAlertButNoAutoRemediationID(t *testing.T) {
 	httpClient = &http.Client{Transport: mockRoundTripper}
 
 	input := &models.ComplianceNotification{
-		ResourceID:      aws.String("test-resource"),
-		PolicyID:        aws.String("test-policy"),
-		PolicyVersionID: aws.String("test-version"),
-		ShouldAlert:     aws.Bool(true),
-		Timestamp:       aws.Time(time.Now()),
+		ResourceID:      "test-resource",
+		PolicyID:        "test-policy",
+		PolicyVersionID: "test-version",
+		ShouldAlert:     true,
+		Timestamp:       time.Now(),
 	}
 
 	complianceResponse := &compliancemodels.ComplianceStatus{
@@ -145,10 +144,10 @@ func TestHandleEventWithoutAlert(t *testing.T) {
 	httpClient = &http.Client{Transport: mockRoundTripper}
 
 	input := &models.ComplianceNotification{
-		ResourceID:      aws.String("test-resource"),
-		PolicyID:        aws.String("test-policy"),
-		PolicyVersionID: aws.String("test-version"),
-		ShouldAlert:     aws.Bool(false),
+		ResourceID:      "test-resource",
+		PolicyID:        "test-policy",
+		PolicyVersionID: "test-version",
+		ShouldAlert:     false,
 	}
 
 	complianceResponse := &compliancemodels.ComplianceStatus{
@@ -181,10 +180,10 @@ func TestSkipActionsIfResourceIsNotFailing(t *testing.T) {
 	httpClient = &http.Client{Transport: mockRoundTripper}
 
 	input := &models.ComplianceNotification{
-		ResourceID:      aws.String("test-resource"),
-		PolicyID:        aws.String("test-policy"),
-		PolicyVersionID: aws.String("test-version"),
-		ShouldAlert:     aws.Bool(true),
+		ResourceID:      "test-resource",
+		PolicyID:        "test-policy",
+		PolicyVersionID: "test-version",
+		ShouldAlert:     true,
 	}
 
 	responseBody := &compliancemodels.ComplianceStatus{
@@ -211,9 +210,9 @@ func TestSkipActionsIfLookupFailed(t *testing.T) {
 	httpClient = &http.Client{Transport: mockRoundTripper}
 
 	input := &models.ComplianceNotification{
-		ResourceID:  aws.String("test-resource"),
-		PolicyID:    aws.String("test-policy"),
-		ShouldAlert: aws.Bool(true),
+		ResourceID:  "test-resource",
+		PolicyID:    "test-policy",
+		ShouldAlert: true,
 	}
 
 	mockRoundTripper.On("RoundTrip", mock.Anything).Return(generateResponse("", http.StatusInternalServerError), nil)

--- a/internal/compliance/resource_processor/processor/handler.go
+++ b/internal/compliance/resource_processor/processor/handler.go
@@ -241,13 +241,13 @@ func (r *batchResults) analyze(resources resourceMap, policies policyMap) error 
 			// Every failed policy, if not suppressed, will trigger the remediation flow
 			complianceNotification := &alertmodels.ComplianceNotification{
 				OutputIds:       policy.OutputIds,
-				ResourceID:      aws.String(string(resource.ID)),
-				PolicyID:        aws.String(string(policy.ID)),
-				PolicyVersionID: aws.String(string(policy.VersionID)),
-				Timestamp:       aws.Time(time.Now()),
+				ResourceID:      string(resource.ID),
+				PolicyID:        string(policy.ID),
+				PolicyVersionID: string(policy.VersionID),
+				Timestamp:       time.Now(),
 
 				// We only need to send an alert to the user if the status is newly FAILing
-				ShouldAlert: aws.Bool(status != compliancemodels.StatusFAIL),
+				ShouldAlert: status != compliancemodels.StatusFAIL,
 			}
 			var sqsMessageBody string
 			if sqsMessageBody, err = jsoniter.MarshalToString(complianceNotification); err != nil {

--- a/tools/mage/test/cfn.go
+++ b/tools/mage/test/cfn.go
@@ -75,7 +75,14 @@ func testCfnLint() error {
 	//
 	// But if we keep them integers, yaml marshaling converts large integers to scientific notation,
 	// which CFN does not understand. So we force string values to serialize them correctly.
-	args := []string{"-x", "E3012:strict=false", "--"}
+	args := []string{
+		"-x", "E3012:strict=false",
+		// cfn-lint complains: E3002 Invalid Property Resources/WebApplicationServer/Properties/NetworkConfiguration/AwsvpcConfiguration
+		//deployments/web_server.yml:208:9 .
+		// nolint:lll
+		// However this property is valid: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-networkconfiguration.html#cfn-ecs-service-networkconfiguration-awsvpcconfiguration
+		"-i", "E3002",
+		"--"}
 	args = append(args, templates...)
 	if err := sh.RunV(util.PipPath("cfn-lint"), args...); err != nil {
 		return err


### PR DESCRIPTION
## Background

* While investigating an error I realized some of the error messages were missing some information. Updated error messages in alert-processor to give more context about the operation that failed (policyID & resourceID)

* I modified the `ComplianceNotification` to include scalars instead of pointers. All the fields are getting anyway populated, new code is much simpler since we don't need to dereference pointers. 

* cfn-lint started failing with 
```
E3002 Invalid Property Resources/WebApplicationServer/Properties/NetworkConfiguration/AwsvpcConfiguration
deployments/web_server.yml:208:9
```
However, the property is valid: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-networkconfiguration.html#cfn-ecs-service-networkconfiguration-awsvpcconfiguration . I removed the check, we can re-add it when the cfn-lint fixes its bug. 

## Testing

- mage test:ci
