### PR TITLE
Slight increase in source-api retries

### DIFF
--- a/internal/core/source_api/api/list_integrations.go
+++ b/internal/core/source_api/api/list_integrations.go
@@ -19,6 +19,8 @@ package api
  */
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/panther-labs/panther/api/lambda/source/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
@@ -31,6 +33,7 @@ func (API) ListIntegrations(
 
 	integrationItems, err := dynamoClient.ScanIntegrations(input.IntegrationType)
 	if err != nil {
+		zap.L().Error("failed to list integrations", zap.Error(err))
 		return nil, genericListError
 	}
 

--- a/internal/core/source_api/api/vars.go
+++ b/internal/core/source_api/api/vars.go
@@ -68,11 +68,9 @@ func Setup() {
 	envconfig.MustProcess("", &env)
 
 	awsSession = session.Must(session.NewSession())
-	dynamoClient = ddb.New(env.TableName)
+	dynamoClient = ddb.New(awsSession, env.TableName)
 	sqsClient = sqs.New(awsSession)
-	templateS3Client = s3.New(awsSession, &aws.Config{
-		Region: aws.String(templateBucketRegion),
-	})
+	templateS3Client = s3.New(awsSession, aws.NewConfig().WithRegion(templateBucketRegion))
 	lambdaClient = lambda.New(awsSession)
 }
 

--- a/internal/core/source_api/ddb/ddb.go
+++ b/internal/core/source_api/ddb/ddb.go
@@ -19,6 +19,7 @@ package ddb
  */
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
@@ -35,9 +36,9 @@ type DDB struct {
 }
 
 // New instantiates a new client.
-func New(tableName string) *DDB {
+func New(awsSession *session.Session, tableName string) *DDB {
 	return &DDB{
-		Client:    dynamodb.New(session.Must(session.NewSession())),
+		Client:    dynamodb.New(awsSession, aws.NewConfig().WithMaxRetries(5)),
 		TableName: tableName,
 	}
 }


### PR DESCRIPTION
## Background

Small increase in default number of retries for source-api. Now doing 5 retries (compared to default of 3), so we are retrying for ~5 seconds. 
Source-api is queried by BE and FE services, so need to keep the number of retries to something that would make sense for both. 

## Testing

- test:ci
