### PR TITLE
Fix config issues with recent refactor of alerts_api

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -201,8 +201,8 @@ Resources:
         Variables:
           DEBUG: !Ref Debug
           ALERTS_TABLE_NAME: !Ref LogAlertsTable
-          RULE_INDEX_NAME: ruleId-creationTime-index
-          TIME_INDEX_NAME: timePartition-creationTime-index
+          ALERTS_RULE_INDEX_NAME: ruleId-creationTime-index
+          ALERTS_TIME_INDEX_NAME: timePartition-creationTime-index
           ANALYSIS_API_HOST: !Sub '${AnalysisApiId}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
           ANALYSIS_API_PATH: v1
           PROCESSED_DATA_BUCKET: !Ref ProcessedDataBucket

--- a/internal/log_analysis/alerts_api/api/api.go
+++ b/internal/log_analysis/alerts_api/api/api.go
@@ -60,6 +60,7 @@ func Setup() *API {
 		awsSession: awsSession,
 		alertsDB:   env.NewAlertsTable(dynamodb.New(awsSession)),
 		s3Client:   s3.New(awsSession),
+		env:        env,
 	}
 
 	return api


### PR DESCRIPTION
## Background

This fixes some missing config in the backport of the [refactor of the alerts api](russ-fix-alerts-api-env-vars)

## Changes

- Fix env for alerts_api

## Testing

- mage test:ci
- mage deploy plus created rule + alerts and viewed
- Alex tested patch
