### PR TITLE
ci: force clone entire repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Git Credentials
         run: |
@@ -90,9 +92,7 @@ jobs:
 
       - name: Bootstrap a PR branch
         run: |
-          git fetch origin release --depth=5
-          git checkout release
-          git checkout -b $HEAD
+          git checkout -b $HEAD origin/release
           git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} || true
           CONFLICTS=$(git diff --name-only --diff-filter=U)
           git add -A .


### PR DESCRIPTION
## Background

Github actions behaves weirdly  when switching & checking-out branches using custom `run` commands. This PR fixes this and makes sure that `git checkout` works correctly in a job's steps

## Changes

- Add `fetch-depth: 0`
- Shorten new-branch-spawning commands

## Testing

- In Fork
