### PR TITLE
Increase aws sdk retries for rules engine

### DIFF
--- a/internal/log_analysis/rules_engine/src/aws_clients.py
+++ b/internal/log_analysis/rules_engine/src/aws_clients.py
@@ -14,22 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from unittest import mock
+import boto3
+from botocore.config import Config
 
-S3_MOCK = mock.MagicMock()
-DDB_MOCK = mock.MagicMock()
-SNS_MOCK = mock.MagicMock()
+# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
+_BOTO_CONFIG = Config(retries={'max_attempts': 10, 'mode': 'standard'})
 
-
-# pylint: disable=unused-argument
-def mock_to_return(value: str, **kwargs: int) -> mock.MagicMock:
-    if value == 'sns':
-        return SNS_MOCK
-
-    if value == 's3':
-        return S3_MOCK
-
-    if value == 'dynamodb':
-        return DDB_MOCK
-
-    raise Exception('Unexpected value {}'.format(value))
+# AWS Clients
+S3_CLIENT = boto3.client('s3', config=_BOTO_CONFIG)
+SNS_CLIENT = boto3.client('sns', config=_BOTO_CONFIG)
+DDB_CLIENT = boto3.client('dynamodb', config=_BOTO_CONFIG)

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -21,16 +21,15 @@ from io import TextIOWrapper
 from timeit import default_timer
 from typing import Any, Dict, List, Optional, Tuple
 
-import boto3
-
 from .engine import Engine
 from .analysis_api import AnalysisAPIClient
 from .logging import get_logger
 from .output import MatchedEventsBuffer
 from .rule import Rule
+from .aws_clients import S3_CLIENT
 
-_S3_CLIENT = boto3.client('s3')
 _LOGGER = get_logger()
+
 _RULES_ENGINE = Engine(AnalysisAPIClient())
 
 
@@ -145,6 +144,6 @@ def _load_s3_notifications(records: List[Dict[str, Any]]) -> List[Tuple[str, str
 
 # Returns a TextIOWrapper for the S3 data. This makes sure that we don't have to keep all contents of S3 object in memory
 def _load_contents(bucket: str, key: str) -> TextIOWrapper:
-    response = _S3_CLIENT.get_object(Bucket=bucket, Key=key)
+    response = S3_CLIENT.get_object(Bucket=bucket, Key=key)
     gzipped = GzipFile(None, 'rb', fileobj=response['Body'])
     return TextIOWrapper(gzipped)  # type: ignore


### PR DESCRIPTION
## Background

We have occasional alarms due to aws api failures in the rule engine. It is using default settings. This PR increase the retries to 10 and uses a more modern (similar to Golang SDK) implementation for retries.

## Changes

- Added config for retries using "standard' retry mechanism
- Refactored AWS client creation

## Testing

- mage test:ci
- deployed and created an `AlwaysTrue` rule, no errors in CloudWatch and UI displayed the alerts and alert events.
