### PR TITLE
Feat: use pounce's `Popover` for filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7425,6 +7425,14 @@
       "requires": {
         "node-fetch": "2.6.0",
         "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
+        }
       }
     },
     "cross-spawn": {
@@ -8240,24 +8248,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -10363,9 +10353,9 @@
           },
           "dependencies": {
             "node-fetch": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-              "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
               "dev": true
             }
           }
@@ -11651,7 +11641,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.5",
@@ -11721,13 +11712,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -16105,12 +16092,6 @@
       "requires": {
         "semver": "^5.4.1"
       }
-    },
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
     },
     "node-forge": {
       "version": "0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1647,9 +1647,9 @@
           "integrity": "sha512-W9YjlRRq8ImIARa3iHlmDnJIBcuUoVciML767eAO42bZnWkrYLSBssbjTVWiAUJ9AQn1WZR+L3TFlPYXI7NWmA=="
         },
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         }
       }
     },
@@ -1720,9 +1720,9 @@
           "integrity": "sha512-W9YjlRRq8ImIARa3iHlmDnJIBcuUoVciML767eAO42bZnWkrYLSBssbjTVWiAUJ9AQn1WZR+L3TFlPYXI7NWmA=="
         },
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         }
       }
     },
@@ -4481,9 +4481,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         }
       }
     },
@@ -4496,9 +4496,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         }
       }
     },
@@ -7425,14 +7425,6 @@
       "requires": {
         "node-fetch": "2.6.0",
         "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
-        }
       }
     },
     "cross-spawn": {
@@ -8248,6 +8240,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -10353,9 +10363,9 @@
           },
           "dependencies": {
             "node-fetch": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+              "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
               "dev": true
             }
           }
@@ -11641,8 +11651,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.5",
@@ -11712,9 +11721,13 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
         }
       }
     },
@@ -12056,9 +12069,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+          "integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
@@ -12116,14 +12129,14 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-diff": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
-          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+          "integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.5.2"
+            "pretty-format": "^26.6.1"
           }
         },
         "jest-get-type": {
@@ -12132,26 +12145,31 @@
           "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
         },
         "jest-matcher-utils": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
-          "integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+          "integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^26.5.2",
+            "jest-diff": "^26.6.1",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.5.2"
+            "pretty-format": "^26.6.1"
           }
         },
         "pretty-format": {
-          "version": "26.5.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+          "integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
           "requires": {
-            "@jest/types": "^26.5.2",
+            "@jest/types": "^26.6.1",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -16088,6 +16106,12 @@
         "semver": "^5.4.1"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
@@ -16959,13 +16983,14 @@
       "dev": true
     },
     "pouncejs": {
-      "version": "0.71.1",
-      "resolved": "https://registry.npmjs.org/pouncejs/-/pouncejs-0.71.1.tgz",
-      "integrity": "sha512-CKcFTltFInMW8Kle5g40vllFhQKx0UJdYssIRJwJsRMpX8y2WCyttCAkLMaKHT4PArmJMP1odY2Y095at5TqIw==",
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/pouncejs/-/pouncejs-0.73.0.tgz",
+      "integrity": "sha512-uRgTAiDfjqqMc1JrDClxrveZ/44WwLrITl3zIShA2/9y/Ke6tjhrUFtCPAWuAY/QROeXuoaTuJXo63FivNA6QQ==",
       "requires": {
         "@emotion/react": "^11.0.0-next.12",
         "@emotion/styled": "^11.0.0-next.12",
         "@juggle/resize-observer": "^3.2.0",
+        "@reach/auto-id": "^0.11.2",
         "@reach/dialog": "^0.11.2",
         "@reach/menu-button": "^0.11.2",
         "@reach/popover": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "linkifyjs": "^2.1.9",
     "lodash": "^4.17.19",
     "mixpanel-browser": "^2.39.0",
-    "pouncejs": "^0.71.1",
+    "pouncejs": "^0.73.0",
     "qrcode.react": "^1.0.0",
     "query-string": "^6.10.1",
     "react": "^16.12.0",

--- a/web/src/components/Navigation/ProfileIcon/ProfileIcon.test.tsx
+++ b/web/src/components/Navigation/ProfileIcon/ProfileIcon.test.tsx
@@ -35,7 +35,7 @@ test('opens menu on click with correct entries', () => {
   fireEvent.mouseDown(getByAriaLabel('Toggle User Menu'));
 
   // Find proper static data
-  const menuElement = getByRole('menu');
+  const menuElement = getByRole('tooltip');
   expect(menuElement).toHaveTextContent(getUserDisplayName(userInfo));
   expect(menuElement).toHaveTextContent(userInfo.email);
 

--- a/web/src/components/Navigation/ProfileIcon/ProfileIcon.tsx
+++ b/web/src/components/Navigation/ProfileIcon/ProfileIcon.tsx
@@ -18,9 +18,9 @@
 
 import React from 'react';
 import {
-  Dropdown,
-  DropdownButton,
-  DropdownMenu,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
   Divider,
   Box,
   Text,
@@ -28,6 +28,7 @@ import {
   AbstractButton,
   Flex,
   Img,
+  Card,
 } from 'pouncejs';
 import useAuth from 'Hooks/useAuth';
 import { UserInfo } from 'Components/utils/AuthContext';
@@ -63,15 +64,15 @@ const ProfileIcon: React.FC = () => {
   const { showModal } = useModal();
 
   return (
-    <Dropdown>
-      {({ isExpanded }) => (
+    <Popover>
+      {({ isOpen, close: closePopover }) => (
         <React.Fragment>
-          <DropdownButton
+          <PopoverTrigger
             as={AbstractButton}
             display="flex"
             width={40}
             height={40}
-            backgroundColor={isExpanded ? 'violet-400' : 'violet-500'}
+            backgroundColor={isOpen ? 'violet-400' : 'violet-500'}
             _hover={{ backgroundColor: 'violet-400' }}
             transition="background-color 0.1s linear"
             borderRadius="circle"
@@ -82,44 +83,62 @@ const ProfileIcon: React.FC = () => {
             aria-label="Toggle User Menu"
           >
             {getUserInitials(userInfo).toUpperCase()}
-          </DropdownButton>
-          <DropdownMenu alignment="right" transform="translate(65px, -65px)">
-            <Box p={6} minWidth={240} backgroundColor="navyblue-400" fontSize="medium">
-              <Text>{getUserDisplayName(userInfo)}</Text>
-              <Link external href={`mailto:${userInfo.email}`}>
-                {userInfo.email}
-              </Link>
-              <Divider mt={6} mb={3} color="navyblue-200" />
-              <Box mb={2} mx={-2}>
-                <AbstractButton
-                  p={2}
-                  onClick={() => showModal({ modal: MODALS.EDIT_PROFILE_SETTINGS })}
-                >
-                  Profile Settings
-                </AbstractButton>
-              </Box>
-              <Box mx={-2}>
-                <AbstractButton p={2} onClick={() => signOut({ global: true, onError: alert })}>
-                  Log Out
-                </AbstractButton>
-              </Box>
-            </Box>
-            <Flex
-              as="footer"
-              justify="center"
-              backgroundColor="navyblue-600"
-              p={3}
-              mt={-2}
-              fontSize="small"
-              fontStyle="italic"
+          </PopoverTrigger>
+          <PopoverContent alignment="right-bottom">
+            <Card
+              mx={20}
+              my={-12}
+              shadow="dark300"
+              minWidth={240}
+              fontSize="medium"
+              overflow="hidden"
             >
-              <Img src={PantherIcon} alt="Panther logo" nativeWidth={16} nativeHeight={16} mr={2} />
-              Panther&nbsp;<b>{STABLE_PANTHER_VERSION}</b>
-            </Flex>
-          </DropdownMenu>
+              <Box p={6}>
+                <Text>{getUserDisplayName(userInfo)}</Text>
+                <Link external href={`mailto:${userInfo.email}`}>
+                  {userInfo.email}
+                </Link>
+                <Divider mt={6} mb={3} color="navyblue-200" />
+                <Box mb={2} mx={-2}>
+                  <AbstractButton
+                    p={2}
+                    onClick={() => {
+                      showModal({ modal: MODALS.EDIT_PROFILE_SETTINGS });
+                      closePopover();
+                    }}
+                  >
+                    Profile Settings
+                  </AbstractButton>
+                </Box>
+                <Box mx={-2}>
+                  <AbstractButton p={2} onClick={() => signOut({ global: true, onError: alert })}>
+                    Log Out
+                  </AbstractButton>
+                </Box>
+              </Box>
+              <Flex
+                as="footer"
+                justify="center"
+                backgroundColor="navyblue-600"
+                p={3}
+                mt={-2}
+                fontSize="small"
+                fontStyle="italic"
+              >
+                <Img
+                  src={PantherIcon}
+                  alt="Panther logo"
+                  nativeWidth={16}
+                  nativeHeight={16}
+                  mr={2}
+                />
+                Panther&nbsp;<b>{STABLE_PANTHER_VERSION}</b>
+              </Flex>
+            </Card>
+          </PopoverContent>
         </React.Fragment>
       )}
-    </Dropdown>
+    </Popover>
   );
 };
 

--- a/web/src/pages/ListAlerts/ListAlertFilters/DropdownFilters.tsx
+++ b/web/src/pages/ListAlerts/ListAlertFilters/DropdownFilters.tsx
@@ -18,8 +18,16 @@
 
 import React from 'react';
 import { Form, Formik, FastField } from 'formik';
-import { Box, SimpleGrid, Button, Dropdown, DropdownButton, DropdownMenu, Flex } from 'pouncejs';
-
+import {
+  Box,
+  SimpleGrid,
+  Button,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Flex,
+  Card,
+} from 'pouncejs';
 import { ListAlertsInput, SeverityEnum, AlertStatusesEnum } from 'Generated/schema';
 import useRequestParamsWithoutPagination from 'Hooks/useRequestParamsWithoutPagination';
 import { capitalize } from 'Helpers/utils';
@@ -61,74 +69,80 @@ const DropdownFilters: React.FC = () => {
     .length;
 
   return (
-    <Dropdown>
-      <DropdownButton
-        as={Button}
-        iconAlignment="right"
-        icon="filter-light"
-        aria-label="Additional Filters"
-      >
-        Filters {filtersCount ? `(${filtersCount})` : ''}
-      </DropdownButton>
-      <DropdownMenu>
-        <Box p={6} pb={4} backgroundColor="navyblue-400" minWidth={425}>
-          <Formik<ListAlertsDropdownFiltersValues>
-            onSubmit={updateRequestParams}
-            initialValues={initialDropdownFilters}
+    <Popover>
+      {({ close: closePopover }) => (
+        <React.Fragment>
+          <PopoverTrigger
+            as={Button}
+            iconAlignment="right"
+            icon="filter-light"
+            aria-label="Additional Filters"
           >
-            <Form>
-              <Box pb={4}>
-                <FastField
-                  name="status"
-                  as={FormikMultiCombobox}
-                  items={statusOptions}
-                  itemToString={filterItemToString}
-                  label="Status"
-                />
-              </Box>
-              <Box pb={4}>
-                <FastField
-                  name="severity"
-                  as={FormikMultiCombobox}
-                  items={severityOptions}
-                  itemToString={filterItemToString}
-                  label="Severity"
-                />
-              </Box>
-              <SimpleGrid columns={2} gap={4} pb={4}>
-                <FastField
-                  name="eventCountMin"
-                  as={FormikTextInput}
-                  type="number"
-                  min={0}
-                  label="Min Events"
-                />
-                <FastField
-                  name="eventCountMax"
-                  as={FormikTextInput}
-                  type="number"
-                  min={0}
-                  label="Max Events"
-                />
-              </SimpleGrid>
-              <Flex direction="column" justify="center" align="center" spacing={4}>
-                <Box>
-                  <Button type="submit">Apply Filters</Button>
-                </Box>
-                <TextButton
-                  role="button"
-                  onClick={() => {
-                    updateRequestParams(defaultValues);
-                  }}
-                >
-                  Clear All Filters
-                </TextButton>
-              </Flex>
-            </Form>
-          </Formik>
-        </Box>
-      </DropdownMenu>
-    </Dropdown>
+            Filters {filtersCount ? `(${filtersCount})` : ''}
+          </PopoverTrigger>
+          <PopoverContent alignment="bottom-left">
+            <Card shadow="dark300" my={14} p={6} pb={4} minWidth={425}>
+              <Formik<ListAlertsDropdownFiltersValues>
+                onSubmit={updateRequestParams}
+                initialValues={initialDropdownFilters}
+              >
+                <Form>
+                  <Box pb={4}>
+                    <FastField
+                      name="status"
+                      as={FormikMultiCombobox}
+                      items={statusOptions}
+                      itemToString={filterItemToString}
+                      label="Status"
+                    />
+                  </Box>
+                  <Box pb={4}>
+                    <FastField
+                      name="severity"
+                      as={FormikMultiCombobox}
+                      items={severityOptions}
+                      itemToString={filterItemToString}
+                      label="Severity"
+                    />
+                  </Box>
+                  <SimpleGrid columns={2} gap={4} pb={4}>
+                    <FastField
+                      name="eventCountMin"
+                      as={FormikTextInput}
+                      type="number"
+                      min={0}
+                      label="Min Events"
+                    />
+                    <FastField
+                      name="eventCountMax"
+                      as={FormikTextInput}
+                      type="number"
+                      min={0}
+                      label="Max Events"
+                    />
+                  </SimpleGrid>
+                  <Flex direction="column" justify="center" align="center" spacing={4}>
+                    <Box>
+                      <Button type="submit" onClick={closePopover}>
+                        Apply Filters
+                      </Button>
+                    </Box>
+                    <TextButton
+                      role="button"
+                      onClick={() => {
+                        updateRequestParams(defaultValues);
+                      }}
+                    >
+                      Clear All Filters
+                    </TextButton>
+                  </Flex>
+                </Form>
+              </Formik>
+            </Card>
+          </PopoverContent>
+        </React.Fragment>
+      )}
+    </Popover>
   );
 };
 

--- a/web/src/pages/ListRules/ListRulesFilters/DropdownFilters.tsx
+++ b/web/src/pages/ListRules/ListRulesFilters/DropdownFilters.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { Form, Formik, Field } from 'formik';
-import { Box, Flex, Button, Dropdown, DropdownButton, DropdownMenu } from 'pouncejs';
+import { Box, Flex, Button, Popover, PopoverTrigger, PopoverContent, Card } from 'pouncejs';
 import { ListRulesInput, SeverityEnum } from 'Generated/schema';
 import useRequestParamsWithPagination from 'Hooks/useRequestParamsWithPagination';
 import isUndefined from 'lodash/isUndefined';
@@ -53,8 +53,8 @@ const DropdownFilters: React.FC = () => {
     .length;
 
   return (
-    <Dropdown>
-      <DropdownButton
+    <Popover>
+      <PopoverTrigger
         as={Button}
         iconAlignment="right"
         icon="filter-light"
@@ -62,10 +62,11 @@ const DropdownFilters: React.FC = () => {
         aria-label="Rule Options"
       >
         Filters {filtersCount ? `(${filtersCount})` : ''}
-      </DropdownButton>
-      <DropdownMenu>
-        <Box p={6} pb={4} backgroundColor="navyblue-400" minWidth={425}>
+      </PopoverTrigger>
+      <PopoverContent>
+        <Card shadow="dark300" my={14} p={6} pb={4} backgroundColor="navyblue-400" minWidth={425}>
           <Formik<ListAlertsDropdownFiltersValues>
+            enableReinitialize
             onSubmit={(values: ListAlertsDropdownFiltersValues) => {
               updateRequestParamsAndResetPaging(values);
             }}
@@ -110,9 +111,9 @@ const DropdownFilters: React.FC = () => {
               </Flex>
             </Form>
           </Formik>
-        </Box>
-      </DropdownMenu>
-    </Dropdown>
+        </Card>
+      </PopoverContent>
+    </Popover>
   );
 };
 


### PR DESCRIPTION

## Background

This PR replaces `Dropdown` usages that don't relate to menu buttons, with `Popover` which provides a more customized experience to the developer

## Changes

- Replace `Dropdown` with `Popover`


## Screenshots

<img width="331" alt="Screen Shot 2020-10-23 at 5 52 22 PM" src="https://user-images.githubusercontent.com/10436045/97019190-b309c780-1558-11eb-8bf8-bd685b81c4c9.png">
<img width="1359" alt="Screen Shot 2020-10-23 at 5 52 38 PM" src="https://user-images.githubusercontent.com/10436045/97019196-b4d38b00-1558-11eb-9853-85e2d15df340.png">
<img width="1640" alt="Screen Shot 2020-10-23 at 5 53 06 PM" src="https://user-images.githubusercontent.com/10436045/97019201-b69d4e80-1558-11eb-9f83-e65a03223b10.png">


## Testing

- `npm run test`
