### PR TITLE
Added backslash to escape dot in 'github.com'

### DIFF
--- a/tools/mage/gen/gen.go
+++ b/tools/mage/gen/gen.go
@@ -79,7 +79,7 @@ func swaggerClients() error {
 
 	// This import has to be fixed, see below
 	clientImport := regexp.MustCompile(
-		`"github.com/panther-labs/panther/api/gateway/[a-z]+/client/operations"`)
+		`"github\.com/panther-labs/panther/api/gateway/[a-z]+/client/operations"`)
 
 	for _, spec := range specs {
 		dir := filepath.Dir(spec)


### PR DESCRIPTION
## Background

Code Scanning found an insecure regex containing an unescaped period `.` in `github.com`

## Changes

- Added a backslash to regex to denote a literal `.` i.e. `github.com` => `github\.com`

