### PR TITLE
Updating max lambda duration for log alert forwarder

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -102,7 +102,7 @@ Mappings:
       Timeout: 60
     AlertsForwarder:
       Memory: 128
-      Timeout: 30
+      Timeout: 60
     LogProcessor:
       # Memory is a parameter above
       Timeout: 900 # max!


### PR DESCRIPTION
## Background

Noticed that very rarely, this Lambda would timeout as it is retrying failed requests to 
## Changes

- List your changes here in more detail

## Testing

- How did you test your change?
