### PR TITLE
Revert the change to the log processor glue customer resource id

### DIFF
--- a/internal/core/custom_resources/resources/log_processor_tables.go
+++ b/internal/core/custom_resources/resources/log_processor_tables.go
@@ -46,7 +46,7 @@ func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (strin
 	switch event.RequestType {
 	case cfn.RequestCreate, cfn.RequestUpdate:
 		// It's important to always return this physicalResourceID
-		const physicalResourceID = "custom:glue:update-log-processor-tables"
+		const physicalResourceID = "custom:glue:update-tables" // NOTE: this can NEVER be changed!
 		var props UpdateLogProcessorTablesProperties
 		if err := parseProperties(event.ResourceProperties, &props); err != nil {
 			zap.L().Error("failed to parse resource properties", zap.Error(err))

--- a/internal/core/custom_resources/resources/map.go
+++ b/internal/core/custom_resources/resources/map.go
@@ -100,7 +100,7 @@ var CustomResources = map[string]cfn.CustomResourceFunction{
 	// Parameters:
 	//    DeploymentId:  string (required)
 	// Outputs: None
-	// PhysicalId: custom:glue:update-log-processor-tables
+	// PhysicalId: custom:glue:update-tables
 	"Custom::UpdateLogProcessorTables": customUpdateLogProcessorTables,
 
 	// Updates databases and table schemas from the cloud security


### PR DESCRIPTION
## Background

Reverts the physical resource id for the log processor glue custom resource. These ids can never change once used or upgrades will fail.