### PR TITLE
Release sync automation: Strip origin prefix from branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           LATEST_RELEASE_BRANCH=$(git branch -r --list "origin/release*" | sort -V -r | head -n 1 | xargs)
           git checkout -b $HEAD $LATEST_RELEASE_BRANCH
-          echo "LATEST_RELEASE_BRANCH={$LATEST_RELEASE_BRANCH#origin/}" >> $GITHUB_ENV
+          echo "LATEST_RELEASE_BRANCH=${LATEST_RELEASE_BRANCH#origin/}" >> $GITHUB_ENV
           git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} || true
           CONFLICTS=$(git diff --name-only --diff-filter=U)
           git add -A .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           LATEST_RELEASE_BRANCH=$(git branch -r --list "origin/release*" | sort -V -r | head -n 1 | xargs)
           git checkout -b $HEAD $LATEST_RELEASE_BRANCH
-          echo "LATEST_RELEASE_BRANCH=$LATEST_RELEASE_BRANCH" >> $GITHUB_ENV
+          echo "LATEST_RELEASE_BRANCH={$LATEST_RELEASE_BRANCH#origin/}" >> $GITHUB_ENV
           git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} || true
           CONFLICTS=$(git diff --name-only --diff-filter=U)
           git add -A .
@@ -109,5 +109,7 @@ jobs:
         with:
           repo: ${{ github.repository }}
           head: ${{ env.HEAD }}
+          # e.g. "release-1.10": this env variable was set in the previous step,
+          # where the "origin/" prefix was stripped away already
           base: ${{ env.LATEST_RELEASE_BRANCH }}
           token: ${{ secrets.PR_SYNC_TOKEN }}


### PR DESCRIPTION
## Background

Take 3! #1657 was able to get the branch name passed to the PR creation, but because we are listing remote branches, the branch name was `origin/release-1.10` instead of `release-1.10` and the action failed: https://github.com/panther-labs/panther/runs/1200950117?check_suite_focus=true

So now I strip the `origin/` prefix from the branch name before passing the env variable.

## Testing

Verified syntax locally:

```bash
BRANCH="origin/release-1.10"
echo "LATEST_RELEASE_BRANCH=${BRANCH#origin/}"
# LATEST_RELEASE_BRANCH=release-1.10
```