### PR TITLE
[Sync] 1.10.1 Bug fixes

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -131,7 +131,9 @@ Resources:
 
   ###### Update Glue Table Schemas for Deployed Tables #####
   UpdateGlueTables:
-    DependsOn: AthenaConfigure
+    DependsOn:
+      - AthenaConfigure
+      - UpdaterFunction
     Type: Custom::UpdateGlueTables
     Properties:
       # Update in case TablesSignature or CustomResourceVersion has changed

--- a/internal/log_analysis/gluetasks/recover.go
+++ b/internal/log_analysis/gluetasks/recover.go
@@ -23,7 +23,6 @@ import (
 	goerr "errors"
 	"fmt"
 	"path"
-	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -79,7 +78,7 @@ func (r *RecoverDatabaseTables) Run(ctx context.Context, glueAPI glueiface.GlueA
 			DatabaseName: &r.DatabaseName,
 		}
 		if r.MatchPrefix != "" {
-			expr := "^" + regexp.QuoteMeta(r.MatchPrefix)
+			expr := r.MatchPrefix + "*"
 			input.Expression = &expr
 		}
 		err := glueAPI.GetTablesPagesWithContext(ctx, &input, func(page *glue.GetTablesOutput, _ bool) bool {

--- a/internal/log_analysis/gluetasks/sync.go
+++ b/internal/log_analysis/gluetasks/sync.go
@@ -21,7 +21,6 @@ package gluetasks
 import (
 	"context"
 	"reflect"
-	"regexp"
 	"sync/atomic"
 	"time"
 
@@ -62,7 +61,7 @@ func (s *SyncDatabaseTables) Run(ctx context.Context, api glueiface.GlueAPI, log
 			DatabaseName: &s.DatabaseName,
 		}
 		if s.MatchPrefix != "" {
-			expr := "^" + regexp.QuoteMeta(s.MatchPrefix)
+			expr := s.MatchPrefix + "*"
 			input.Expression = &expr
 		}
 		log.Info("scanning for tables")


### PR DESCRIPTION
## Background

Syncing #1759 and #1751 into the 1.10 release (they automatically synced to the 1.11 release branch, but we have to manually copy it back to 1.10)

After these fixes, we can publish 1.10.1 from this branch

## Changes

- Fix deploy dependency (git cherry-pick 71ccf54)
- Fix `glue*` tools (git cherry-pick 6807436)
