### PR TITLE
Aggelos fix overview tables

### DIFF
--- a/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/TopFailingPoliciesTable.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/TopFailingPoliciesTable.tsx
@@ -42,7 +42,7 @@ const TopFailingPoliciesTable: React.FC<TopFailingPoliciesTableProps> = ({ polic
           <Table.Row key={policy.id}>
             <Table.Cell>{index + 1}</Table.Cell>
             <Table.Cell>
-              <Link as={RRLink} to={urls.compliance.policies.details(policy.id)} py={4} pr={4}>
+              <Link as={RRLink} to={urls.compliance.policies.details(policy.id)} py={4} pr={4} wordBreak="break-all">
                 {policy.id}
               </Link>
             </Table.Cell>

--- a/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/TopFailingPoliciesTable.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/TopFailingPoliciesTable.tsx
@@ -42,7 +42,13 @@ const TopFailingPoliciesTable: React.FC<TopFailingPoliciesTableProps> = ({ polic
           <Table.Row key={policy.id}>
             <Table.Cell>{index + 1}</Table.Cell>
             <Table.Cell>
-              <Link as={RRLink} to={urls.compliance.policies.details(policy.id)} py={4} pr={4} wordBreak="break-all">
+              <Link
+                as={RRLink}
+                to={urls.compliance.policies.details(policy.id)}
+                py={4}
+                pr={4}
+                wordBreak="break-all"
+              >
                 {policy.id}
               </Link>
             </Table.Cell>

--- a/web/src/pages/ComplianceOverview/TopFailingResourcesTable/TopFailingResourcesTable.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingResourcesTable/TopFailingResourcesTable.tsx
@@ -41,7 +41,13 @@ const TopFailingResourcesTable: React.FC<TopFailingResourcesTableProps> = ({ res
             <Table.Cell>{index + 1}</Table.Cell>
 
             <Table.Cell>
-              <Link as={RRLink} to={urls.compliance.resources.details(resource.id)} py={4} pr={4} wordBreak="break-all">
+              <Link
+                as={RRLink}
+                to={urls.compliance.resources.details(resource.id)}
+                py={4}
+                pr={4}
+                wordBreak="break-all"
+              >
                 {resource.id}
               </Link>
             </Table.Cell>

--- a/web/src/pages/ComplianceOverview/TopFailingResourcesTable/TopFailingResourcesTable.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingResourcesTable/TopFailingResourcesTable.tsx
@@ -41,7 +41,7 @@ const TopFailingResourcesTable: React.FC<TopFailingResourcesTableProps> = ({ res
             <Table.Cell>{index + 1}</Table.Cell>
 
             <Table.Cell>
-              <Link as={RRLink} to={urls.compliance.resources.details(resource.id)} py={4} pr={4}>
+              <Link as={RRLink} to={urls.compliance.resources.details(resource.id)} py={4} pr={4} wordBreak="break-all">
                 {resource.id}
               </Link>
             </Table.Cell>


### PR DESCRIPTION
## Background

In Cloud Security overview page, some data cause the tables to overflow. This PR makes sure to force words to wrap( since we have stuff like ARNs which is a **single big word** that can easily overflow) whenever they exceed the available width

## Changes

- Add `word-break: break-all` to links that have large texts

## Testing

- Visually
