### PR TITLE
Bump version in master stack

### DIFF
--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -154,7 +154,7 @@ Parameters:
 Mappings:
   Constants:
     Panther:
-      Version: v1.9.0-RC1
+      Version: v1.10.0-RC1
 
 Conditions:
   RegistryProvided: !Not [!Equals [!Ref ImageRegistry, '']]


### PR DESCRIPTION
## Background

Again, this is really just testing the sync-to-release functionality, which I forgot to do in #1654 

## Changes

- Bump version in master template to `1.10.0-RC1`
