### PR TITLE
Removed error from metrics API

### DIFF
--- a/api/lambda/metrics/models/api.go
+++ b/api/lambda/metrics/models/api.go
@@ -52,8 +52,8 @@ type GetMetricsOutput struct {
 
 // MetricResult is either a single data point or a series of timestamped data points
 type MetricResult = struct {
-	SingleValue []SingleMetric   `json:"singleValue,omitempty"`
-	SeriesData  TimeSeriesMetric `json:"seriesData,omitempty"`
+	SingleValue []SingleMetric   `json:"singleValue"`
+	SeriesData  TimeSeriesMetric `json:"seriesData"`
 }
 
 type SingleMetric struct {

--- a/internal/core/metrics_api/api/get_metrics.go
+++ b/internal/core/metrics_api/api/get_metrics.go
@@ -230,7 +230,7 @@ func getMetricData(input *models.GetMetricsInput, queries []*cloudwatch.MetricDa
 	}
 
 	if len(responses) == 0 {
-		zap.L().Warn("no metrics returned for query", zap.Any("queries", queries))
+		zap.L().Info("no metrics returned for query", zap.Any("queries", queries))
 	}
 
 	return responses, nil

--- a/internal/core/metrics_api/api/get_metrics.go
+++ b/internal/core/metrics_api/api/get_metrics.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	metricsInternalError = &genericapi.InternalError{Message: "Failed to generate requested metrics. Please try again later"}
-	metricResolvers = map[string]func(input *models.GetMetricsInput, output *models.GetMetricsOutput) error{
+	metricResolvers      = map[string]func(input *models.GetMetricsInput, output *models.GetMetricsOutput) error{
 		"alertsByRuleID":   getAlertsByRuleID,
 		"alertsBySeverity": getAlertsBySeverity,
 		"eventsLatency":    getEventsLatency,

--- a/internal/core/metrics_api/api/get_metrics.go
+++ b/internal/core/metrics_api/api/get_metrics.go
@@ -39,8 +39,6 @@ const (
 
 var (
 	metricsInternalError = &genericapi.InternalError{Message: "Failed to generate requested metrics. Please try again later"}
-	metricsNoDataError   = &genericapi.DoesNotExistError{
-		Message: "Could not find data points for the given metric in the selected time period"}
 	metricResolvers = map[string]func(input *models.GetMetricsInput, output *models.GetMetricsOutput) error{
 		"alertsByRuleID":   getAlertsByRuleID,
 		"alertsBySeverity": getAlertsBySeverity,
@@ -229,11 +227,6 @@ func getMetricData(input *models.GetMetricsInput, queries []*cloudwatch.MetricDa
 			zap.L().Error("unable to query metric data", zap.Any("queries", queries), zap.Error(err))
 			return nil, metricsInternalError
 		}
-	}
-
-	if len(responses) == 0 {
-		zap.L().Warn("no metrics returned for query", zap.Any("queries", queries))
-		return nil, metricsNoDataError
 	}
 
 	return responses, nil

--- a/internal/core/metrics_api/api/get_metrics.go
+++ b/internal/core/metrics_api/api/get_metrics.go
@@ -229,5 +229,9 @@ func getMetricData(input *models.GetMetricsInput, queries []*cloudwatch.MetricDa
 		}
 	}
 
+	if len(responses) == 0 {
+		zap.L().Info("no metrics returned for query", zap.Any("queries", queries))
+	}
+
 	return responses, nil
 }

--- a/internal/core/metrics_api/api/get_metrics.go
+++ b/internal/core/metrics_api/api/get_metrics.go
@@ -230,7 +230,7 @@ func getMetricData(input *models.GetMetricsInput, queries []*cloudwatch.MetricDa
 	}
 
 	if len(responses) == 0 {
-		zap.L().Info("no metrics returned for query", zap.Any("queries", queries))
+		zap.L().Warn("no metrics returned for query", zap.Any("queries", queries))
 	}
 
 	return responses, nil


### PR DESCRIPTION
## Background

Closes #1648 

Sometimes Panther will have no data points to report for a specific metric. This is an expected state for the system (I believe) and can happen if someone hasn't enabled some part of the Panther application (e.g. if they haven't onboarded any logs) 

Stop throwing an error if the metrics api doesn't have datapoints for a given metric for a given period. 

## Changes

- Remove error check

## Testing

- mage test:ci
- Pending E2E test
