### PR TITLE
Removed data from trackError for analytics

### DIFF
--- a/web/src/components/utils/AuthContext/AuthContext.tsx
+++ b/web/src/components/utils/AuthContext/AuthContext.tsx
@@ -277,7 +277,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
         trackEvent({ event: EventEnum.SignedIn, src: SrcEnum.Auth });
         onSuccess();
       } catch (err) {
-        trackError({ event: TrackErrorEnum.FailedMfa, src: SrcEnum.Auth, data: err });
+        trackError({ event: TrackErrorEnum.FailedMfa, src: SrcEnum.Auth });
         onError(err as AuthError);
       }
     },

--- a/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
@@ -69,7 +69,7 @@ const ConfigureDestinationPanel: React.FC = () => {
       goToNextStep();
     },
     onError: error => {
-      trackError({ event: TrackErrorEnum.FailedToAddDestination, src: SrcEnum.Destinations, ctx: selectedDestinationType, data: error }); // prettier-ignore
+      trackError({ event: TrackErrorEnum.FailedToAddDestination, src: SrcEnum.Destinations, ctx: selectedDestinationType }); // prettier-ignore
       pushSnackbar({
         variant: 'error',
         title:

--- a/web/src/helpers/analytics.ts
+++ b/web/src/helpers/analytics.ts
@@ -164,21 +164,17 @@ export enum TrackErrorEnum {
   FailedMfa = 'Failed MFA',
 }
 
-interface ErrorEvent {
-  data: any;
-}
-
-interface AddDestinationError extends ErrorEvent {
+interface AddDestinationError {
   event: TrackErrorEnum.FailedToAddDestination;
   src: SrcEnum.Destinations;
   ctx: DestinationTypeEnum;
 }
 
-interface AddRuleError extends ErrorEvent {
+interface AddRuleError {
   event: TrackErrorEnum.FailedToAddRule;
   src: SrcEnum.Rules;
 }
-interface MfaError extends ErrorEvent {
+interface MfaError {
   event: TrackErrorEnum.FailedMfa;
   src: SrcEnum.Auth;
 }
@@ -190,6 +186,5 @@ export const trackError = (payload: TrackError) => {
     type: 'error',
     src: payload.src,
     ctx: 'ctx' in payload ? payload.ctx : null,
-    data: 'data' in payload ? payload.data : null,
   });
 };

--- a/web/src/pages/CreateRule/CreateRule.tsx
+++ b/web/src/pages/CreateRule/CreateRule.tsx
@@ -58,8 +58,7 @@ const CreateRulePage: React.FC = () => {
       trackEvent({ event: EventEnum.AddedRule, src: SrcEnum.Rules });
       history.push(urls.logAnalysis.rules.details(data.addRule.id));
     },
-    onError: err =>
-      trackError({ event: TrackErrorEnum.FailedToAddRule, src: SrcEnum.Rules, data: err }),
+    onError: () => trackError({ event: TrackErrorEnum.FailedToAddRule, src: SrcEnum.Rules }),
   });
 
   const handleSubmit = React.useCallback(


### PR DESCRIPTION
## Background

We shouldn't report error data to our product analytics.

## Changes

- Removed data property from `trackError`

## Testing

- Locally
