### PR TITLE
Make rule engine return the exception if title() or dedup() raises

### DIFF
--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -76,7 +76,7 @@ def direct_analysis(request: Dict[str, Any]) -> Dict[str, Any]:
             # If rule was invalid, no need to try to run it
 
         else:
-            rule_result = test_rule.run(event['data'])
+            rule_result = test_rule.run(event['data'], raise_title_dedup=True)
             if rule_result.exception:
                 result['errored'] = [
                     {

--- a/internal/log_analysis/rules_engine/tests/test_output.py
+++ b/internal/log_analysis/rules_engine/tests/test_output.py
@@ -314,7 +314,7 @@ class TestMatchedEventsBuffer(TestCase):
     def test_add_overflows_buffer(self) -> None:
         buffer = MatchedEventsBuffer()
         # Reducing max_bytes so that it will cause the overflow condition to trigger earlier
-        buffer.max_bytes = 50
+        buffer.max_bytes = 20
         event_match = EngineResult(
             rule_id='rule_id',
             rule_version='rule_version',

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -111,8 +111,8 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(expected_rule, rule.run({}))
 
     def test_restrict_dedup_size(self) -> None:
-        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'.\
-            format(MAX_DEDUP_STRING_SIZE+1)
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'. \
+            format(MAX_DEDUP_STRING_SIZE + 1)
         rule = Rule({'id': 'test_restrict_dedup_size', 'body': rule_body, 'versionId': 'versionId'})
 
         expected_dedup_string_prefix = ''.join('a' for _ in range(MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)))
@@ -123,7 +123,7 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         rule_body = 'def rule(event):\n\treturn True\n' \
                     'def dedup(event):\n\treturn "test"\n' \
                     'def title(event):\n\treturn "".join("a" for i in range({}))'. \
-            format(MAX_TITLE_SIZE+1)
+            format(MAX_TITLE_SIZE + 1)
         rule = Rule({'id': 'test_restrict_title_size', 'body': rule_body, 'versionId': 'versionId'})
 
         expected_title_string_prefix = ''.join('a' for _ in range(MAX_TITLE_SIZE - len(TRUNCATED_STRING_SUFFIX)))
@@ -199,5 +199,5 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
         rule = Rule({'id': 'test_rule_title_returns_empty_string', 'body': rule_body, 'versionId': 'versionId'})
 
-        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_title_returns_empty_string')
-        self.assertEqual(rule.run({}), expected_result)
+        expected_result = RuleResult(matched=True, dedup_string='defaultDedupString:test_rule_title_returns_empty_string', title='')
+        self.assertEqual(expected_result, rule.run({}))


### PR DESCRIPTION
Closes #1592

## Background

See https://github.com/panther-labs/panther/issues/1592 for more context.

## Changes

The rule engine now returns any errors raised from `title()` or `dedup()` instead of swallowing them.
Subsequently, rule tests will fail if any of its functions raises an exception.

## Testing

- unit test
