### PR TITLE
Add meta data options

### DIFF
--- a/internal/compliance/snapshot_poller/models/aws/ec2_instance.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_instance.go
@@ -51,6 +51,7 @@ type Ec2Instance struct {
 	KernelId                                *string
 	KeyName                                 *string
 	Licenses                                []*ec2.LicenseConfiguration
+	MetaDataOptions                         *ec2.InstanceMetadataOptionsResponse
 	Monitoring                              *ec2.Monitoring
 	NetworkInterfaces                       []*ec2.InstanceNetworkInterface
 	Placement                               *ec2.Placement

--- a/internal/compliance/snapshot_poller/models/aws/ec2_instance.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_instance.go
@@ -51,7 +51,7 @@ type Ec2Instance struct {
 	KernelId                                *string
 	KeyName                                 *string
 	Licenses                                []*ec2.LicenseConfiguration
-	MetaDataOptions                         *ec2.InstanceMetadataOptionsResponse
+	MetadataOptions                         *ec2.InstanceMetadataOptionsResponse
 	Monitoring                              *ec2.Monitoring
 	NetworkInterfaces                       []*ec2.InstanceNetworkInterface
 	Placement                               *ec2.Placement

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_instance.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_instance.go
@@ -153,6 +153,7 @@ func buildEc2InstanceSnapshot(instance *ec2.Instance) *awsmodels.Ec2Instance {
 		KernelId:                                instance.KernelId,
 		KeyName:                                 instance.KeyName,
 		Licenses:                                instance.Licenses,
+		MetaDataOptions:                         instance.MetadataOptions,
 		Monitoring:                              instance.Monitoring,
 		NetworkInterfaces:                       instance.NetworkInterfaces,
 		Placement:                               instance.Placement,

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_instance.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_instance.go
@@ -153,7 +153,7 @@ func buildEc2InstanceSnapshot(instance *ec2.Instance) *awsmodels.Ec2Instance {
 		KernelId:                                instance.KernelId,
 		KeyName:                                 instance.KeyName,
 		Licenses:                                instance.Licenses,
-		MetaDataOptions:                         instance.MetadataOptions,
+		MetadataOptions:                         instance.MetadataOptions,
 		Monitoring:                              instance.Monitoring,
 		NetworkInterfaces:                       instance.NetworkInterfaces,
 		Placement:                               instance.Placement,


### PR DESCRIPTION
## Background

Add the `EC2MetaDataOptions` field to the CloudSecurity EC2 Instance resource. Closes https://github.com/panther-labs/panther-analysis/issues/112. 

## Changes

- Add new field to resource model

## Testing

- Dev deployment
