### PR TITLE
Fix AppSync for ListAvailableLogTypes

### DIFF
--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -1902,7 +1902,7 @@ Resources:
           "version" : "2017-02-28",
           "operation": "Invoke",
           "payload": $util.toJson({
-            "ListAvailableLogTypes": $ctx.args.input
+            "ListAvailableLogTypes": {}
           })
         }
       ResponseMappingTemplate: |


### PR DESCRIPTION
## Background

ListAvailableLogTypes was not working after backporting cutomlog changes. (The change was missed in the sea of changed files)

No need to sync to release, already fixed there

## Changes

- Forces empty object (`{}`) payload for `ListAvailableLogtypes` endpoint in AppSync resolver

## Testing

- Deployed and tested that FE can retrieve available log types
