### PR TITLE
Add retryer to datacatalog-updater lambda

### DIFF
--- a/internal/log_analysis/datacatalog_updater/process/setup.go
+++ b/internal/log_analysis/datacatalog_updater/process/setup.go
@@ -20,6 +20,7 @@ package process
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
@@ -28,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/panther-labs/panther/pkg/awsretry"
 )
 
 const (
@@ -47,7 +49,8 @@ var (
 
 func Setup() {
 	envconfig.MustProcess("", &config)
-	awsSession = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(maxRetries)))
+	awsSession = session.Must(session.NewSession(request.WithRetryer(aws.NewConfig().WithMaxRetries(maxRetries),
+		awsretry.NewConnectionErrRetryer(maxRetries))))
 	glueClient = glue.New(awsSession)
 	lambdaClient = lambda.New(awsSession)
 	athenaClient = athena.New(awsSession)

--- a/internal/log_analysis/datacatalog_updater/process/setup.go
+++ b/internal/log_analysis/datacatalog_updater/process/setup.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/kelseyhightower/envconfig"
+
 	"github.com/panther-labs/panther/pkg/awsretry"
 )
 


### PR DESCRIPTION
## Background

Got ticket for "read: connection reset by peer".

## Changes

- Changed to use custom retryer

## Testing

- mage test:ci

