### PR TITLE
Fix edge case in role assumption

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/assume_role.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/assume_role.go
@@ -26,8 +26,6 @@ import (
 )
 
 // AssumeRoleMock generates a set of fake credentials for testing.
-func AssumeRoleMock(pollerInput *awsmodels.ResourcePollerInput, sess *session.Session,
-	region string) *credentials.Credentials {
-
+func AssumeRoleMock(_ *awsmodels.ResourcePollerInput, _ *session.Session) *credentials.Credentials {
 	return &credentials.Credentials{}
 }

--- a/internal/compliance/snapshot_poller/pollers/aws/poll_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll_test.go
@@ -26,5 +26,5 @@ import (
 
 // Unit tests
 func TestAssumeRoleMissingParams(t *testing.T) {
-	assert.Panics(t, func() { _ = assumeRole(nil, nil, "") })
+	assert.Panics(t, func() { _ = assumeRole(nil, nil) })
 }

--- a/internal/compliance/snapshot_poller/pollers/aws/utils_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/utils_test.go
@@ -19,7 +19,6 @@ package aws
  */
 
 import (
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/panther-labs/panther/internal/compliance/snapshot_poller/pollers/aws/awstest"
@@ -31,7 +30,7 @@ func init() {
 
 	// mocks the assume role
 	assumeRoleFunc = awstest.AssumeRoleMock
-	verifyAssumedCredsFunc = func(creds *credentials.Credentials, region string) error {
+	verifyAssumedCredsFunc = func(creds *session.Session, region string) error {
 		return nil
 	}
 }


### PR DESCRIPTION
## Background

When assuming a role in another account in the snapshot-poller, we always used the ENV credentials of the lambda function to create a session in the Panther account and used that session to assume the role. This works fine, except for when you want to use the credentials created by the assumed role to query regional endpoints in regions that are not enabled in the Panther account but are enabled in the account the role to be assumed lives in.

I believe this affects the Log Analysis log-processor based on the source code, but I was repeatedly failing to subscribe an SNS topic in `ap-east-1` to the the panther SQS queue I had deployed in `us-east-1` in a different account to test this. I still have not figured it out, creating the subscription with CloudFormation failed. Creating it from the SQS queue failed. Creating it from the SNS console failed. After lots of troubleshooting I gave up because I just can't figure out how to test whether it's an issue in the first place, but I suspect it is. For any Log Analysis gurus out there that want to check, you can test by deploying Panther into an account that does not have `ap-east-1` enabled and then onboarding an s3 bucket in `ap-east-1` from an account that does have `ap-east-1` enabled. I suspect it won't work.

The fix is to use the Panther session to create credentials in the target account (as before), but then use those credentials to create a new session to the target account and authenticate with that.

## Changes

- Change the snapshot-poller cross account role assumption code

## Testing

- Deployed it into my dev account and confirmed the before/after
- Updated existing unit tests
