### PR TITLE
Least privilege for satellite account IAM roles

### DIFF
--- a/deployments/auxiliary/README.md
+++ b/deployments/auxiliary/README.md
@@ -13,3 +13,55 @@ For example, [panther-cloudsec-iam](cloudformation/panther-cloudsec-iam.yml) cre
 which Panther Cloud Security can assume to scan your AWS account.
 
 Each template is provided in [CloudFormation](cloudformation) and [Terraform](terraform) formats for your convenience.
+
+# Least Privilege Trust Principals
+
+The default trust principals for various IAM roles and one SNS topic policy sid are the entire _master_ account. These can be further restricted as follows:
+
+"Cloud Security" template:
+--- for AWS configuration scanning and remediation
+
+"panther_audit" role trust principal:
+- arn:aws:iam::${var.master_account_id}:role/panther-app-SnapshotInfra-1111-PollerFunctionRole-11111111111
+
+"panther_cloud_formation_stackset_execution" role trust principal:
+-- arn:aws:iam::${var.master_account_id}:role/PantherCloudFormationStackSetAdminRole-${var.aws_region}
+
+-- Note: no Panther component ever assumes the PantherCloudFormationStackSetExecutionRole. The StackSet Execution role allows admins to manually to deploy StackSets that create "real time notifications" from the master account using the AWS CloudFormation service. If you plan to use this role, the PantherCloudFormationStackSetAdminRole (see separate template) has to be created in the master account. If you plan to apply the "Cloudwatch Events" and "Log Processing Notifications" templates (below) to satellite accounts, you will not need the StackSetExecution role or the StackSetAdmin role.
+
+"panther_remediation" role trust principals:
+- arn:aws:iam::${var.master_account_id}:role/panther-CloudSecurity-111111-RemediationFunctionRole-111111111
+- arn:aws:iam::${var.master_account_id}:role/panther-Core-11111-SourceApiFunctionRole-111111111
+
+
+
+"Cloudwatch Events" template:
+--- for "real time notifications" of changes in AWS configuration; you will not need the contents of this template if you are using the StackSetExecution/Admin roles (above) to create the Panther components for real time notifications
+
+"panther_events" SNS topic policy "CrossAccountSubscription" sid trust principal:
+- arn:aws:iam::${var.master_account_id}:role/panther-cloud-security-EventProcessorFunctionRole-1111111111
+
+
+
+"Log Analysis" template:
+-- for log analysis
+
+"log_processing" role trust principals:
+- arn:aws:iam::${var.master_account_id}:role/panther-Core-11111-SourceApiFunctionRole-1111
+- arn:aws:iam::${var.master_account_id}:role/panther-LogAnalysis-11111-LogProcessorFunctionRole-111111111
+
+
+
+"Log Processing Notifications" template:
+--- analog to Cloudwatch event notifications for cloud security real time notifications
+
+"policy" SNS topic policy "AllowSubscriptionToPanther" sid trust principal:
+- arn:aws:iam::${var.master_account_id}:role/panther-LogAnalysis-11111-LogProcessorFunctionRole-111111111 (same as for Log Analysis)
+
+
+
+"Deployment" template:
+--- for programmatically deploying Panther
+
+"deployment" role trust principal:
+-- trust principal won't be a Panther component; it will be whatever external automation principal is deploying Panther


### PR DESCRIPTION
## Background

IAM role principals default to the entire master account.

## Changes

- Updated trust principals for IAM roles and one SNS topic policy sid

## Testing

- N/A
