### PR TITLE
fix: Alert Delivery text

### DIFF
--- a/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDeliverySection/AlertDeliverySection.test.tsx
+++ b/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDeliverySection/AlertDeliverySection.test.tsx
@@ -65,7 +65,9 @@ describe('AlertDeliveryTable', () => {
 
     const { queryByText } = render(<AlertDeliverySection alert={alert} alertDestinations={[]} />);
 
-    expect(queryByText('No delivery information could be found for this alert')).toBeInTheDocument();
+    expect(
+      queryByText('No delivery information could be found for this alert')
+    ).toBeInTheDocument();
     expect(queryByText('Show History')).not.toBeInTheDocument();
   });
 

--- a/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDeliverySection/AlertDeliverySection.test.tsx
+++ b/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDeliverySection/AlertDeliverySection.test.tsx
@@ -65,7 +65,7 @@ describe('AlertDeliveryTable', () => {
 
     const { queryByText } = render(<AlertDeliverySection alert={alert} alertDestinations={[]} />);
 
-    expect(queryByText('Delivery information could not be retrieved')).toBeInTheDocument();
+    expect(queryByText('No delivery information could be found for this alert')).toBeInTheDocument();
     expect(queryByText('Show History')).not.toBeInTheDocument();
   });
 

--- a/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDeliverySection/AlertDeliverySection.tsx
+++ b/web/src/pages/AlertDetails/AlertDetailsInfo/AlertDeliverySection/AlertDeliverySection.tsx
@@ -96,7 +96,7 @@ const AlertDeliverySection: React.FC<AlertDeliverySectionProps> = ({
     return (
       <Flex align="warning" spacing={4}>
         <Icon type="info" size="medium" color="blue-400" />
-        <Text fontWeight="medium">Delivery information could not be retrieved</Text>
+        <Text fontWeight="medium">No delivery information could be found for this alert</Text>
       </Flex>
     );
   }


### PR DESCRIPTION
## Background

The phrasing used in the Alert Delivery text in the Alert Details page was a bit misleading. This PR makes it a bit more clear

## Changes

- Update phrasing

## Testing

- `npm run test`
