### PR TITLE
Override `.env` variables for Jest

### DIFF
--- a/web/__tests__/env.ts
+++ b/web/__tests__/env.ts
@@ -17,9 +17,9 @@
  */
 
 import path from 'path';
-import { loadDotEnvVars, getAppTemplateParams } from '../scripts/utils';
+import { overrideDotEnvVars, getAppTemplateParams } from '../scripts/utils';
 
-loadDotEnvVars(path.resolve(__dirname, '.env.test'));
+overrideDotEnvVars(path.resolve(__dirname, '.env.test'));
 /**
  * Mock the server-side EJS-injected AWS configuration.
  * See `web/public/index.ejs`

--- a/web/scripts/utils.js
+++ b/web/scripts/utils.js
@@ -18,6 +18,15 @@
 
 const dotenv = require('dotenv');
 const chalk = require('chalk');
+const fs = require('fs');
+
+function overrideDotEnvVars(path) {
+  const envConfig = dotenv.parse(fs.readFileSync(path));
+  // eslint-disable-next-line
+  for (const k in envConfig) {
+    process.env[k] = envConfig[k];
+  }
+}
 
 function loadDotEnvVars(path) {
   const dotenvResult = dotenv.config({ path });
@@ -57,4 +66,9 @@ const getCacheControlForFileType = filepath => {
   return 'no-cache';
 };
 
-module.exports = { loadDotEnvVars, getAppTemplateParams, getCacheControlForFileType };
+module.exports = {
+  overrideDotEnvVars,
+  loadDotEnvVars,
+  getAppTemplateParams,
+  getCacheControlForFileType,
+};


### PR DESCRIPTION
## Background

For our specs running, we are using the `dotenv` npm module to load some test environmental variables. Unfortunately, lots of us have some values hardcoded and it causes hiccups and flakiness to some test scenarios. This PR introduces `env` variables overrides **just** for our test suite.

## How to reproduce this one
Run `AWS_REGION="FOO" npm run test web/src/pages/GeneralSettings/GeneralSettings.test.tsx` and you may witness a failure from snapshot testing since `AWS_REGION` gets overridden by the call site.

## Testing
``
