### PR TITLE
Make auto remediations more consistent

### DIFF
--- a/internal/compliance/alert_processor/processor/processor.go
+++ b/internal/compliance/alert_processor/processor/processor.go
@@ -189,7 +189,7 @@ func triggerAlert(event *models.ComplianceNotification) (canRemediate bool, err 
 		aerr, ok := err.(awserr.Error)
 		if ok && aerr.Code() == dynamodb.ErrCodeConditionalCheckFailedException {
 			zap.L().Debug("update on ddb failed on condition, we will not trigger an alert")
-			return false, nil
+			return canRemediate, nil
 		}
 		return false, errors.Wrapf(err, "experienced issue while updating ddb table for policy: %s", event.PolicyID)
 	}


### PR DESCRIPTION
## Background

Auto remediations would not fire in the alert suppress window. This is not working as intended; the auto remediations should trigger on a per resource basis regardless of whether alerts are being sent or not. We already have a separate check in place that ensures we don't repeatedly try (and fail) to remediate a failing resource.

This elusive bug has plagued the last few release tests, because it will _sometimes_ work, depending on how many times you try and how long you wait.

## Changes

- Still attempt auto remediations if auto remediations are enabled and we are in the alert suppress window.

## Testing

- No testing, but I eyeballed the code really hard to be sure :) I can test if someone really wants me to...