### PR TITLE
Switch to using "Alert Type" in the alert rather than "error Type"

### DIFF
--- a/api/lambda/alerts/models/api.go
+++ b/api/lambda/alerts/models/api.go
@@ -183,6 +183,7 @@ type ListAlertsOutput struct {
 // AlertSummary contains summary information for an alert
 type AlertSummary struct {
 	AlertID           *string             `json:"alertId" validate:"required"`
+	Type              string              `json:"type,omitempty"`
 	RuleID            *string             `json:"ruleId" validate:"required"`
 	RuleDisplayName   *string             `json:"ruleDisplayName,omitempty"`
 	RuleVersion       *string             `json:"ruleVersion" validate:"required"`
@@ -197,7 +198,6 @@ type AlertSummary struct {
 	Title             *string             `json:"title" validate:"required"`
 	LastUpdatedBy     string              `json:"lastUpdatedBy,omitempty"`
 	LastUpdatedByTime time.Time           `json:"lastUpdatedByTime,omitempty"`
-	ErrorType         string              `json:"errorType,omitempty"`
 }
 
 // Alert contains the details of an alert

--- a/api/lambda/delivery/models/api.go
+++ b/api/lambda/delivery/models/api.go
@@ -27,8 +27,11 @@ import (
 )
 
 const (
-	// RuleType identifies the Alert to be for a Policy
+	// RuleType identifies the Alert to be for a Rule
 	RuleType = "RULE"
+
+	// RuleErrorType identifies the Alert to be for a Rule error
+	RuleErrorType = "RULE_ERROR"
 
 	// PolicyType identifies the Alert to be for a Policy
 	PolicyType = "POLICY"
@@ -123,7 +126,7 @@ type Alert struct {
 	AnalysisID string `json:"analysisId" validate:"required"`
 
 	// Type specifies if an alert is for a policy or a rule
-	Type string `json:"type" validate:"oneof=RULE POLICY"`
+	Type string `json:"type" validate:"oneof=RULE POLICY RULE_ERROR"`
 
 	// CreatedAt is the creation timestamp (seconds since epoch).
 	CreatedAt time.Time `json:"createdAt" validate:"required"`
@@ -166,9 +169,4 @@ type Alert struct {
 
 	// IsResent is a flag set to indicate the alert is not new
 	IsResent bool `json:"isResent,omitempty"`
-
-	// ErrorType declares the type of the error. Currently only "RULE_ERROR" is supported
-	// If the alert is not because of an error in the system but because of a rule match,
-	// this field will be empty
-	ErrorType string `json:"errorType"`
 }

--- a/internal/core/alert_delivery/outputs/asana_test.go
+++ b/internal/core/alert_delivery/outputs/asana_test.go
@@ -37,6 +37,7 @@ func TestAsanaAlert(t *testing.T) {
 	require.NoError(t, err)
 	alert := &alertModels.Alert{
 		AnalysisID:          "ruleId",
+		Type:                alertModels.PolicyType,
 		CreatedAt:           createdAtTime,
 		OutputIds:           []string{"output-id"},
 		AnalysisDescription: aws.String("description"),

--- a/internal/core/alert_delivery/outputs/custom_webhook_test.go
+++ b/internal/core/alert_delivery/outputs/custom_webhook_test.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	alertModels "github.com/panther-labs/panther/api/lambda/delivery/models"
-	outputModels "github.com/panther-labs/panther/api/lambda/outputs/models"
+	alertmodels "github.com/panther-labs/panther/api/lambda/delivery/models"
+	outputmodels "github.com/panther-labs/panther/api/lambda/outputs/models"
 )
 
-var customWebhookConfig = &outputModels.CustomWebhookConfig{
+var customWebhookConfig = &outputmodels.CustomWebhookConfig{
 	WebhookURL: "custom-webhook-url",
 }
 
@@ -43,8 +43,9 @@ func TestCustomWebhookAlert(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	alert := &alertModels.Alert{
+	alert := &alertmodels.Alert{
 		AnalysisID: "policyId",
+		Type:       alertmodels.PolicyType,
 		CreatedAt:  createdAtTime,
 		Severity:   "INFO",
 	}

--- a/internal/core/alert_delivery/outputs/custom_webhook_test.go
+++ b/internal/core/alert_delivery/outputs/custom_webhook_test.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	alertmodels "github.com/panther-labs/panther/api/lambda/delivery/models"
-	outputmodels "github.com/panther-labs/panther/api/lambda/outputs/models"
+	alertModels "github.com/panther-labs/panther/api/lambda/delivery/models"
+	outputModels "github.com/panther-labs/panther/api/lambda/outputs/models"
 )
 
-var customWebhookConfig = &outputmodels.CustomWebhookConfig{
+var customWebhookConfig = &outputModels.CustomWebhookConfig{
 	WebhookURL: "custom-webhook-url",
 }
 
@@ -43,9 +43,9 @@ func TestCustomWebhookAlert(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	alert := &alertmodels.Alert{
+	alert := &alertModels.Alert{
 		AnalysisID: "policyId",
-		Type:       alertmodels.PolicyType,
+		Type:       alertModels.PolicyType,
 		CreatedAt:  createdAtTime,
 		Severity:   "INFO",
 	}

--- a/internal/core/alert_delivery/outputs/github_test.go
+++ b/internal/core/alert_delivery/outputs/github_test.go
@@ -37,18 +37,19 @@ func TestGithubAlert(t *testing.T) {
 
 	var createdAtTime, _ = time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	alert := &alertModels.Alert{
-		AnalysisID:          "ruleId",
+		AnalysisID:          "policyId",
+		Type:                alertModels.PolicyType,
 		CreatedAt:           createdAtTime,
 		OutputIds:           []string{"output-id"},
 		AnalysisDescription: aws.String("description"),
-		AnalysisName:        aws.String("rule_name"),
+		AnalysisName:        aws.String("policy_name"),
 		Severity:            "INFO",
 	}
 
 	githubRequest := map[string]interface{}{
-		"title": "Policy Failure: rule_name",
+		"title": "Policy Failure: policy_name",
 		"body": "**Description:** description\n " +
-			"[Click here to view in the Panther UI](https://panther.io/policies/ruleId)\n" +
+			"[Click here to view in the Panther UI](https://panther.io/policies/policyId)\n" +
 			" **Runbook:** \n **Severity:** INFO\n **Tags:** ",
 	}
 

--- a/internal/core/alert_delivery/outputs/jira_test.go
+++ b/internal/core/alert_delivery/outputs/jira_test.go
@@ -45,7 +45,8 @@ func TestJiraAlert(t *testing.T) {
 
 	var createdAtTime, _ = time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	alert := &alertModels.Alert{
-		AnalysisID:          "ruleId",
+		AnalysisID:          "policyId",
+		Type:                alertModels.PolicyType,
 		CreatedAt:           createdAtTime,
 		OutputIds:           []string{"output-id"},
 		AnalysisDescription: aws.String("policyDescription"),
@@ -54,9 +55,9 @@ func TestJiraAlert(t *testing.T) {
 
 	jiraPayload := map[string]interface{}{
 		"fields": map[string]interface{}{
-			"summary": "Policy Failure: ruleId",
+			"summary": "Policy Failure: policyId",
 			"description": "*Description:* policyDescription\n " +
-				"[Click here to view in the Panther UI](https://panther.io/policies/ruleId)\n" +
+				"[Click here to view in the Panther UI](https://panther.io/policies/policyId)\n" +
 				" *Runbook:* \n *Severity:* INFO\n *Tags:* ",
 			"project": map[string]*string{
 				"key": aws.String(jiraConfig.ProjectKey),

--- a/internal/core/alert_delivery/outputs/msteams_test.go
+++ b/internal/core/alert_delivery/outputs/msteams_test.go
@@ -40,6 +40,7 @@ func TestMsTeamsAlert(t *testing.T) {
 	var createdAtTime, _ = time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	alert := &alertModels.Alert{
 		AnalysisID:   "policyId",
+		Type:         alertModels.PolicyType,
 		CreatedAt:    createdAtTime,
 		OutputIds:    []string{"output-id"},
 		AnalysisName: aws.String("policyName"),

--- a/internal/core/alert_delivery/outputs/opsgenie_test.go
+++ b/internal/core/alert_delivery/outputs/opsgenie_test.go
@@ -40,6 +40,7 @@ func TestOpsgenieAlert(t *testing.T) {
 	require.NoError(t, err)
 	alert := &alertModels.Alert{
 		AnalysisID:   "policyId",
+		Type:         alertModels.PolicyType,
 		CreatedAt:    createdAtTime,
 		OutputIds:    []string{"output-id"},
 		AnalysisName: aws.String("policyName"),

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -27,8 +27,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 
-	alertmodels "github.com/panther-labs/panther/api/lambda/delivery/models"
-	outputmodels "github.com/panther-labs/panther/api/lambda/outputs/models"
+	alertModels "github.com/panther-labs/panther/api/lambda/delivery/models"
+	outputModels "github.com/panther-labs/panther/api/lambda/outputs/models"
 	"github.com/panther-labs/panther/pkg/gatewayapi"
 )
 
@@ -62,16 +62,16 @@ type HTTPiface interface {
 
 // API is the interface for output delivery that can be used for mocks in tests.
 type API interface {
-	Slack(*alertmodels.Alert, *outputmodels.SlackConfig) *AlertDeliveryResponse
-	PagerDuty(*alertmodels.Alert, *outputmodels.PagerDutyConfig) *AlertDeliveryResponse
-	Github(*alertmodels.Alert, *outputmodels.GithubConfig) *AlertDeliveryResponse
-	Jira(*alertmodels.Alert, *outputmodels.JiraConfig) *AlertDeliveryResponse
-	Opsgenie(*alertmodels.Alert, *outputmodels.OpsgenieConfig) *AlertDeliveryResponse
-	MsTeams(*alertmodels.Alert, *outputmodels.MsTeamsConfig) *AlertDeliveryResponse
-	Sqs(*alertmodels.Alert, *outputmodels.SqsConfig) *AlertDeliveryResponse
-	Sns(*alertmodels.Alert, *outputmodels.SnsConfig) *AlertDeliveryResponse
-	Asana(*alertmodels.Alert, *outputmodels.AsanaConfig) *AlertDeliveryResponse
-	CustomWebhook(*alertmodels.Alert, *outputmodels.CustomWebhookConfig) *AlertDeliveryResponse
+	Slack(*alertModels.Alert, *outputModels.SlackConfig) *AlertDeliveryResponse
+	PagerDuty(*alertModels.Alert, *outputModels.PagerDutyConfig) *AlertDeliveryResponse
+	Github(*alertModels.Alert, *outputModels.GithubConfig) *AlertDeliveryResponse
+	Jira(*alertModels.Alert, *outputModels.JiraConfig) *AlertDeliveryResponse
+	Opsgenie(*alertModels.Alert, *outputModels.OpsgenieConfig) *AlertDeliveryResponse
+	MsTeams(*alertModels.Alert, *outputModels.MsTeamsConfig) *AlertDeliveryResponse
+	Sqs(*alertModels.Alert, *outputModels.SqsConfig) *AlertDeliveryResponse
+	Sns(*alertModels.Alert, *outputModels.SnsConfig) *AlertDeliveryResponse
+	Asana(*alertModels.Alert, *outputModels.AsanaConfig) *AlertDeliveryResponse
+	CustomWebhook(*alertModels.Alert, *outputModels.CustomWebhookConfig) *AlertDeliveryResponse
 }
 
 // OutputClient encapsulates the clients that allow sending alerts to multiple outputs
@@ -138,7 +138,7 @@ type Notification struct {
 	Version *string `json:"version"`
 }
 
-func generateNotificationFromAlert(alert *alertmodels.Alert) Notification {
+func generateNotificationFromAlert(alert *alertModels.Alert) Notification {
 	notification := Notification{
 		ID:          alert.AnalysisID,
 		AlertID:     alert.AlertID,
@@ -157,20 +157,20 @@ func generateNotificationFromAlert(alert *alertmodels.Alert) Notification {
 	return notification
 }
 
-func generateAlertMessage(alert *alertmodels.Alert) string {
+func generateAlertMessage(alert *alertModels.Alert) string {
 	switch alert.Type {
-	case alertmodels.RuleType:
+	case alertModels.RuleType:
 		return getDisplayName(alert) + " triggered"
-	case alertmodels.RuleErrorType:
+	case alertModels.RuleErrorType:
 		return getDisplayName(alert) + " encountered an error"
-	case alertmodels.PolicyType:
+	case alertModels.PolicyType:
 		return getDisplayName(alert) + " failed on new resources"
 	default:
 		panic("uknown alert type " + alert.Type)
 	}
 }
 
-func generateDetailedAlertMessage(alert *alertmodels.Alert) string {
+func generateDetailedAlertMessage(alert *alertModels.Alert) string {
 	return fmt.Sprintf(
 		detailedMessageTemplate,
 		generateAlertMessage(alert),
@@ -181,40 +181,40 @@ func generateDetailedAlertMessage(alert *alertmodels.Alert) string {
 	)
 }
 
-func generateAlertTitle(alert *alertmodels.Alert) string {
+func generateAlertTitle(alert *alertModels.Alert) string {
 	if alert.IsResent {
 		return "[Re-sent]: " + *alert.Title
 	}
 	switch alert.Type {
-	case alertmodels.RuleType:
+	case alertModels.RuleType:
 		if alert.Title != nil {
 			return "New Alert: " + *alert.Title
 		}
 		return "New Alert: " + getDisplayName(alert)
-	case alertmodels.RuleErrorType:
+	case alertModels.RuleErrorType:
 		return "New rule error: " + *alert.Title
-	case alertmodels.PolicyType:
+	case alertModels.PolicyType:
 		return "Policy Failure: " + getDisplayName(alert)
 	default:
 		panic("uknown alert type " + alert.Type)
 	}
 }
 
-func getDisplayName(alert *alertmodels.Alert) string {
+func getDisplayName(alert *alertModels.Alert) string {
 	if aws.StringValue(alert.AnalysisName) != "" {
 		return *alert.AnalysisName
 	}
 	return alert.AnalysisID
 }
 
-func generateURL(alert *alertmodels.Alert) string {
+func generateURL(alert *alertModels.Alert) string {
 	if alert.IsTest {
 		return appDomainURL
 	}
 	switch alert.Type {
-	case alertmodels.RuleType, alertmodels.RuleErrorType:
+	case alertModels.RuleType, alertModels.RuleErrorType:
 		return alertURLPrefix + *alert.AlertID
-	case alertmodels.PolicyType:
+	case alertModels.PolicyType:
 		return policyURLPrefix + alert.AnalysisID
 	default:
 		panic("uknown alert type" + alert.Type)

--- a/internal/core/alert_delivery/outputs/outputs_test.go
+++ b/internal/core/alert_delivery/outputs/outputs_test.go
@@ -46,6 +46,7 @@ func (m *mockHTTPWrapper) post(postInput *PostInput) *AlertDeliveryResponse {
 func TestGenerateAlertTitleReturnGivenTitle(t *testing.T) {
 	alert := &alertModel.Alert{
 		Title: aws.String("my title"),
+		Type:  alertModel.RuleType,
 	}
 
 	assert.Equal(t, "New Alert: my title", generateAlertTitle(alert))

--- a/internal/core/alert_delivery/outputs/slack_test.go
+++ b/internal/core/alert_delivery/outputs/slack_test.go
@@ -38,6 +38,7 @@ func TestSlackAlert(t *testing.T) {
 	createdAtTime := time.Now()
 	alert := &alertModels.Alert{
 		AnalysisID:   "policyId",
+		Type:         alertModels.PolicyType,
 		CreatedAt:    createdAtTime,
 		OutputIds:    []string{"output-id"},
 		AnalysisName: aws.String("policyName"),

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -46,6 +46,7 @@ func TestSendSns(t *testing.T) {
 	createdAtTime := time.Now()
 	alert := &alertModels.Alert{
 		AnalysisName:        aws.String("policyName"),
+		Type:                alertModels.PolicyType,
 		AnalysisID:          "policyId",
 		AnalysisDescription: aws.String("policyDescription"),
 		Severity:            "severity",
@@ -55,6 +56,7 @@ func TestSendSns(t *testing.T) {
 
 	defaultMessage := Notification{
 		ID:          "policyId",
+		Type:        alertModels.PolicyType,
 		Name:        aws.String("policyName"),
 		Description: aws.String("policyDescription"),
 		Severity:    "severity",

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -43,6 +43,7 @@ func TestSendSqs(t *testing.T) {
 	}
 	alert := &alertModels.Alert{
 		AnalysisName:        aws.String("policyName"),
+		Type:                alertModels.PolicyType,
 		AnalysisID:          "policyId",
 		AnalysisDescription: aws.String("policyDescription"),
 		Severity:            "severity",
@@ -51,6 +52,7 @@ func TestSendSqs(t *testing.T) {
 
 	expectedSqsMessage := &Notification{
 		ID:          alert.AnalysisID,
+		Type:        alertModels.PolicyType,
 		Name:        alert.AnalysisName,
 		Description: alert.AnalysisDescription,
 		Severity:    alert.Severity,

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -171,7 +171,7 @@ func (h *Handler) storeNewAlert(rule *ruleModel.Rule, alertDedup *AlertDedupEven
 			UpdateTime:   alertDedup.UpdateTime,
 			EventCount:   alertDedup.EventCount,
 			LogTypes:     alertDedup.LogTypes,
-			ErrorType:    alertDedup.ErrorType,
+			Type:         alertDedup.Type,
 		},
 	}
 
@@ -192,6 +192,12 @@ func (h *Handler) storeNewAlert(rule *ruleModel.Rule, alertDedup *AlertDedupEven
 }
 
 func (h *Handler) sendAlertNotification(rule *ruleModel.Rule, alertDedup *AlertDedupEvent) error {
+	var alertType string
+	if alertDedup.IsError() {
+		alertType = alertModel.RuleErrorType
+	} else {
+		alertType = alertModel.RuleType
+	}
 	alertNotification := &alertModel.Alert{
 		AlertID:             aws.String(generateAlertID(alertDedup)),
 		AnalysisDescription: aws.String(string(rule.Description)),
@@ -205,10 +211,9 @@ func (h *Handler) sendAlertNotification(rule *ruleModel.Rule, alertDedup *AlertD
 		Runbook:      aws.String(string(rule.Runbook)),
 		Severity:     string(rule.Severity),
 		Tags:         rule.Tags,
-		Type:         alertModel.RuleType,
+		Type:         alertType,
 		Title:        aws.String(getAlertTitle(rule, alertDedup)),
 		Version:      &alertDedup.RuleVersion,
-		ErrorType:    alertDedup.ErrorType,
 	}
 
 	msgBody, err := jsoniter.MarshalToString(alertNotification)

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -99,7 +99,7 @@ func (h *Handler) handleNewAlert(rule *ruleModel.Rule, event *AlertDedupEvent) e
 	}
 
 	err := h.sendAlertNotification(rule, event)
-	if err == nil && !event.IsError() {
+	if err == nil && event.Type == alertModel.RuleType {
 		h.logStats(rule)
 	}
 	return err
@@ -192,12 +192,6 @@ func (h *Handler) storeNewAlert(rule *ruleModel.Rule, alertDedup *AlertDedupEven
 }
 
 func (h *Handler) sendAlertNotification(rule *ruleModel.Rule, alertDedup *AlertDedupEvent) error {
-	var alertType string
-	if alertDedup.IsError() {
-		alertType = alertModel.RuleErrorType
-	} else {
-		alertType = alertModel.RuleType
-	}
 	alertNotification := &alertModel.Alert{
 		AlertID:             aws.String(generateAlertID(alertDedup)),
 		AnalysisDescription: aws.String(string(rule.Description)),
@@ -211,7 +205,7 @@ func (h *Handler) sendAlertNotification(rule *ruleModel.Rule, alertDedup *AlertD
 		Runbook:      aws.String(string(rule.Runbook)),
 		Severity:     string(rule.Severity),
 		Tags:         rule.Tags,
-		Type:         alertType,
+		Type:         alertDedup.Type,
 		Title:        aws.String(getAlertTitle(rule, alertDedup)),
 		Version:      &alertDedup.RuleVersion,
 	}

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -58,6 +58,7 @@ var (
 		RuleID:              "ruleId",
 		RuleVersion:         "ruleVersion",
 		DeduplicationString: "dedupString",
+		Type:                alertModel.RuleType,
 		AlertCount:          10,
 		CreationTime:        time.Now().UTC(),
 		UpdateTime:          time.Now().UTC().Add(1 * time.Minute),
@@ -70,6 +71,7 @@ var (
 		RuleID:              oldAlertDedupEvent.RuleID,
 		RuleVersion:         oldAlertDedupEvent.RuleVersion,
 		DeduplicationString: oldAlertDedupEvent.DeduplicationString,
+		Type:                oldAlertDedupEvent.Type,
 		AlertCount:          oldAlertDedupEvent.AlertCount + 1,
 		CreationTime:        time.Now().UTC(),
 		UpdateTime:          time.Now().UTC().Add(1 * time.Minute),
@@ -147,6 +149,7 @@ func TestHandleStoreAndSendNotification(t *testing.T) {
 		LogTypes:            newAlertDedupEvent.LogTypes,
 		AlertDedupEvent: AlertDedupEvent{
 			RuleID:              newAlertDedupEvent.RuleID,
+			Type:                newAlertDedupEvent.Type,
 			RuleVersion:         newAlertDedupEvent.RuleVersion,
 			LogTypes:            newAlertDedupEvent.LogTypes,
 			EventCount:          newAlertDedupEvent.EventCount,
@@ -205,6 +208,7 @@ func TestHandleStoreAndSendNotificationNoRuleDisplayNameNoTitle(t *testing.T) {
 		UpdateTime:          time.Now().UTC().Add(1 * time.Minute),
 		EventCount:          oldAlertDedupEvent.EventCount,
 		LogTypes:            oldAlertDedupEvent.LogTypes,
+		Type:                oldAlertDedupEvent.Type,
 	}
 
 	expectedAlertNotification := &alertModel.Alert{
@@ -254,6 +258,7 @@ func TestHandleStoreAndSendNotificationNoRuleDisplayNameNoTitle(t *testing.T) {
 			GeneratedTitle:      newAlertDedupEventWithoutTitle.GeneratedTitle,
 			UpdateTime:          newAlertDedupEventWithoutTitle.UpdateTime,
 			CreationTime:        newAlertDedupEventWithoutTitle.UpdateTime,
+			Type:                newAlertDedupEventWithoutTitle.Type,
 		},
 	}
 
@@ -305,7 +310,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 		Runbook:             aws.String(string(testRuleResponse.Runbook)),
 		Severity:            string(testRuleResponse.Severity),
 		Tags:                []string{"Tag"},
-		Type:                alertModel.RuleType,
+		Type:                newAlertDedupEvent.Type,
 		AlertID:             aws.String("b25dc23fb2a0b362da8428dbec1381a8"),
 		Title:               aws.String("DisplayName"),
 	}
@@ -331,6 +336,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 			RuleID:              newAlertDedupEvent.RuleID,
 			RuleVersion:         newAlertDedupEvent.RuleVersion,
 			LogTypes:            newAlertDedupEvent.LogTypes,
+			Type:                newAlertDedupEvent.Type,
 			EventCount:          newAlertDedupEvent.EventCount,
 			AlertCount:          newAlertDedupEvent.AlertCount,
 			DeduplicationString: newAlertDedupEvent.DeduplicationString,
@@ -351,6 +357,7 @@ func TestHandleStoreAndSendNotificationNoGeneratedTitle(t *testing.T) {
 	dedupEventWithoutTitle := &AlertDedupEvent{
 		RuleID:              newAlertDedupEvent.RuleID,
 		RuleVersion:         newAlertDedupEvent.RuleVersion,
+		Type:                newAlertDedupEvent.Type,
 		DeduplicationString: newAlertDedupEvent.DeduplicationString,
 		AlertCount:          newAlertDedupEvent.AlertCount,
 		CreationTime:        newAlertDedupEvent.CreationTime,
@@ -423,6 +430,7 @@ func TestHandleStoreAndSendNotificationNilOldDedup(t *testing.T) {
 		LogTypes:            newAlertDedupEvent.LogTypes,
 		AlertDedupEvent: AlertDedupEvent{
 			RuleID:              newAlertDedupEvent.RuleID,
+			Type:                newAlertDedupEvent.Type,
 			RuleVersion:         newAlertDedupEvent.RuleVersion,
 			LogTypes:            newAlertDedupEvent.LogTypes,
 			EventCount:          newAlertDedupEvent.EventCount,
@@ -628,6 +636,7 @@ func TestHandleShouldCreateAlertIfThresholdNowReached(t *testing.T) {
 
 	newAlertDedup := &AlertDedupEvent{
 		RuleID:              oldAlertDedupEvent.RuleID,
+		Type:                oldAlertDedupEvent.Type,
 		RuleVersion:         oldAlertDedupEvent.RuleVersion,
 		DeduplicationString: oldAlertDedupEvent.DeduplicationString,
 		AlertCount:          oldAlertDedupEvent.AlertCount + 1,

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -680,8 +680,8 @@ func TestHandleError(t *testing.T) {
 
 	oldErrorDedupEvent := *oldAlertDedupEvent
 	newErrorDedupEvent := *newAlertDedupEvent
-	oldErrorDedupEvent.ErrorType = "RULE_ERROR"
-	newErrorDedupEvent.ErrorType = "RULE_ERROR"
+	oldErrorDedupEvent.Type = "RULE_ERROR"
+	newErrorDedupEvent.Type = "RULE_ERROR"
 	assert.NoError(t, handler.Do(&oldErrorDedupEvent, &newErrorDedupEvent))
 
 	ddbMock.AssertExpectations(t)

--- a/internal/log_analysis/alert_forwarder/forwarder/models.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models.go
@@ -24,8 +24,6 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
-
-	"github.com/panther-labs/panther/api/lambda/delivery/models"
 )
 
 const (
@@ -44,13 +42,9 @@ type AlertDedupEvent struct {
 	UpdateTime          time.Time `dynamodbav:"updateTime"`
 	EventCount          int64     `dynamodbav:"eventCount"`
 	LogTypes            []string  `dynamodbav:"logTypes,stringset"`
-	Type                string    `dynamodbav:"alertType"`
+	Type                string    `dynamodbav:"type"`
 	GeneratedTitle      *string   `dynamodbav:"-"` // The title that was generated dynamically using Python. Might be null.
 	AlertCount          int64     `dynamodbav:"-"` // There is no need to store this item in DDB
-}
-
-func (e *AlertDedupEvent) IsError() bool {
-	return e.Type == models.RuleErrorType
 }
 
 // Alert contains all the fields associated to the alert stored in DDB
@@ -137,7 +131,7 @@ func FromDynamodDBAttribute(input map[string]events.DynamoDBAttributeValue) (eve
 		result.GeneratedTitle = aws.String(generatedTitle.String())
 	}
 
-	alertType := getOptionalAttribute("alertType", input)
+	alertType := getOptionalAttribute("type", input)
 	if alertType != nil {
 		result.Type = alertType.String()
 	}

--- a/internal/log_analysis/alert_forwarder/forwarder/models_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models_test.go
@@ -38,7 +38,7 @@ func TestConvertAttribute(t *testing.T) {
 		EventCount:          100,
 		LogTypes:            []string{"Log.Type.1", "Log.Type.2"},
 		GeneratedTitle:      aws.String("test title"),
-		ErrorType:           "RULE_ERROR",
+		Type:                "RULE_ERROR",
 	}
 
 	alertDedupEvent, err := FromDynamodDBAttribute(getNewTestCase())
@@ -66,7 +66,7 @@ func TestConvertAttributeWithoutOptionalFields(t *testing.T) {
 
 	ddbItem := getNewTestCase()
 	delete(ddbItem, "title")
-	delete(ddbItem, "errorType")
+	delete(ddbItem, "alertType")
 	alertDedupEvent, err := FromDynamodDBAttribute(ddbItem)
 	require.NoError(t, err)
 	require.Equal(t, expectedAlertDedup, alertDedupEvent)
@@ -156,6 +156,6 @@ func getNewTestCase() map[string]events.DynamoDBAttributeValue {
 		"logTypes":          events.NewStringSetAttribute([]string{"Log.Type.1", "Log.Type.2"}),
 		"title":             events.NewStringAttribute("test title"),
 		"status":            events.NewStringAttribute("OPEN"),
-		"errorType":         events.NewStringAttribute("RULE_ERROR"),
+		"alertType":         events.NewStringAttribute("RULE_ERROR"),
 	}
 }

--- a/internal/log_analysis/alert_forwarder/forwarder/models_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models_test.go
@@ -66,7 +66,7 @@ func TestConvertAttributeWithoutOptionalFields(t *testing.T) {
 
 	ddbItem := getNewTestCase()
 	delete(ddbItem, "title")
-	delete(ddbItem, "alertType")
+	delete(ddbItem, "type")
 	alertDedupEvent, err := FromDynamodDBAttribute(ddbItem)
 	require.NoError(t, err)
 	require.Equal(t, expectedAlertDedup, alertDedupEvent)
@@ -156,6 +156,6 @@ func getNewTestCase() map[string]events.DynamoDBAttributeValue {
 		"logTypes":          events.NewStringSetAttribute([]string{"Log.Type.1", "Log.Type.2"}),
 		"title":             events.NewStringAttribute("test title"),
 		"status":            events.NewStringAttribute("OPEN"),
-		"alertType":         events.NewStringAttribute("RULE_ERROR"),
+		"type":              events.NewStringAttribute("RULE_ERROR"),
 	}
 }

--- a/internal/log_analysis/alerts_api/api/get_alert.go
+++ b/internal/log_analysis/alerts_api/api/get_alert.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/panther-labs/panther/api/lambda/alerts/models"
 	logprocessormodels "github.com/panther-labs/panther/api/lambda/core/log_analysis/log_processor/models"
+	alertmodels "github.com/panther-labs/panther/api/lambda/delivery/models"
 	"github.com/panther-labs/panther/internal/log_analysis/alerts_api/table"
 	"github.com/panther-labs/panther/internal/log_analysis/alerts_api/utils"
 	"github.com/panther-labs/panther/internal/log_analysis/awsglue"
@@ -142,7 +143,7 @@ func getEventsForLogType(
 		}
 
 		var dataType logprocessormodels.DataType
-		if len(alert.ErrorType) > 0 {
+		if alert.Type == alertmodels.RuleErrorType {
 			dataType = logprocessormodels.RuleErrors
 		} else {
 			dataType = logprocessormodels.RuleData

--- a/internal/log_analysis/alerts_api/table/table.go
+++ b/internal/log_analysis/alerts_api/table/table.go
@@ -68,6 +68,7 @@ type DynamoItem = map[string]*dynamodb.AttributeValue
 // AlertItem is a DDB representation of an Alert
 type AlertItem struct {
 	AlertID             string                     `json:"id"`
+	Type                string                     `json:"type"`
 	RuleID              string                     `json:"ruleId"`
 	RuleVersion         string                     `json:"ruleVersion"`
 	RuleDisplayName     *string                    `json:"ruleDisplayName"`
@@ -86,5 +87,4 @@ type AlertItem struct {
 	LastUpdatedBy string `json:"lastUpdatedBy"`
 	// LastUpdatedByTime - stores the timestamp of the last person who modified the Alert
 	LastUpdatedByTime time.Time `json:"lastUpdatedByTime"`
-	ErrorType         string    `json:"errorType"`
 }

--- a/internal/log_analysis/alerts_api/utils/utils.go
+++ b/internal/log_analysis/alerts_api/utils/utils.go
@@ -45,6 +45,7 @@ func AlertItemToSummary(item *table.AlertItem) *models.AlertSummary {
 
 	return &models.AlertSummary{
 		AlertID:           &item.AlertID,
+		Type:              item.Type,
 		CreationTime:      &item.CreationTime,
 		DedupString:       &item.DedupString,
 		EventsMatched:     &item.EventCount,
@@ -59,7 +60,6 @@ func AlertItemToSummary(item *table.AlertItem) *models.AlertSummary {
 		LastUpdatedByTime: item.LastUpdatedByTime,
 		UpdateTime:        &item.UpdateTime,
 		DeliveryResponses: item.DeliveryResponses,
-		ErrorType:         item.ErrorType,
 	}
 }
 

--- a/internal/log_analysis/awsglue/schema.go
+++ b/internal/log_analysis/awsglue/schema.go
@@ -56,6 +56,10 @@ var (
 			To:   GlueStringType,
 		},
 		{
+			From: reflect.TypeOf([]jsoniter.RawMessage{}),
+			To:   ArrayOf(GlueStringType),
+		},
+		{
 			From: reflect.TypeOf(numerics.Integer(0)),
 			To:   "bigint",
 		},
@@ -338,7 +342,7 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 			glueType = ArrayOf(structType)
 			return
 		default:
-			elementType := inferType(sliceOfType, customMappingsTable)
+			elementType := toGlueType(sliceOfType)
 			glueType = ArrayOf(elementType)
 			return
 		}
@@ -363,7 +367,7 @@ func inferStructFieldType(sf reflect.StructField, customMappingsTable map[string
 		}
 
 		// simple types
-		glueType = inferType(t, customMappingsTable)
+		glueType = toGlueType(t)
 		return
 	}
 }
@@ -410,14 +414,12 @@ func inferMap(t reflect.Type, customMappingsTable map[string]string) (glueType s
 		glueType = fmt.Sprintf("map<%s,%s>", t.Key(), mapGlueType)
 		return
 	}
-	glueType = fmt.Sprintf("map<%s,%s>", t.Key(), inferType(mapOfType, customMappingsTable))
+	glueType = fmt.Sprintf("map<%s,%s>", t.Key(), toGlueType(mapOfType))
 	return glueType, structFieldNames
 }
 
-func inferType(t reflect.Type, customMappings map[string]string) (glueType string) {
-	if customType, ok := customMappings[t.String()]; ok {
-		return customType
-	}
+// Primitive mappings
+func toGlueType(t reflect.Type) (glueType string) {
 	switch t.String() {
 	case "bool":
 		glueType = "boolean"

--- a/internal/log_analysis/awsglue/schema_test.go
+++ b/internal/log_analysis/awsglue/schema_test.go
@@ -129,10 +129,9 @@ func TestInferJsonColumns(t *testing.T) {
 		StructField       TestStruct   `description:"test field"`
 		NestedStructField NestedStruct `description:"test field"`
 
-		CustomTypeField        TestCustomSimpleType   `description:"test field"`
-		SliceOfCustomTypeField []TestCustomSimpleType `description:"test field"`
-		CustomSliceField       TestCustomSliceType    `description:"test field"`
-		CustomStructField      TestCustomStructType   `description:"test field"`
+		CustomTypeField   TestCustomSimpleType `description:"test field"`
+		CustomSliceField  TestCustomSliceType  `description:"test field"`
+		CustomStructField TestCustomStructType `description:"test field"`
 	}{
 		BoolField: true,
 
@@ -175,7 +174,6 @@ func TestInferJsonColumns(t *testing.T) {
 		NestedStructField: NestedStruct{
 			C: &TestStruct{}, // test with ptrs
 		},
-		SliceOfCustomTypeField: []TestCustomSimpleType{},
 	}
 
 	// adjust for native int expected results
@@ -232,7 +230,6 @@ func TestInferJsonColumns(t *testing.T) {
 		{Name: "StructField", Type: "struct<Field1:string,Field2:int,at_sign_remap:string>", Comment: "test field"},
 		{Name: "NestedStructField", Type: "struct<InheritedField:string,A:struct<Field1:string,Field2:int,at_sign_remap:string>,B:struct<Field1:string,Field2:int,at_sign_remap:string>,C:struct<Field1:string,Field2:int,at_sign_remap:string>>", Comment: "test field"}, // nolint
 		{Name: "CustomTypeField", Type: "foo", Comment: "test field"},
-		{Name: "SliceOfCustomTypeField", Type: "array<foo>", Comment: "test field"},
 		{Name: "CustomSliceField", Type: "baz", Comment: "test field"},
 		{Name: "CustomStructField", Type: "bar", Comment: "test field"},
 	}

--- a/internal/log_analysis/awsglue/schema_test.go
+++ b/internal/log_analysis/awsglue/schema_test.go
@@ -129,9 +129,10 @@ func TestInferJsonColumns(t *testing.T) {
 		StructField       TestStruct   `description:"test field"`
 		NestedStructField NestedStruct `description:"test field"`
 
-		CustomTypeField   TestCustomSimpleType `description:"test field"`
-		CustomSliceField  TestCustomSliceType  `description:"test field"`
-		CustomStructField TestCustomStructType `description:"test field"`
+		CustomTypeField        TestCustomSimpleType   `description:"test field"`
+		SliceOfCustomTypeField []TestCustomSimpleType `description:"test field"`
+		CustomSliceField       TestCustomSliceType    `description:"test field"`
+		CustomStructField      TestCustomStructType   `description:"test field"`
 	}{
 		BoolField: true,
 
@@ -174,6 +175,7 @@ func TestInferJsonColumns(t *testing.T) {
 		NestedStructField: NestedStruct{
 			C: &TestStruct{}, // test with ptrs
 		},
+		SliceOfCustomTypeField: []TestCustomSimpleType{},
 	}
 
 	// adjust for native int expected results
@@ -230,6 +232,7 @@ func TestInferJsonColumns(t *testing.T) {
 		{Name: "StructField", Type: "struct<Field1:string,Field2:int,at_sign_remap:string>", Comment: "test field"},
 		{Name: "NestedStructField", Type: "struct<InheritedField:string,A:struct<Field1:string,Field2:int,at_sign_remap:string>,B:struct<Field1:string,Field2:int,at_sign_remap:string>,C:struct<Field1:string,Field2:int,at_sign_remap:string>>", Comment: "test field"}, // nolint
 		{Name: "CustomTypeField", Type: "foo", Comment: "test field"},
+		{Name: "SliceOfCustomTypeField", Type: "array<foo>", Comment: "test field"},
 		{Name: "CustomSliceField", Type: "baz", Comment: "test field"},
 		{Name: "CustomStructField", Type: "bar", Comment: "test field"},
 	}

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -88,12 +88,9 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     2. This rule with the same dedup string has fired before, but after the dedup period has expired
     """
     condition_expression = '(#1 < :1) OR (attribute_not_exists(#2))'
-    update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10'
+    update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
 
     if group_info.title:
-        update_expression += ', #11=:11'
-
-    if group_info.is_rule_error:
         update_expression += ', #12=:12'
 
     expresion_attribute_names = {
@@ -107,12 +104,16 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
         '#8': _ALERT_EVENT_COUNT,
         '#9': _ALERT_LOG_TYPES,
         '#10': _RULE_VERSION_ATTR_NAME,
+        '#11': _ALERT_TYPE
     }
+
     if group_info.title:
-        expresion_attribute_names['#11'] = _ALERT_TITLE
+        expresion_attribute_names['#12'] = _ALERT_TITLE
 
     if group_info.is_rule_error:
-        expresion_attribute_names['#12'] = _ALERT_TYPE
+        alert_type = "RULE_ERROR"
+    else:
+        alert_type = "RULE"
 
     expression_attribute_values = {
         ':1':
@@ -144,12 +145,12 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
         ':10': {
             'S': group_info.rule_version
         },
+        ':11': {
+            'S': alert_type
+        },
     }
     if group_info.title:
-        expression_attribute_values[':11'] = {'S': group_info.title}
-
-    if group_info.is_rule_error:
-        expression_attribute_values[':12'] = {'S': 'RULE_ERROR'}
+        expression_attribute_values[':12'] = {'S': group_info.title}
 
     response = _DDB_CLIENT.update_item(
         TableName=_DDB_TABLE_NAME,

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -39,7 +39,7 @@ _ALERT_EVENT_COUNT = 'eventCount'
 _ALERT_LOG_TYPES = 'logTypes'
 _ALERT_TITLE = 'title'
 # The attribute defining the type of the error
-_ALERT_TYPE = 'alertType'
+_ALERT_TYPE = 'type'
 
 
 # pylint: disable=too-many-instance-attributes

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -39,7 +39,7 @@ _ALERT_EVENT_COUNT = 'eventCount'
 _ALERT_LOG_TYPES = 'logTypes'
 _ALERT_TITLE = 'title'
 # The attribute defining the type of the error
-_ERROR_TYPE = 'errorType'
+_ALERT_TYPE = 'alertType'
 
 
 # pylint: disable=too-many-instance-attributes
@@ -112,7 +112,7 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
         expresion_attribute_names['#11'] = _ALERT_TITLE
 
     if group_info.is_rule_error:
-        expresion_attribute_names['#12'] = _ERROR_TYPE
+        expresion_attribute_names['#12'] = _ALERT_TYPE
 
     expression_attribute_values = {
         ':1':

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -58,10 +58,11 @@ class Engine:
                     dedup=type(result.exception).__name__,
                     dedup_period_mins=1440,  # one day
                     event=event,
+                    title=repr(result.exception),
                     error_message=repr(result.exception)
                 )
                 engine_results.append(rule_error)
-            if result.matched:
+            elif result.matched:
                 match = EngineResult(
                     rule_id=rule.rule_id,
                     rule_version=rule.rule_version,

--- a/internal/log_analysis/rules_engine/tests/test_engine.py
+++ b/internal/log_analysis/rules_engine/tests/test_engine.py
@@ -114,7 +114,8 @@ class TestEngine(TestCase):
                 dedup='Exception',
                 event={},
                 dedup_period_mins=1440,
-                error_message="Exception('Found an issue')"
+                error_message="Exception('Found an issue')",
+                title="Exception('Found an issue')"
             ),
             EngineResult(
                 rule_id='rule_id_3',

--- a/internal/log_analysis/rules_engine/tests/test_output.py
+++ b/internal/log_analysis/rules_engine/tests/test_output.py
@@ -68,7 +68,8 @@ class TestMatchedEventsBuffer(TestCase):
                 '#7': 'alertUpdateTime',
                 '#8': 'eventCount',
                 '#9': 'logTypes',
-                '#10': 'ruleVersion'
+                '#10': 'ruleVersion',
+                '#11': 'type'
             },
             ExpressionAttributeValues={
                 ':1': {
@@ -97,6 +98,9 @@ class TestMatchedEventsBuffer(TestCase):
                 },
                 ':10': {
                     'S': 'rule_version'
+                },
+                ':11': {
+                    'S': 'RULE'
                 }
             },
             Key={
@@ -107,7 +111,7 @@ class TestMatchedEventsBuffer(TestCase):
             },
             ReturnValues='ALL_NEW',
             TableName='table_name',
-            UpdateExpression='ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10'
+            UpdateExpression='ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
         )
 
         S3_MOCK.put_object.assert_called_once_with(Body=mock.ANY, Bucket='s3_bucket', ContentType='gzip', Key=mock.ANY)


### PR DESCRIPTION
## Background

We were using "Type" to define if an alert if because of a Rule or Policy and an "ErrorType" to differentiate between "Rule Error" and "Rule matches". Seems better approach to extend the Alert Type to be one of "Policy"(failure), "Rule"(match), "Rule Error". This could make it easier to use the same structure for other types that are not necessarily errors

## Changes

- Changed Alert API to handle the new type
- Changed Alert Delivery to handle the new type
- Changed rules engine to populate handle the new type

## Testing

- mage test:ci
- Deployed and generated a rule that hits an error. Seeing it in the UI: 

<img width="1630" alt="Screen Shot 2020-09-28 at 6 31 03 PM" src="https://user-images.githubusercontent.com/2652630/94452978-d1c6a980-01b8-11eb-86fc-203f9be88c1d.png">

