### PR TITLE
Small comment change to trigger release sync again

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters:
     - whitespace
 
   # don't enable:
-  # Formatting (we check for that separately)
+  # Formatting (we autofmt in CI)
   # - gofmt
   # - goimports
   #


### PR DESCRIPTION
## Background

#1658 seemed to work: the `release-1.10` branch was checked out and a PR was attempted, but the last step failed with
> refusing to change .github/workflows/main from GitHub App without the "workflows" permission

I'm hopeful that means any other change will sync correctly. Let's find out!

## Changes

- Fix comment in `.golangci` - we don't "check" formatting, we just do it on behalf of the developer

## Testing

We'll see what happens when this merges!
