### PR TITLE
Ensure master template is published with same version tag as repo

### DIFF
--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -154,7 +154,7 @@ Parameters:
 Mappings:
   Constants:
     Panther:
-      Version: 1.8.0-beta
+      Version: v1.9.0-RC1
 
 Conditions:
   RegistryProvided: !Not [!Equals [!Ref ImageRegistry, '']]
@@ -403,9 +403,7 @@ Resources:
               - !Sub 349240696275.dkr.ecr.${AWS::Region}.amazonaws.com/panther-community
             tag: !FindInMap [Constants, Panther, Version]
         InitialAnalysisPackUrls: !Join [',', !Ref InitialAnalysisPackUrls]
-        PantherVersion: !Sub
-          - v${version} # has to be prefixed with 'v' for docs link in web app to work
-          - version: !FindInMap [Constants, Panther, Version]
+        PantherVersion: !FindInMap [Constants, Panther, Version] # has to be prefixed with 'v' for docs link in web app to work
         SecurityGroup: !GetAtt Bootstrap.Outputs.WebSecurityGroup
         SubnetOneId: !GetAtt Bootstrap.Outputs.SubnetOneId
         SubnetTwoId: !GetAtt Bootstrap.Outputs.SubnetTwoId

--- a/tools/mage/master/publish.go
+++ b/tools/mage/master/publish.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/pkg/awsutils"
@@ -46,6 +47,13 @@ func Publish() error {
 	version, err := GetVersion()
 	if err != nil {
 		return err
+	}
+
+	// ensure the compiled version matches the declared version in master template
+	repoVersion := util.RepoVersion()
+	if version != repoVersion {
+		return errors.Errorf("master panther version %s does not match repo version %s",
+			version, repoVersion)
 	}
 
 	if err = getPublicationApproval(log, version); err != nil {

--- a/tools/mage/master/publish.go
+++ b/tools/mage/master/publish.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/pkg/awsutils"
@@ -49,10 +48,10 @@ func Publish() error {
 		return err
 	}
 
-	// ensure the compiled version matches the declared version in master template
+	// ensure the git tag in the repo matches the declared version in master template
 	repoVersion := util.RepoVersion()
 	if version != repoVersion {
-		return errors.Errorf("master panther version %s does not match repo version %s",
+		return fmt.Errorf("master panther version %s does not match repo version %s",
 			version, repoVersion)
 	}
 


### PR DESCRIPTION
## Background

The Panther version is applied manually the master.yml template before a release.

This PR validates that the applied version tag matches the repo git tag.

I did not test this, but it looks right and we can test with 1.9 release.