### PR TITLE
Bugfix for custom-resources lambda

### DIFF
--- a/tools/mage/deploy/deploy.go
+++ b/tools/mage/deploy/deploy.go
@@ -227,7 +227,8 @@ func updateLambdaCode(function, srcPath, runtime string) error {
 	var pathToZip string
 
 	if strings.HasPrefix(runtime, "go") {
-		srcPath = strings.TrimPrefix(srcPath, "out/bin/")
+		srcPath = strings.TrimPrefix(srcPath, "out/")
+		srcPath = strings.TrimPrefix(srcPath, "bin/")
 		log.Infof("compiling %s", srcPath)
 		binary, err := build.LambdaPackage(srcPath)
 		if err != nil {


### PR DESCRIPTION
## Background

#1795 had a bug when deploying the `cfn-custom-resources` lambda directly - this function is in the `bootstrap-gateway` stack, which has to be injected with Swagger before CloudFormation runs, which means the function code path is slightly different from the other stacks.

## Changes

- Instead of stripping `out/bin/`, we now strip `out/` and `bin/` separately. Kind of a hack, but works fine

## Testing

- `LAMBDA=cfn-custom-resources mage deploy`
- `LAMBDA=policy-engine mage deploy` (to make sure this doesn't introduce a Python regression)
- `LAMBDA=log-processor mage deploy` (to make sure this doesn't introduce a Go regression)
