### PR TITLE
1.10.1: bump version in master template

### DIFF
--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -174,7 +174,7 @@ Parameters:
 Mappings:
   Constants:
     Panther:
-      Version: v1.10.0
+      Version: v1.10.1
 
 Conditions:
   RegistryProvided: !Not [!Equals [!Ref ImageRegistry, '']]


### PR DESCRIPTION
## Background

Forgot to bump the master template version in #1765 (this sort of PR won't be necessary after #1711 )
