### PR TITLE
Change doc branch name

### DIFF
--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -103,8 +103,8 @@ const PANTHER_DOCS_BASE = 'https://docs.runpanther.io';
 
 export const STABLE_PANTHER_VERSION = pantherConfig.PANTHER_VERSION.split('-')[0]; // e.g. "v1.7.1"
 const VERSION_PARTS = STABLE_PANTHER_VERSION.split('.'); // ["v1", "7", "1]
-export const MINOR_PANTHER_VERSION = `${VERSION_PARTS[0]}.${VERSION_PARTS[1]}`; // "v1.7"
-export const PANTHER_DOCS_LINK = `${PANTHER_DOCS_BASE}/v/${MINOR_PANTHER_VERSION}-docs`;
+const MINOR_PANTHER_VERSION = `${VERSION_PARTS[0]}.${VERSION_PARTS[1]}`.replace('v', ''); // "1.7"
+export const PANTHER_DOCS_LINK = `${PANTHER_DOCS_BASE}/v/release-${MINOR_PANTHER_VERSION}`;
 
 export const ANALYSIS_UPLOAD_DOC_URL = `${PANTHER_DOCS_LINK}/user-guide/analysis/panther-analysis-tool#uploading-to-panther`;
 export const CLOUD_SECURITY_REAL_TIME_DOC_URL = `${PANTHER_DOCS_LINK}/cloud-security/setup#configure-real-time-monitoring`;

--- a/web/src/pages/GeneralSettings/__snapshots__/GeneralSettings.test.tsx.snap
+++ b/web/src/pages/GeneralSettings/__snapshots__/GeneralSettings.test.tsx.snap
@@ -705,7 +705,7 @@ exports[`GeneralSettings it renders the general settings page along with the foo
                   You can read more info about our security privacy
                   <a
                     class="panther-32"
-                    href="https://docs.runpanther.io/v/test.undefined-docs/user-guide/help/security-privacy#privacy"
+                    href="https://docs.runpanther.io/v/release-test.undefined/user-guide/help/security-privacy#privacy"
                     rel="noopener noreferrer"
                     target="_blank"
                   >


### PR DESCRIPTION
## Background

Until now, documentation has been built from versioned doc branches, e.g. `v1.11-docs`. But now that we have versioned release branches, e.g. `release-1.11`, the separate doc branch is redundant (and it's a pain to remember to keep it up to date).

I've updated our GitBook settings to sync `release-X` branches; this PR is just changing the base doc link in the web app to have the new branch name

Closes: https://github.com/panther-labs/panther-enterprise/issues/944

## Changes

- `docs.runpanther.io/v/v1.11-docs` => `docs.runpanther.io/v/release-1.11` (I like this link better anyway)

## Testing

- Deploying now and will verify doc links work in web app
