### PR TITLE
Fixing issue with alert merging

### DIFF
--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -207,9 +207,9 @@ func (h *Handler) sendAlertNotification(rule *ruleModel.Rule, alertDedup *AlertD
 		Version:      &alertDedup.RuleVersion,
 	}
 
-	if len(alertDedup.AlertContext) > 0 {
+	if alertDedup.AlertContext != nil {
 		var context map[string]interface{}
-		err := jsoniter.UnmarshalFromString(alertDedup.AlertContext, &context)
+		err := jsoniter.UnmarshalFromString(*alertDedup.AlertContext, &context)
 		if err != nil {
 			// best effort
 			zap.L().Warn("failed to unmarshal alert context", zap.Error(err))

--- a/internal/log_analysis/alert_forwarder/forwarder/models_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/models_test.go
@@ -39,7 +39,7 @@ func TestConvertAttribute(t *testing.T) {
 		LogTypes:            []string{"Log.Type.1", "Log.Type.2"},
 		GeneratedTitle:      aws.String("test title"),
 		Type:                aws.String("RULE_ERROR"),
-		AlertContext:        "{}",
+		AlertContext:        aws.String("{}"),
 	}
 
 	alertDedupEvent, err := FromDynamodDBAttribute(getNewTestCase())
@@ -62,7 +62,7 @@ func TestConvertAttributeWithoutOptionalFields(t *testing.T) {
 		CreationTime:        time.Unix(1582285279, 0).UTC(),
 		UpdateTime:          time.Unix(1582285280, 0).UTC(),
 		EventCount:          100,
-		AlertContext:        "{}",
+		AlertContext:        aws.String("{}"),
 		LogTypes:            []string{"Log.Type.1", "Log.Type.2"},
 	}
 

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -88,7 +88,10 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     2. This rule with the same dedup string has fired before, but after the dedup period has expired
     """
     condition_expression = '(#1 < :1) OR (attribute_not_exists(#2))'
-    update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
+    update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10'
+
+    if group_info.alert_context:
+        update_expression += ', #11=:11'
 
     if group_info.title:
         update_expression += ', #12=:12'

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -107,8 +107,11 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
         '#8': _ALERT_EVENT_COUNT,
         '#9': _ALERT_LOG_TYPES,
         '#10': _RULE_VERSION_ATTR_NAME,
-        '#11': _ALERT_CONTEXT,
     }
+
+    if group_info.alert_context:
+        expresion_attribute_names['#11'] = _ALERT_CONTEXT
+
     if group_info.title:
         expresion_attribute_names['#12'] = _ALERT_TITLE
 
@@ -145,10 +148,11 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
         ':10': {
             'S': group_info.rule_version
         },
-        ':11': {
-            'S': group_info.alert_context
-        },
     }
+
+    if group_info.alert_context:
+        expression_attribute_values[':11'] = {'S': group_info.alert_context}
+
     if group_info.title:
         expression_attribute_values[':12'] = {'S': group_info.title}
 

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -91,10 +91,10 @@ def _update_get_conditional(group_info: MatchingGroupInfo) -> AlertInfo:
     update_expression = 'ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
 
     if group_info.title:
-        update_expression += ', #11=:11'
+        update_expression += ', #12=:12'
 
     if group_info.is_rule_error:
-        update_expression += ', #12=:12'
+        update_expression += ', #13=:13'
 
     expresion_attribute_names = {
         '#1': _ALERT_CREATION_TIME_ATTR_NAME,

--- a/internal/log_analysis/rules_engine/tests/test_output.py
+++ b/internal/log_analysis/rules_engine/tests/test_output.py
@@ -48,7 +48,8 @@ class TestMatchedEventsBuffer(TestCase):
             dedup='dedup',
             dedup_period_mins=100,
             alert_context='{"key":"value"}',
-            event={'data_key': 'data_value'}
+            event={'data_key': 'data_value'},
+            title='test title'
         )
         buffer.add_event(event_match)
 
@@ -70,7 +71,8 @@ class TestMatchedEventsBuffer(TestCase):
                 '#8': 'eventCount',
                 '#9': 'logTypes',
                 '#10': 'ruleVersion',
-                '#11': 'context'
+                '#11': 'context',
+                '#12': 'title'
             },
             ExpressionAttributeValues={
                 ':1': {
@@ -102,6 +104,9 @@ class TestMatchedEventsBuffer(TestCase):
                 },
                 ':11': {
                     'S': '{"key":"value"}'
+                },
+                ':12': {
+                    'S': 'test title'
                 }
             },
             Key={
@@ -112,7 +117,7 @@ class TestMatchedEventsBuffer(TestCase):
             },
             ReturnValues='ALL_NEW',
             TableName='table_name',
-            UpdateExpression='ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11'
+            UpdateExpression='ADD #3 :3\nSET #4=:4, #5=:5, #6=:6, #7=:7, #8=:8, #9=:9, #10=:10, #11=:11, #12=:12'
         )
 
         S3_MOCK.put_object.assert_called_once_with(Body=mock.ANY, Bucket='s3_bucket', ContentType='gzip', Key=mock.ANY)


### PR DESCRIPTION
## Background

Fixing issue with alert merging. Rules Engine was not handling properly rules without alert context method specified. 

## Changes

- Fixing bug in the issue

## Testing

- unit tests
- Deploymed master, seen the bug, Deployed fix not seeing it anymore
