### PR TITLE
ci: Fix target branch of release syncs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,7 @@ jobs:
         env:
           ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
         with:
-          repo: ${{ env.GITHUB_REPOSITORY }}
+          repo: ${{ github.repository }}
           head: ${{ env.HEAD }}
+          base: release
           token: ${{ secrets.PR_SYNC_TOKEN }}


### PR DESCRIPTION
## Background

The release sync automation targets the `master` branch. This PR fixes it to target the `release`

## Changes

- Use github event item instead of ENV var
- Change PR sync's base branch

## Testing

- In fork
