### PR TITLE
Updating Glue table update to run on CUSTOM_RESOURCE_VERSION upgrade

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -134,8 +134,9 @@ Resources:
     DependsOn: AthenaConfigure
     Type: Custom::UpdateGlueTables
     Properties:
-      # Here we use TablesSignature instead of CustomResourceVersion to trigger updates
+      # Update in case TablesSignature or CustomResourceVersion has changed
       TablesSignature: !Ref TablesSignature
+      CustomResourceVersion: !Ref CustomResourceVersion
       ProcessedDataBucket: !Ref ProcessedDataBucket
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -66,7 +66,7 @@ func (api API) PutIntegration(input *models.PutIntegrationInput) (newIntegration
 	// First creating table - this action is idempotent. In case we succeed here and
 	// fail at a later stage, in case of retry this will succeed again.
 	if err = createTables(newIntegration); err != nil {
-		err = errors.Wrap(err, "Failed to create Glue tables")
+		err = errors.Wrap(err, "failed to create Glue tables")
 		return nil, putIntegrationInternalError
 	}
 

--- a/internal/log_analysis/awsglue/table_metadata.go
+++ b/internal/log_analysis/awsglue/table_metadata.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/panther-labs/panther/api/lambda/core/log_analysis/log_processor/models"
+	"github.com/panther-labs/panther/pkg/awsutils"
 	"github.com/panther-labs/panther/pkg/box"
 )
 
@@ -241,8 +242,7 @@ func (gm *GlueTableMetadata) CreateOrUpdateTable(glueClient glueiface.GlueAPI, b
 	}
 	_, err := glueClient.CreateTable(createTableInput)
 	if err != nil {
-		var awsErr awserr.Error
-		if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeAlreadyExistsException {
+		if awsutils.IsAnyError(err, glue.ErrCodeAlreadyExistsException) {
 			// need to do an update
 			updateTableInput := &glue.UpdateTableInput{
 				DatabaseName: &gm.databaseName,


### PR DESCRIPTION
## Background

I realized there is no easy way to force the custom resource "Custom::UpdateGlueTables" to run on a deployment. 
Before it was only running if the signature of the deployed tables had changed or if the Panther version had changed. With this change, it also runs in case some user specifies a `CUSTOM_RESOURCE_VERSION` env variable (this is the model we follow for all other resources as well)


## Testing

- Deployed to my account and verified the script runs in case the `CUSTOM_RESOURCE_VERSION` variable is specified. 
