### PR TITLE
Sync automation: fix release branch base

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           LATEST_RELEASE_BRANCH=$(git branch -r --list "origin/release*" | sort -V -r | head -n 1 | xargs)
           git checkout -b $HEAD $LATEST_RELEASE_BRANCH
+          echo "LATEST_RELEASE_BRANCH=$LATEST_RELEASE_BRANCH" >> $GITHUB_ENV
           git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} || true
           CONFLICTS=$(git diff --name-only --diff-filter=U)
           git add -A .
@@ -108,5 +109,5 @@ jobs:
         with:
           repo: ${{ github.repository }}
           head: ${{ env.HEAD }}
-          base: release
+          base: ${{ env.LATEST_RELEASE_BRANCH }}
           token: ${{ secrets.PR_SYNC_TOKEN }}


### PR DESCRIPTION
## Background

#1652 updated the automation to *checkout* the correct release branch, but when submitting the sync PR, `panther-bot` still set `release` as the branch base: https://github.com/panther-labs/panther/pull/1656

I had to manually change the branch base, and then the PR was fine.

## Changes

- Fix the sync automation: change base branch from `release` to the same versioned release branch that we checked out

According to the [GitHub docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable), the `echo >> $GITHUB_ENV` syntax I'm using allows me to share an environment variable with a future step in the same job

## Testing

We'll see what happens when this PR is merged! GitHub actions seem to be pretty hard to test without just making lots of PRs...
