### PR TITLE
Update the latency threshold for compliance-api

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -387,6 +387,9 @@ Resources:
       AlarmTopicArn: !Ref AlarmTopicArn
       CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
+      # The `describe-org` operation has to scan through the DDB resources table to generate
+      # some statistics about an organization and is a high-latency operation
+      LatencyThresholdMs: 3000
 
   RemediationApi:
     Type: AWS::Serverless::Api

--- a/internal/core/custom_resources/resources/alarms_api_gateway.go
+++ b/internal/core/custom_resources/resources/alarms_api_gateway.go
@@ -73,7 +73,7 @@ func putGatewayAlarmGroup(props APIGatewayAlarmProperties) error {
 		Dimensions: []*cloudwatch.Dimension{
 			{Name: aws.String("ApiName"), Value: &props.APIName},
 		},
-		EvaluationPeriods: aws.Int64(5),
+		EvaluationPeriods: aws.Int64(3),
 		MetricName:        aws.String("IntegrationLatency"),
 		Namespace:         aws.String("AWS/ApiGateway"),
 		Period:            aws.Int64(60),


### PR DESCRIPTION
## Background

The `describe-org` operation of compliance-api needs to scan the DDB resources table in order to generate some statistics. 
This operation can take longer in deployments that include a lot of monitored resources. This is an architectural deficiency of the current design. This operation invoked whenever a user accesses the Panther dashboard in order to generate some statistics.  

Increasing the latency threshold for compliance-api

## Changes

- Increasing the latency threshold for compliance-api

## Testing

- mage test:ci
