### PR TITLE
VPC Scanning bug fix

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc.go
@@ -206,7 +206,7 @@ func describeSecurityGroupsVPC(svc ec2iface.EC2API, vpcID *string) (securityGrou
 	}, func(page *ec2.DescribeSecurityGroupsOutput, lastPage bool) bool {
 		for _, securityGroup := range page.SecurityGroups {
 			securityGroups = append(securityGroups, securityGroup.GroupId)
-			if aws.StringValue(securityGroup.GroupName) == "default " {
+			if aws.StringValue(securityGroup.GroupName) == "default" {
 				defaultId = securityGroup.GroupId
 			}
 		}

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc_test.go
@@ -151,6 +151,8 @@ func TestEC2BuildVpcSnapshot(t *testing.T) {
 	assert.Len(t, ec2Snapshot.NetworkAcls, 1)
 	assert.NotEmpty(t, ec2Snapshot.RouteTables)
 	assert.NotEmpty(t, ec2Snapshot.FlowLogs)
+	assert.NotNil(t, ec2Snapshot.DefaultNetworkAclId)
+	assert.NotNil(t, ec2Snapshot.DefaultSecurityGroupId)
 }
 
 func TestEC2PollVpcs(t *testing.T) {


### PR DESCRIPTION
## Background

In a recent change (#1784) I changed how VPC scanning works to include only a list of security group and network acl IDs, and not a full list of embedded security groups and network acls. Policies that needed to consider the contents of a security group while evaluating a VPC would need to use the `resource_lookup` helper.

As a convenience, I pulled up the default security group ID and the default network ACL ID as these elements are frequently more interesting than other security groups/network acls, and having to do 20 resource lookups just to find the default seemed unwieldly. Unfortunately, I mistyped the check for default security groups so this feature is not working as intended. This PR fixes that bug.

## Changes

- Removed an extraneous trailing space

## Testing

- Deployed into my dev account and checked specifically this field in a scanned VPC.
- Added a check to unit testing for this field
<img width="299" alt="Screen Shot 2020-10-21 at 4 52 43 PM" src="https://user-images.githubusercontent.com/49166439/96802043-d9473000-13bd-11eb-9806-658301846093.png">

