### PR TITLE
Bugfix: remove duplicate logType from GraphQL schema

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -105,7 +105,6 @@ input ListAlertsInput {
   status: [AlertStatusesEnum]
   eventCountMin: Int
   eventCountMax: Int
-  logTypes: [String!]
   sortBy: ListAlertsSortFieldsEnum # defaults to `createdAt`
   sortDir: SortDirEnum # defaults to `descending` (always on `createdAt` field)
 }


### PR DESCRIPTION
## Background

Deployments from `master` are failing with:

> stack panther-appsync: AWS::AppSync::GraphQLSchema GraphQLSchema CREATE_FAILED: Schema Creation Status is FAILED with details: Found 1 problem(s) with the schema:
The type 'ListAlertsInput' [@202:1] has declared an input field with a non unique name 'logTypes'.

Turns out there is a duplicate schema field. @3nvi , is there a check we can add to CI to prevent a bug like this from merging again?

This bug is not present in the `release-1.10` branch

## Changes

- Remove duplicate field

## Testing

- Fresh deploy (in progress)
