### PR TITLE
Onboarding Logs validation fix

### DIFF
--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
@@ -26,6 +26,7 @@ import { WizardPanel } from 'Components/Wizard';
 import { pantherConfig } from 'Source/config';
 import logo from 'Assets/sqs-minimal-logo.svg';
 import { useListAvailableLogTypes } from 'Source/graphql/queries/listAvailableLogTypes.generated';
+import { yupIntegrationLabelValidation } from 'Helpers/utils';
 import { SqsLogSourceWizardValues } from '../SqsSourceWizard';
 
 const emptyArray = [];
@@ -105,7 +106,12 @@ const SqsSourceConfigurationPanel: React.FC = () => {
       </Box>
       <WizardPanel.Actions>
         <WizardPanel.ActionNext
-          disabled={(!values.logTypes.length && !values.integrationLabel) || !isValid || !dirty}
+          disabled={
+            (!values.logTypes.length &&
+              !yupIntegrationLabelValidation.isValidSync(values.integrationLabel)) ||
+            !isValid ||
+            !dirty
+          }
         >
           Continue Setup
         </WizardPanel.ActionNext>

--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
@@ -26,13 +26,12 @@ import { WizardPanel } from 'Components/Wizard';
 import { pantherConfig } from 'Source/config';
 import logo from 'Assets/sqs-minimal-logo.svg';
 import { useListAvailableLogTypes } from 'Source/graphql/queries/listAvailableLogTypes.generated';
-import { yupIntegrationLabelValidation } from 'Helpers/utils';
 import { SqsLogSourceWizardValues } from '../SqsSourceWizard';
 
 const emptyArray = [];
 
 const SqsSourceConfigurationPanel: React.FC = () => {
-  const { initialValues, values, isValid, dirty } = useFormikContext<SqsLogSourceWizardValues>();
+  const { initialValues, isValid, dirty } = useFormikContext<SqsLogSourceWizardValues>();
   const { pushSnackbar } = useSnackbar();
   const { data } = useListAvailableLogTypes({
     onError: () => pushSnackbar({ title: "Couldn't fetch your available log types" }),
@@ -105,14 +104,7 @@ const SqsSourceConfigurationPanel: React.FC = () => {
         </ErrorBoundary>
       </Box>
       <WizardPanel.Actions>
-        <WizardPanel.ActionNext
-          disabled={
-            (!values.logTypes.length &&
-              !yupIntegrationLabelValidation.isValidSync(values.integrationLabel)) ||
-            !isValid ||
-            !dirty
-          }
-        >
+        <WizardPanel.ActionNext disabled={!isValid || !dirty}>
           Continue Setup
         </WizardPanel.ActionNext>
       </WizardPanel.Actions>

--- a/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -35,7 +35,7 @@ const ValidationPanel: React.FC = () => {
   const { pushSnackbar } = useSnackbar();
   const [errorMessage, setErrorMessage] = React.useState('');
   const result = React.useRef<AddSqsLogSourceMutationResult | UpdateSqsLogSourceMutationResult>(null); // prettier-ignore
-  const { goToPrevStep, reset: resetWizard, currentStepStatus, setCurrentStepStatus } = useWizardContext(); // prettier-ignore
+  const { reset: resetWizard, currentStepStatus, setCurrentStepStatus } = useWizardContext(); // prettier-ignore
   const { initialValues, submitForm, resetForm } = useFormikContext<SqsLogSourceWizardValues>();
 
   React.useEffect(() => {
@@ -148,11 +148,6 @@ const ValidationPanel: React.FC = () => {
           alt="Validating source health..."
           src={WaitingStatus}
         />
-        <WizardPanel.Actions>
-          <Button variantColor="darkgray" onClick={goToPrevStep}>
-            Cancel
-          </Button>
-        </WizardPanel.Actions>
       </Flex>
     </WizardPanel>
   );

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.test.tsx
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.test.tsx
@@ -37,7 +37,7 @@ describe('CreateSqsLogSource', () => {
     (document.execCommand as jest.MockedFunction<any>).mockClear();
   });
 
-  it('can successfully update an Sqs log source', async () => {
+  it('can successfully create an Sqs log source', async () => {
     const logSource = buildSqsLogSourceIntegration();
     const { logTypes } = logSource.sqsConfig;
 
@@ -97,7 +97,6 @@ describe('CreateSqsLogSource', () => {
 
     // Expect to see a loading animation while the resource is being validated ...
     expect(getByText('Creating an SQS queue')).toBeInTheDocument();
-    expect(getByText('Cancel')).toBeInTheDocument();
 
     // ... replaced by a success screen
     expect(await findByText('An SQS Queue has been created for you!')).toBeInTheDocument();

--- a/web/src/pages/EditSqsLogSource/ΕditSqsLogSource.test.tsx
+++ b/web/src/pages/EditSqsLogSource/ΕditSqsLogSource.test.tsx
@@ -97,7 +97,6 @@ describe('EditSqsLogSource', () => {
 
     // Expect to see a loading animation while the resource is being validated ...
     expect(getByText('Updating your SQS queue')).toBeInTheDocument();
-    expect(getByText('Cancel')).toBeInTheDocument();
 
     // ... replaced by a success screen
     expect(await findByText('Your SQS source was successfully updated')).toBeInTheDocument();


### PR DESCRIPTION
## Background

This PR includes fixes for some bad validation checks for wizards used when onboarding logs.

## Changes

- Correct validation for `integrationLabel`
- Removed misleading button when creating/updating SQS

## Testing

- Locally
