### PR TITLE
AnalyticsConsent for General settings

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -442,12 +442,14 @@ input UpdateGeneralSettingsInput {
   displayName: String
   email: String
   errorReportingConsent: Boolean
+  analyticsConsent: Boolean
 }
 
 type GeneralSettings {
   displayName: String
   email: String
   errorReportingConsent: Boolean
+  analyticsConsent: Boolean
 }
 
 input TestPolicyInput {

--- a/api/lambda/organization/models/api.go
+++ b/api/lambda/organization/models/api.go
@@ -37,4 +37,5 @@ type GeneralSettings struct {
 	DisplayName           *string `json:"displayName" validate:"omitempty,min=1,excludesall='<>&\""`
 	Email                 *string `genericapi:"redact" json:"email" validate:"omitempty,email"`
 	ErrorReportingConsent *bool   `json:"errorReportingConsent"`
+	AnalyticsConsent      *bool   `json:"analyticsConsent"`
 }

--- a/internal/core/custom_resources/resources/map.go
+++ b/internal/core/custom_resources/resources/map.go
@@ -155,6 +155,7 @@ var CustomResources = map[string]cfn.CustomResourceFunction{
 	//     DisplayName:           string
 	//     Email:                 string
 	//     ErrorReportingConsent: bool
+	//     AnalyticsConsent:      bool
 	// Outputs: None
 	// PhysicalId: custom:panther-settings:singleton
 	"Custom::PantherSettings": customPantherSettings,

--- a/internal/core/organization_api/main/integration_test.go
+++ b/internal/core/organization_api/main/integration_test.go
@@ -92,6 +92,7 @@ func updateSettings(t *testing.T) {
 		UpdateSettings: &models.UpdateSettingsInput{
 			DisplayName:           aws.String("panther-test"),
 			ErrorReportingConsent: aws.Bool(true),
+			AnalyticsConsent:      aws.Bool(true),
 		},
 	}
 	require.NoError(t, genericapi.Invoke(lambdaClient, orgAPI, &input, &output))
@@ -100,6 +101,7 @@ func updateSettings(t *testing.T) {
 		DisplayName:           aws.String("panther-test"),
 		Email:                 aws.String("test@example.com"),
 		ErrorReportingConsent: aws.Bool(true),
+		AnalyticsConsent:      aws.Bool(true),
 	}
 	assert.Equal(t, expected, output)
 }
@@ -113,6 +115,7 @@ func getSettings(t *testing.T) {
 		DisplayName:           aws.String("panther-test"),
 		Email:                 aws.String("test@example.com"),
 		ErrorReportingConsent: aws.Bool(true),
+		AnalyticsConsent:      aws.Bool(true),
 	}
 	assert.Equal(t, expected, output)
 }

--- a/internal/core/organization_api/table/update.go
+++ b/internal/core/organization_api/table/update.go
@@ -57,6 +57,9 @@ func buildGeneralSettingsExpression(settings *models.GeneralSettings) (expressio
 	if settings.ErrorReportingConsent != nil {
 		update = update.Set(expression.Name("errorReportingConsent"), expression.Value(*settings.ErrorReportingConsent))
 	}
+	if settings.AnalyticsConsent != nil {
+        update = update.Set(expression.Name("analyticsConsent"), expression.Value(*settings.AnalyticsConsent))
+    }
 
 	expr, err := expression.NewBuilder().WithUpdate(update).Build()
 	if err != nil {

--- a/internal/core/organization_api/table/update.go
+++ b/internal/core/organization_api/table/update.go
@@ -58,8 +58,8 @@ func buildGeneralSettingsExpression(settings *models.GeneralSettings) (expressio
 		update = update.Set(expression.Name("errorReportingConsent"), expression.Value(*settings.ErrorReportingConsent))
 	}
 	if settings.AnalyticsConsent != nil {
-        update = update.Set(expression.Name("analyticsConsent"), expression.Value(*settings.AnalyticsConsent))
-    }
+		update = update.Set(expression.Name("analyticsConsent"), expression.Value(*settings.AnalyticsConsent))
+	}
 
 	expr, err := expression.NewBuilder().WithUpdate(update).Build()
 	if err != nil {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -350,6 +350,7 @@ export type GeneralSettings = {
   displayName?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   errorReportingConsent?: Maybe<Scalars['Boolean']>;
+  analyticsConsent?: Maybe<Scalars['Boolean']>;
 };
 
 export type GetAlertInput = {
@@ -1242,6 +1243,7 @@ export type UpdateGeneralSettingsInput = {
   displayName?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   errorReportingConsent?: Maybe<Scalars['Boolean']>;
+  analyticsConsent?: Maybe<Scalars['Boolean']>;
 };
 
 export type UpdatePolicyInput = {
@@ -1961,6 +1963,7 @@ export type GeneralSettingsResolvers<
   displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   errorReportingConsent?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  analyticsConsent?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -566,6 +566,7 @@ export const buildGeneralSettings = (overrides: Partial<GeneralSettings> = {}): 
     email: 'email' in overrides ? overrides.email : 'tertiary',
     errorReportingConsent:
       'errorReportingConsent' in overrides ? overrides.errorReportingConsent : false,
+    analyticsConsent: 'analyticsConsent' in overrides ? overrides.analyticsConsent : true,
   };
 };
 
@@ -1468,6 +1469,7 @@ export const buildUpdateGeneralSettingsInput = (
     email: 'email' in overrides ? overrides.email : 'olive',
     errorReportingConsent:
       'errorReportingConsent' in overrides ? overrides.errorReportingConsent : true,
+    analyticsConsent: 'analyticsConsent' in overrides ? overrides.analyticsConsent : false,
   };
 };
 


### PR DESCRIPTION
## Background

Since we are implementing telemetry for the frontend, we need to allow users to opt-out from product analytics. We need to persist their selection in DB in an identical fashion as we do with errorReportingConsent.

We need to update the backend to handle this operation and store the `analyticsConsent` boolean

Closes #1598 
## Changes

- Added `AnalyticsConsent` Bool in API model
- Updated `organization-api` to handle update
- Updated schema

## Testing

- Deployed env API and UI test
