### PR TITLE
Updating threshold for analysis API

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -366,6 +366,8 @@ Resources:
       AlarmTopicArn: !Ref AlarmTopicArn
       CustomResourceVersion: !Ref CustomResourceVersion
       ServiceToken: !GetAtt CustomResourceFunction.Arn
+      # Listing rules/policies requires scanning the DDB table
+      LatencyThresholdMs: 3000
 
   ComplianceApi:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
## Background

Analysis API is currently doing a DDB scan to retrieve the enabled rules/policies. Seeing sometimes the `/enabled` operation, depending on the number of rules, can to take >1second

## Changes

- Updating threshold


@austinbyers @s0l0ist not sure if there is a reason for greater concern here?
