### PR TITLE
handle case where sns subject is over 100 characters

### DIFF
--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -75,8 +75,7 @@ func (client *OutputClient) Sns(alert *alertModels.Alert, config *outputModels.S
 	}
 
 	title := generateAlertTitle(alert)
-	titleLength := len(title)
-	if titleLength > 100 {
+	if len(title) > 100 {
 		title = title[0:100]
 	}
 

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -74,11 +74,17 @@ func (client *OutputClient) Sns(alert *alertModels.Alert, config *outputModels.S
 		}
 	}
 
+	title := generateAlertTitle(alert)
+	titleLength := len(title)
+	if titleLength > 100 {
+		title = title[0:100]
+	}
+
 	snsMessageInput := &sns.PublishInput{
 		TopicArn: aws.String(config.TopicArn),
 		Message:  aws.String(serializedMessage),
 		// Subject is optional in case the topic is subscribed to Email
-		Subject:          aws.String(generateAlertTitle(alert)),
+		Subject:          aws.String(title),
 		MessageStructure: aws.String("json"),
 	}
 

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -19,6 +19,8 @@ package testutils
  */
 
 import (
+	"errors"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/athena"
@@ -289,6 +291,9 @@ type SnsMock struct {
 
 func (m *SnsMock) Publish(input *sns.PublishInput) (*sns.PublishOutput, error) {
 	args := m.Called(input)
+	if len(aws.StringValue(input.Subject)) > 100 {
+		return nil, errors.New("invalid subject")
+	}
 	return args.Get(0).(*sns.PublishOutput), args.Error(1)
 }
 


### PR DESCRIPTION
## Background

There was a bug in the SNS destination. SNS subjects can only be up to 100 characters in length, but we were only limiting alert titles to 1000 characters in length. I updated specifically the SNS destination to truncate to 100 characters in the subject field. The full (up to 1000 characters) title is still present in the message body.

## Changes

- Truncate subject after 100 characters when sending to SNS

## Testing

- Updated unit test to have a policy name over 100 characters in length, and ensured it was adequately truncated for SNS messages
- Fresh deploy in progress, will update once I verify a message is successfully delivered to an SNS topic even with a 100+ character title.
