### PR TITLE
Added warning in case we fail to delete SQS messages

### DIFF
--- a/pkg/awsbatch/sqsbatch/delete_message_batch.go
+++ b/pkg/awsbatch/sqsbatch/delete_message_batch.go
@@ -62,8 +62,8 @@ func deleteMessageBatch(sqsClient sqsiface.SQSAPI, queueURL string,
 		Entries:  deleteMessageBatchRequestEntries,
 		QueueUrl: &queueURL,
 	})
-	if err != nil {
-		zap.L().Error("failure deleting sqs messages",
+	if err != nil || len(deleteMessageBatchOutput.Failed) > 0 {
+		zap.L().Warn("failure deleting sqs messages",
 			zap.String("guidance", "failed messages will be reprocessed"),
 			zap.String("queueURL", queueURL),
 			zap.Int("numberOfFailedMessages", len(deleteMessageBatchOutput.Failed)),


### PR DESCRIPTION
## Background

It appears that from time to time we see cases were the log processor fails to delete SQS messages from the queue and they get reprocessed. 
I suspect the issue could be caused by partial failures to delete SQS messages in the BatchDelete operation.

Fixing the error logging (changed it to warning) to check for all SQS message deletion failures. 

## Changes

- Logging a warning if we fail to delete a message from SQS

