### PR TITLE
Fix generating default dlq name (naming convention changed) in requeue ops tool

### DIFF
--- a/cmd/opstools/requeue/requeue/main.go
+++ b/cmd/opstools/requeue/requeue/main.go
@@ -135,14 +135,13 @@ func validateFlags() {
 		/*
 		  default to our dlq naming convention where:
 		    - a queue is <queue prefix>-queue
-		    - the associated dlq is <queue prefix>-dlq
+		    - the associated dlq is <queue prefix>-<queue>-dlq
 		*/
-		queuePrefix := strings.Replace(*TOQ, "-queue", "", 1)
 		if strings.HasSuffix(*TOQ, ".fifo") { // these must end in fifo
-			baseQueueName := strings.Split(queuePrefix, ".")[0]
+			baseQueueName := strings.Split(*TOQ, ".")[0]
 			*FROMQ = baseQueueName + "-dlq.fifo"
 		} else {
-			*FROMQ = queuePrefix + "-dlq"
+			*FROMQ = *TOQ + "-dlq"
 		}
 
 		if *VERBOSE || *INTERACTIVE {

--- a/cmd/opstools/requeue/requeue/main.go
+++ b/cmd/opstools/requeue/requeue/main.go
@@ -135,7 +135,7 @@ func validateFlags() {
 		/*
 		  default to our dlq naming convention where:
 		    - a queue is <queue prefix>-queue
-		    - the associated dlq is <queue prefix>-<queue>-dlq
+		    - the associated dlq is <queue prefix>-queue-dlq
 		*/
 		if strings.HasSuffix(*TOQ, ".fifo") { // these must end in fifo
 			baseQueueName := strings.Split(*TOQ, ".")[0]


### PR DESCRIPTION
## Background

We changed our q naming convention to always have `-queue` at the end and dlq's end in `-queue-dlq`.

The default "from" q in the `requeue` opstool was not updated.

## Changes

- Update default for from q to current naming convention.

## Testing

- mage test:ci
