### PR TITLE
Avoid errors during self-onboarding

### DIFF
--- a/internal/core/custom_resources/resources/self_registration.go
+++ b/internal/core/custom_resources/resources/self_registration.go
@@ -125,7 +125,6 @@ func getSelfIntegrations(accountID string) (*models.SourceIntegration, *models.S
 	var cloudSecSource, logSource *models.SourceIntegration
 	for _, integration := range listOutput {
 		if integration.AWSAccountID == accountID &&
-			integration.IntegrationLabel == cloudSecLabel &&
 			integration.IntegrationType == models.IntegrationTypeAWSScan {
 
 			cloudSecSource = integration


### PR DESCRIPTION
## Background

We have noticed that sometimes when updating an account, the sources-api will throw an error. The issue can occur in the following scenario: 

1. User deploys Panther for first time. Disabled self on-boarding for cloud security
2. User onboards Panther account manually. 
3. Use enables self-monitoring when updating the account

The above would lead to an error in the sources API like the one below: 
```
{"level":"error","ts":1602342918.492403,"caller":"api/put_integration.go:58","msg":"failed to put integration","application":"panther","requestId":"1fb2b8d0-98b0-4b26-8bb5-7f0b3b6c49df","error":"Source account 123456789012 already onboarded"}
```

The above error is not causing some permanent issue in the system, it is however leading to some false CW Alarm triggers

## Changes

- Update the self-registration process so that it doesn't try to onboard an account to CloudSec if the account is already onboarded. 

## Testing

- Dev environment
