### PR TITLE
Add support for strftime and unix microseconds/nanoseconds to tcodec 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/influxdata/go-syslog/v3 v3.0.0
+	github.com/itchyny/timefmt-go v0.1.1
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.10
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/go-syslog/v3 v3.0.0 h1:jichmjSZlYK0VMmlz+k4WeOQd7z745YLsvGMqwtYt4I=
 github.com/influxdata/go-syslog/v3 v3.0.0/go.mod h1:tulsOp+CecTAYC27u9miMgq21GqXRW6VdKbOG+QSP4Q=
+github.com/itchyny/timefmt-go v0.1.1 h1:rLpnm9xxb39PEEVzO0n4IRp0q6/RmBc7Dy/rE4HrA0U=
+github.com/itchyny/timefmt-go v0.1.1/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/extension.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/extension.go
@@ -119,12 +119,17 @@ type EncoderDecorator interface {
 }
 
 func (ext *Extension) resolveCodec(tag string) (TimeCodec, error) {
-	// NOTE: [tcodec] Add support for other layout types such as strftime (https://strftime.org/)
 	if strings.HasPrefix(tag, "layout=") {
 		// The tag is of the form `layout=GO_TIME_LAYOUT`.
 		// We strip the prefix and use a LayoutCodec.
 		layout := strings.TrimPrefix(tag, "layout=")
 		return LayoutCodec(layout), nil
+	}
+	if strings.HasPrefix(tag, "strftime=") {
+		// The tag is of the form `strftime=STRFTIME_LAYOUT`.
+		// We strip the prefix and use a StrftimeCodec.
+		layout := strings.TrimPrefix(tag, "strftime=")
+		return StrftimeCodec(layout), nil
 	}
 	if codecs := ext.Codecs; codecs != nil {
 		if codec := codecs.Lookup(tag); codec != nil {

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/extension_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/extension_test.go
@@ -29,11 +29,12 @@ import (
 
 func TestNewExtension(t *testing.T) {
 	type T struct {
-		TimeRFC3339 time.Time `json:"t_rfc,omitempty" tcodec:"rfc3339"`
-		TimeUnixMS  time.Time `json:"t_unix_ms,omitempty" tcodec:"unix_ms"`
-		TimeUnix    time.Time `json:"t_unix,omitempty" tcodec:"unix"`
-		TimeCustom  time.Time `json:"t_custom,omitempty" tcodec:"layout=2006-01-02"`
-		Time        time.Time `json:"t,omitempty"`
+		TimeRFC3339  time.Time `json:"t_rfc,omitempty" tcodec:"rfc3339"`
+		TimeUnixMS   time.Time `json:"t_unix_ms,omitempty" tcodec:"unix_ms"`
+		TimeUnix     time.Time `json:"t_unix,omitempty" tcodec:"unix"`
+		TimeCustom   time.Time `json:"t_custom,omitempty" tcodec:"layout=2006-01-02"`
+		TimeStrftime time.Time `json:"t_strftime,omitempty" tcodec:"strftime=%Y-%m-%dT%H:%M:%S.%f%Z"`
+		Time         time.Time `json:"t,omitempty"`
 	}
 	ext := &Extension{}
 	api := jsoniter.Config{}.Froze()
@@ -43,6 +44,7 @@ func TestNewExtension(t *testing.T) {
 	input := fmt.Sprintf(`{
 		"t_rfc": "%s",
 		"t_custom": "%s",
+		"t_strftime": "2020-10-01T14:32:54.569000MST",
 		"t_unix": "%f",
 		"t_unix_ms": "%d"
 	}`,
@@ -56,6 +58,9 @@ func TestNewExtension(t *testing.T) {
 	require.NoError(t, err)
 	expect := tm.Format(time.RFC3339Nano)
 	require.Equal(t, tm.Format("2006-01-02"), actual.TimeCustom.UTC().Format("2006-01-02"), "custom")
+
+	require.Equal(t, expect, actual.TimeRFC3339.UTC().Format(time.RFC3339Nano), "rfc3339")
+	require.Equal(t, "2020-10-01T14:32:54.569Z", actual.TimeStrftime.Format(time.RFC3339Nano), "strftime")
 	require.Equal(t, expect, actual.TimeRFC3339.UTC().Format(time.RFC3339Nano), "rfc3339")
 	require.Equal(t, expect, actual.TimeUnix.UTC().Format(time.RFC3339Nano), "unix")
 	require.Equal(t, expect, actual.TimeUnixMS.UTC().Format(time.RFC3339Nano), "unix_ms")

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/registry.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/registry.go
@@ -28,6 +28,8 @@ var (
 		codecs: map[string]TimeCodec{
 			"unix":    UnixSecondsCodec(),
 			"unix_ms": UnixMillisecondsCodec(),
+			"unix_us": UnixMicrosecondsCodec(),
+			"unix_ns": UnixNanosecondsCodec(),
 			"rfc3339": Join(LayoutCodec(time.RFC3339), LayoutCodec(time.RFC3339Nano)),
 		},
 	}

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec_test.go
@@ -34,6 +34,18 @@ func TestUnixMilliseconds(t *testing.T) {
 	require.Equal(t, expect.Format(time.RFC3339Nano), actual.Format(time.RFC3339Nano))
 	require.Equal(t, expect, actual)
 }
+func TestUnixMicroseconds(t *testing.T) {
+	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259123*time.Microsecond.Nanoseconds()), time.UTC).Local()
+	actual := UnixMicroseconds(1590364207259123)
+	require.Equal(t, expect.Format(time.RFC3339Nano), actual.Format(time.RFC3339Nano))
+	require.Equal(t, expect, actual)
+}
+func TestUnixNanoseconds(t *testing.T) {
+	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259123456), time.UTC).Local()
+	actual := UnixNanoseconds(1590364207259123456)
+	require.Equal(t, expect.Format(time.RFC3339Nano), actual.Format(time.RFC3339Nano))
+	require.Equal(t, expect, actual)
+}
 func TestUnixSeconds(t *testing.T) {
 	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259*time.Millisecond.Nanoseconds()), time.UTC).Local()
 	actual := UnixSeconds(1590364207.259)

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec_test.go
@@ -29,14 +29,16 @@ import (
 )
 
 func TestUnixMilliseconds(t *testing.T) {
-	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259*time.Millisecond.Nanoseconds()), time.UTC)
+	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259*time.Millisecond.Nanoseconds()), time.UTC).Local()
 	actual := UnixMilliseconds(1590364207259)
-	require.Equal(t, expect, actual.UTC())
+	require.Equal(t, expect.Format(time.RFC3339Nano), actual.Format(time.RFC3339Nano))
+	require.Equal(t, expect, actual)
 }
 func TestUnixSeconds(t *testing.T) {
-	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259*time.Millisecond.Nanoseconds()), time.UTC)
+	expect := time.Date(2020, 05, 24, 23, 50, 07, int(259*time.Millisecond.Nanoseconds()), time.UTC).Local()
 	actual := UnixSeconds(1590364207.259)
-	require.Equal(t, expect, actual.UTC())
+	require.Equal(t, expect.Format(time.RFC3339Nano), actual.Format(time.RFC3339Nano))
+	require.Equal(t, expect, actual)
 }
 
 func TestGlobalRegister(t *testing.T) {

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/unix.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/unix.go
@@ -1,0 +1,161 @@
+package tcodec
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"strconv"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+// UnixSeconds reads a timestamp from seconds since UNIX epoch.
+// Fractions of a second can be set using the fractional part of a float.
+// Precision is kept up to microseconds to avoid float64 precision issues.
+func UnixSeconds(sec float64) time.Time {
+	// We lose nanosecond precision to microsecond to have stable results with float64 values.
+	const usec = float64(time.Second / time.Microsecond)
+	const precision = int64(time.Microsecond)
+	return time.Unix(0, int64(sec*usec)*precision)
+}
+
+// UnixSecondsCodec decodes/encodes a timestamp from seconds since UNIX epoch.
+// Fractions of a second can be set using the fractional part of a float.
+// Precision is kept up to Microseconds to avoid float64 precision issues.
+func UnixSecondsCodec() TimeCodec {
+	return &unixSecondsCodec{}
+}
+
+type unixSecondsCodec struct{}
+
+func (*unixSecondsCodec) EncodeTime(tm time.Time, stream *jsoniter.Stream) {
+	if tm.IsZero() {
+		stream.WriteNil()
+		return
+	}
+	tm = tm.Truncate(time.Microsecond)
+	unixSeconds := time.Duration(tm.UnixNano()).Seconds()
+	stream.WriteFloat64(unixSeconds)
+}
+
+func (*unixSecondsCodec) DecodeTime(iter *jsoniter.Iterator) (tm time.Time) {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		f := iter.ReadFloat64()
+		return UnixSeconds(f)
+	case jsoniter.NilValue:
+		iter.ReadNil()
+		return
+	case jsoniter.StringValue:
+		s := iter.ReadString()
+		if s == "" {
+			return
+		}
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			iter.ReportError("ReadUnixSeconds", err.Error())
+			return
+		}
+		return UnixSeconds(f)
+	default:
+		iter.Skip()
+		iter.ReportError("ReadUnixSeconds", `invalid JSON value`)
+		return
+	}
+}
+
+// UnixMilliseconds reads a timestamp from milliseconds since UNIX epoch.
+func UnixMilliseconds(n int64) time.Time {
+	return time.Unix(0, n*int64(time.Millisecond))
+}
+
+// UnixMillisecondsCodec decodes/encodes a timestamps in UNIX millisecond epoch.
+// It decodes both string and number JSON values and encodes always to number.
+func UnixMillisecondsCodec() TimeCodec {
+	return &unixCodec{
+		Unit: time.Millisecond,
+	}
+}
+
+// UnixMicroseconds reads a timestamp from microseconds since UNIX epoch.
+// It decodes both string and number JSON values and encodes always to number.
+func UnixMicroseconds(n int64) time.Time {
+	return time.Unix(0, n*int64(time.Microsecond))
+}
+
+// UnixMicrosecondsCodec decodes/encodes a timestamps in UNIX millisecond epoch.
+// It decodes both string and number JSON values and encodes always to number.
+func UnixMicrosecondsCodec() TimeCodec {
+	return &unixCodec{
+		Unit: time.Microsecond,
+	}
+}
+
+// UnixNanoseconds reads a timestamp from nanoseconds since UNIX epoch.
+// It decodes both string and number JSON values and encodes always to number.
+func UnixNanoseconds(n int64) time.Time {
+	return time.Unix(0, n)
+}
+
+// UnixNanosecondsCodec decodes/encodes a timestamps in UNIX millisecond epoch.
+// It decodes both string and number JSON values and encodes always to number.
+func UnixNanosecondsCodec() TimeCodec {
+	return &unixCodec{
+		Unit: time.Nanosecond,
+	}
+}
+
+type unixCodec struct {
+	Unit time.Duration
+}
+
+func (c *unixCodec) EncodeTime(tm time.Time, stream *jsoniter.Stream) {
+	if tm.IsZero() {
+		stream.WriteNil()
+		return
+	}
+	msec := tm.UnixNano() / int64(c.Unit)
+	stream.WriteInt64(msec)
+}
+
+func (c *unixCodec) DecodeTime(iter *jsoniter.Iterator) (tm time.Time) {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		n := iter.ReadInt64()
+		return time.Unix(0, n*int64(c.Unit))
+	case jsoniter.NilValue:
+		iter.ReadNil()
+		return
+	case jsoniter.StringValue:
+		s := iter.ReadString()
+		if s == "" {
+			return
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			iter.ReportError("ReadUnixTimestamp", err.Error())
+			return
+		}
+		return time.Unix(0, n*int64(c.Unit))
+	default:
+		iter.Skip()
+		iter.ReportError("ReadUnixTimestamp", `invalid JSON value`)
+		return
+	}
+}


### PR DESCRIPTION
## Background

Closes #1511

## Changes

- Adds the ability to use `tcodec:"strftime=%Y-%m-%d" tags to parse JSON timestamps using a custom format defined in [strftime](https://strftime.org/)
- Adds missing codecs for microsecond and nanosecond UNIX timestamps (`unix_us`, `unix_ns`)

## Testing

- Unit tests
