### PR TITLE
Fixing redirect of successful SQS onboarding

### DIFF
--- a/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -92,7 +92,7 @@ const ValidationPanel: React.FC = () => {
           </AbstractButton>
           <WizardPanel.Actions>
             <Flex direction="column" spacing={4}>
-              <LinkButton to={urls.compliance.sources.list()}>Finish Setup</LinkButton>
+              <LinkButton to={urls.logAnalysis.sources.list()}>Finish Setup</LinkButton>
               {!initialValues.integrationId && (
                 <Link
                   as={AbstractButton}


### PR DESCRIPTION
## Background

SQS onboarding would direct me to the Cloud Security/Sources upon successful completion. 

## Changes

- Fixed redirection

## Testing

- Deployed and verified in my account
