### PR TITLE
Alerts API now can filter the alerts by type (Rule matches or Rule errors)

### DIFF
--- a/api/lambda/alerts/models/api.go
+++ b/api/lambda/alerts/models/api.go
@@ -57,6 +57,7 @@ type GetAlertOutput = Alert
 // {
 //     "listAlerts": {
 //         "ruleId": "My.Rule",
+//	    "type" : "RULE_ERROR",
 //         "pageSize": 25,
 //         "exclusiveStartKey": "abcdef",
 //         "severity": ["INFO"],
@@ -82,7 +83,8 @@ type ListAlertsInput struct {
 	ExclusiveStartKey *string `json:"exclusiveStartKey"`
 
 	// Filtering
-	Severity        []*string  `json:"severity" validate:"omitempty,dive,oneof=INFO LOW MEDIUM HIGH CRITICAL"`
+	Type            string     `json:"type" validate:"omitempty,oneof=RULE RULE_ERROR"`
+	Severity        []string   `json:"severity" validate:"omitempty,dive,oneof=INFO LOW MEDIUM HIGH CRITICAL"`
 	NameContains    *string    `json:"nameContains"`
 	Status          []string   `json:"status" validate:"omitempty,dive,oneof=OPEN TRIAGED CLOSED RESOLVED"`
 	CreatedAtBefore *time.Time `json:"createdAtBefore"`

--- a/internal/log_analysis/alerts_api/api/list_alerts_test.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts_test.go
@@ -84,7 +84,7 @@ func TestListAlertsForRule(t *testing.T) {
 		Status:            []string{models.TriagedStatus},
 		PageSize:          aws.Int(10),
 		ExclusiveStartKey: aws.String("startKey"),
-		Severity:          []*string{aws.String("INFO")},
+		Severity:          []string{"INFO"},
 	}
 
 	tableMock.On("ListAll", input).
@@ -106,7 +106,7 @@ func TestListAllAlerts(t *testing.T) {
 		PageSize:          aws.Int(10),
 		ExclusiveStartKey: aws.String("startKey"),
 		Status:            []string{models.TriagedStatus},
-		Severity:          []*string{aws.String("INFO")},
+		Severity:          []string{"INFO"},
 		NameContains:      aws.String("title"),
 		EventCountMin:     aws.Int(0),
 		EventCountMax:     aws.Int(100),

--- a/internal/log_analysis/alerts_api/table/list.go
+++ b/internal/log_analysis/alerts_api/table/list.go
@@ -307,10 +307,12 @@ func filterByType(filter *expression.ConditionBuilder, input *models.ListAlertsI
 		var multiFilter expression.ConditionBuilder
 		switch input.Type {
 		case alertdeliverymodels.RuleErrorType:
-			multiFilter = expression.Name(TypeKey).Contains(input.Type)
+			multiFilter = expression.Equal(expression.Name(TypeKey), expression.Value(input.Type))
 		case alertdeliverymodels.RuleType:
 			// Alerts for rule matches don't always have the attribute specified
-			multiFilter = expression.Name(TypeKey).Contains(input.Type).Or(expression.Name(TypeKey).AttributeNotExists())
+			multiFilter = expression.
+				Equal(expression.Name(TypeKey), expression.Value(input.Type)).
+				Or(expression.Name(TypeKey).AttributeNotExists())
 		default:
 			panic("Uknown type :" + input.Type)
 		}

--- a/internal/log_analysis/alerts_api/table/list.go
+++ b/internal/log_analysis/alerts_api/table/list.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/alerts/models"
+	alertdeliverymodels "github.com/panther-labs/panther/api/lambda/delivery/models"
 )
 
 // ListAll - lists all alerts and apply filtering, sorting logic
@@ -183,9 +184,9 @@ func getLastKey(input *models.ListAlertsInput, item DynamoItem) DynamoItem {
 // getIndex - gets the primary index to query
 func (table *AlertsTable) getIndex(input *models.ListAlertsInput) *string {
 	if input.RuleID != nil {
-		return aws.String(table.RuleIDCreationTimeIndexName)
+		return &table.RuleIDCreationTimeIndexName
 	}
-	return aws.String(table.TimePartitionCreationTimeIndexName)
+	return &table.TimePartitionCreationTimeIndexName
 }
 
 // getKeyCondition - gets the key condition for a query
@@ -229,6 +230,7 @@ func (table *AlertsTable) applyFilters(builder *expression.Builder, input *model
 	filterByStatus(&filter, input)
 	filterByEventCount(&filter, input)
 	filterByLogType(&filter, input)
+	filterByType(&filter, input)
 
 	// Finally, overwrite the existing condition filter on the builder
 	*builder = builder.WithFilter(filter)
@@ -238,11 +240,11 @@ func (table *AlertsTable) applyFilters(builder *expression.Builder, input *model
 func filterBySeverity(filter *expression.ConditionBuilder, input *models.ListAlertsInput) {
 	if len(input.Severity) > 0 {
 		// Start with the first known key
-		multiFilter := expression.Name(SeverityKey).Equal(expression.Value(*input.Severity[0]))
+		multiFilter := expression.Name(SeverityKey).Equal(expression.Value(input.Severity[0]))
 
 		// Then add or conditions starting at a new slice from the second index
 		for _, severityLevel := range input.Severity[1:] {
-			multiFilter = multiFilter.Or(expression.Name(SeverityKey).Equal(expression.Value(*severityLevel)))
+			multiFilter = multiFilter.Or(expression.Name(SeverityKey).Equal(expression.Value(severityLevel)))
 		}
 
 		*filter = filter.And(multiFilter)
@@ -293,6 +295,22 @@ func filterByLogType(filter *expression.ConditionBuilder, input *models.ListAler
 		// Then add or conditions starting at a new slice from the second index
 		for _, logType := range input.LogTypes[1:] {
 			multiFilter = multiFilter.Or(expression.Name(LogTypesKey).Contains(logType))
+		}
+
+		*filter = filter.And(multiFilter)
+	}
+}
+
+// filterByType - filters by the type of the alert
+func filterByType(filter *expression.ConditionBuilder, input *models.ListAlertsInput) {
+	if len(input.Type) > 0 {
+		var multiFilter expression.ConditionBuilder
+		switch input.Type {
+		case alertdeliverymodels.RuleErrorType:
+			multiFilter = expression.Name(TypeKey).Contains(input.Type)
+		case alertdeliverymodels.RuleType:
+			// Alerts for rule matches don't always have the attribute specified
+			multiFilter = expression.Name(TypeKey).Contains(input.Type).Or(expression.Name(TypeKey).AttributeNotExists())
 		}
 
 		*filter = filter.And(multiFilter)

--- a/internal/log_analysis/alerts_api/table/list.go
+++ b/internal/log_analysis/alerts_api/table/list.go
@@ -225,6 +225,9 @@ func (table *AlertsTable) applyFilters(builder *expression.Builder, input *model
 	// Start with an empty filter for a known attribute
 	filter := expression.AttributeExists(expression.Name(AlertIDKey))
 
+	// TODO: It would read better if each of the below methods returned the multifilter and this block of code would `And` the filters
+	// See https://github.com/panther-labs/panther/pull/1790#discussion_r508342774
+	//
 	// Then, apply our filters
 	filterBySeverity(&filter, input)
 	filterByStatus(&filter, input)

--- a/internal/log_analysis/alerts_api/table/list.go
+++ b/internal/log_analysis/alerts_api/table/list.go
@@ -311,6 +311,8 @@ func filterByType(filter *expression.ConditionBuilder, input *models.ListAlertsI
 		case alertdeliverymodels.RuleType:
 			// Alerts for rule matches don't always have the attribute specified
 			multiFilter = expression.Name(TypeKey).Contains(input.Type).Or(expression.Name(TypeKey).AttributeNotExists())
+		default:
+			panic("Uknown type :" + input.Type)
 		}
 
 		*filter = filter.And(multiFilter)

--- a/internal/log_analysis/alerts_api/table/table.go
+++ b/internal/log_analysis/alerts_api/table/table.go
@@ -42,6 +42,7 @@ const (
 	DeliveryResponsesKey = "deliveryResponses"
 	LastUpdatedByKey     = "lastUpdatedBy"
 	LastUpdatedByTimeKey = "lastUpdatedByTime"
+	TypeKey              = "type"
 )
 
 // API defines the interface for the alerts table which can be used for mocking.


### PR DESCRIPTION
## Background
Closes #1749 

Alerts API now can filter the alerts by type (Rule matches or Rule errors). We introduce a new "Type" parameter that lets the users select the API to return `RULE` or `RULE_ERROR` (in the future it could add one filter for policy @s0l0ist )

## Changes

- Added the ability to filter alerts by type

## Testing

- mage test:ci
- Tested E2E (tested also backwards compatibility)
