### PR TITLE
Increase retries when reading CloudTrail objects from S3

### DIFF
--- a/internal/compliance/aws_event_processor/processor/accounts.go
+++ b/internal/compliance/aws_event_processor/processor/accounts.go
@@ -56,7 +56,7 @@ var (
 
 	// S3 Client used for pulling Log Processor output S3 object.
 	// We want to retry for ~1'
-	s3Client     s3iface.S3API         = s3.New(sess, request.WithRetryer(aws.NewConfig(), awsretry.NewConnectionErrRetryer(10)))
+	s3Client s3iface.S3API = s3.New(sess, request.WithRetryer(aws.NewConfig(), awsretry.NewConnectionErrRetryer(10)))
 )
 
 func resetAccountCache() {

--- a/internal/compliance/aws_event_processor/processor/accounts.go
+++ b/internal/compliance/aws_event_processor/processor/accounts.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
@@ -30,6 +31,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/pkg/awsretry"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
@@ -51,7 +53,10 @@ var (
 	// Setup the clients to talk to the Snapshot API
 	sess                               = session.Must(session.NewSession())
 	lambdaClient lambdaiface.LambdaAPI = lambda.New(sess)
-	s3Svc        s3iface.S3API         = s3.New(sess)
+
+	// S3 Client used for pulling Log Processor output S3 object.
+	// We want to retry for ~1'
+	s3Client     s3iface.S3API         = s3.New(sess, request.WithRetryer(aws.NewConfig(), awsretry.NewConnectionErrRetryer(10)))
 )
 
 func resetAccountCache() {

--- a/internal/compliance/aws_event_processor/processor/handler.go
+++ b/internal/compliance/aws_event_processor/processor/handler.go
@@ -177,7 +177,7 @@ func handleCloudTrail(cloudtrail gjson.Result, changes map[string]*resourceChang
 //
 // Because this data has already been pre-processed, we assume it is in the correct format and return all errors.
 func handleS3Download(object *sources.S3ObjectInfo, changes map[string]*resourceChange) error {
-	logs, err := s3Svc.GetObject(&s3.GetObjectInput{
+	logs, err := s3Client.GetObject(&s3.GetObjectInput{
 		Bucket: &object.S3Bucket,
 		Key:    &object.S3ObjectKey,
 	})

--- a/internal/compliance/aws_event_processor/processor/handler_test.go
+++ b/internal/compliance/aws_event_processor/processor/handler_test.go
@@ -224,7 +224,7 @@ func TestHandleLogCloudTailInvalid(t *testing.T) {
 
 func TestLogProcessorCloudTrail(t *testing.T) {
 	mockS3 := testutils.S3Mock{}
-	s3Svc = &mockS3
+	s3Client = &mockS3
 
 	var dataBuf bytes.Buffer
 	gzipWriter := gzip.NewWriter(&dataBuf)


### PR DESCRIPTION
## Background

Increase retries when reading CloudTrail objects from S3. Found some errors in our logs that could have been avoided. 

## Testing

- mage test:ci
