### PR TITLE
Add dependency to UpdateTables resource

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -131,7 +131,9 @@ Resources:
 
   ###### Update Glue Table Schemas for Deployed Tables #####
   UpdateGlueTables:
-    DependsOn: AthenaConfigure
+    DependsOn:
+      - AthenaConfigure
+      - UpdaterFunction
     Type: Custom::UpdateGlueTables
     Properties:
       # Update in case TablesSignature or CustomResourceVersion has changed


### PR DESCRIPTION
## Background

The `UpdateGlueTables` resource on every deployment is triggers the `panther-datacatalog-updater`. As such, it had an un-enforced dependency on the `UpdaterFunction`. This could lead to a race condition were `UpdateGlueTables` with version X would try to invoke `panther-datacatalog-updater` with version X-1 resulting in message drops. 

## Changes

- Added an explicit dependency between CFN resources.

## Testing

- `mage deploy`
