### PR TITLE
Sequential mage setup and update dev image version

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -17,4 +17,4 @@ docker run \
     -e AWS_REGION=$(if [ -z "$AWS_REGION" ]; then echo $AWS_DEFAULT_REGION; else echo $AWS_REGION; fi) \
     -it \
     --rm \
-    pantherlabs/panther-development-pack:1.2.1
+    pantherlabs/panther-development-pack:1.8.0


### PR DESCRIPTION
## Background

`mage setup` failed for both @vorillaz and I in the development image (`./dev.sh`) with:

>  18:26:43	INFO	[setup]	pip install requirements.txt to .setup/venv...
ERROR: Could not install packages due to an EnvironmentError: [Errno 5] Input/output error

As best I can tell, this is caused by too many open files or not enough disk space. After a `docker system prune --volumes` (from within the image), it worked for me and has continued to work every time I've tried it since. It always works outside the docker image.

So I don't know for sure if these changes will completely fix the problem we encountered, but they should certainly help. One is to update the `dev.sh` image to the correct version and the other is to change `mage setup` to be sequential. `npm install` and `pip install` running at the same time consumes a ton of resources, it would not surprise me if the two together cause problems in a limited docker environment. 

## Changes

- Bump `./dev.sh` to latest image version
- Change `mage setup` to run each step sequentially. The total clock time is not substantially different in my tests, which makes sense, since I assume both `pip` and `npm` already can work in parallel for their respective installations.

## Testing

- `./dev.sh` then `mage setup`