### PR TITLE
Ignore "S3 folder" objects

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -103,6 +103,9 @@ func handleNotificationMessage(notification *SnsNotification) (result []*common.
 		return nil, err
 	}
 	for _, s3Object := range s3Objects {
+		if shouldIgnoreS3Object(s3Object) {
+			continue
+		}
 		var dataStream *common.DataStream
 		dataStream, err = readS3Object(s3Object)
 		if err != nil {
@@ -116,6 +119,12 @@ func handleNotificationMessage(notification *SnsNotification) (result []*common.
 		result = append(result, dataStream)
 	}
 	return result, err
+}
+
+func shouldIgnoreS3Object(s3Object *S3ObjectInfo) bool {
+	// We should ignore S3 objects that end in `/`.
+	// These objects are used in S3 to define a "folder" and do not contain data.
+	return strings.HasSuffix(s3Object.S3ObjectKey, "/")
 }
 
 func readS3Object(s3Object *S3ObjectInfo) (dataStream *common.DataStream, err error) {

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -162,4 +162,30 @@ func TestHandleUnsupportedFileType(t *testing.T) {
 	require.NoError(t, err)
 	// Method should not return data stream
 	require.Equal(t, 0, len(dataStreams))
+	lambdaMock.AssertExpectations(t)
+	s3Mock.AssertExpectations(t)
+}
+
+func TestHandleS3Folder(t *testing.T) {
+	resetCaches()
+
+	//nolint:lll
+	s3Event := "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"1970-01-01T00:00:00.000Z\"," +
+		"\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AIDAJDPLRKLG7UEXAMPLE\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
+		"\"responseElements\":{\"x-amz-request-id\":\"C3D13FE58DE4C810\",\"x-amz-id-2\":\"FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD\"}," +
+		"\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"testConfigRule\"," +
+		"\"bucket\":{\"name\":\"mybucket\",\"ownerIdentity\":{\"principalId\":\"A3NL1KOZZKExample\"},\"arn\":\"arn:aws:s3:::mybucket\"},\"object\":{\"key\":\"test-folder/\",\"size\":1024," +
+		"\"eTag\":\"d41d8cd98f00b204e9800998ecf8427e\",\"versionId\":\"096fKKXTRTtl3on89fVO.nfljtsv6qko\",\"sequencer\":\"0055AED6DCD90281E5\"}}}]}"
+
+	notification := SnsNotification{}
+	notification.Type = "Notification"
+	notification.Message = s3Event
+	marshaledNotification, err := jsoniter.MarshalToString(notification)
+	require.NoError(t, err)
+
+	dataStreams, err := ReadSnsMessages([]string{marshaledNotification})
+	// Method shouldn't return error
+	require.NoError(t, err)
+	// Method should not return data stream
+	require.Equal(t, 0, len(dataStreams))
 }


### PR DESCRIPTION
## Background

An S3 object ending in "/" is a "folder" object. It cannot contain data but it can be used to visually group S3 objects together. 

S3 will send notifications when someone creates an object like this and Log processor would try to process it. Added a check that ignores such objects. 


## Testing

- Added unit test. 
