### PR TITLE
Validate S3 bucket (and prefix) are unique among S3 log sources

### DIFF
--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -169,6 +169,12 @@ func (api API) integrationAlreadyExists(input *models.PutIntegrationInput) error
 							input.IntegrationLabel),
 					}
 				}
+
+				if existingIntegration.S3Bucket == input.S3Bucket && existingIntegration.S3Prefix == input.S3Prefix {
+					return &genericapi.InvalidInputError{
+						Message: "An S3 integration with the same S3 bucket and prefix already exists.",
+					}
+				}
 			case models.IntegrationTypeSqs:
 				if existingIntegration.IntegrationLabel == input.IntegrationLabel {
 					// Sqs sources need to have different labels

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -106,6 +106,7 @@ func (api API) validateUniqueConstraints(existingIntegrationItem *ddb.Integratio
 	for _, existingIntegration := range existingIntegrations {
 		if existingIntegration.IntegrationType == existingIntegrationItem.IntegrationType &&
 			existingIntegration.IntegrationID != existingIntegrationItem.IntegrationID {
+
 			switch existingIntegration.IntegrationType {
 			case models.IntegrationTypeAWS3:
 				if existingIntegration.AWSAccountID == existingIntegrationItem.AWSAccountID &&

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -44,6 +44,10 @@ func (api API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettings
 		return nil, err
 	}
 
+	if err = api.validateUniqueConstraints(existingIntegrationItem, input); err != nil {
+		return nil, err
+	}
+
 	// Validate the updated existingIntegrationItem settings
 	reason, passing, err := evaluateIntegrationFunc(api, &models.CheckIntegrationInput{
 		// From existing existingIntegrationItem
@@ -91,6 +95,45 @@ func (api API) UpdateIntegrationSettings(input *models.UpdateIntegrationSettings
 	existingIntegration := itemToIntegration(existingIntegrationItem)
 
 	return existingIntegration, nil
+}
+
+func (api API) validateUniqueConstraints(existingIntegrationItem *ddb.Integration, input *models.UpdateIntegrationSettingsInput) error {
+	existingIntegrations, err := api.ListIntegrations(&models.ListIntegrationsInput{})
+	if err != nil {
+		zap.L().Error("failed to fetch integrations", zap.Error(errors.WithStack(err)))
+		return updateIntegrationInternalError
+	}
+	for _, existingIntegration := range existingIntegrations {
+		if existingIntegration.IntegrationType == existingIntegrationItem.IntegrationType &&
+			existingIntegration.IntegrationID != existingIntegrationItem.IntegrationID {
+			switch existingIntegration.IntegrationType {
+			case models.IntegrationTypeAWS3:
+				if existingIntegration.AWSAccountID == existingIntegrationItem.AWSAccountID &&
+					existingIntegration.IntegrationLabel == input.IntegrationLabel {
+					// Log sources for same account need to have different labels
+					return &genericapi.InvalidInputError{
+						Message: fmt.Sprintf("Log source for account %s with label %s already onboarded",
+							existingIntegrationItem.AWSAccountID,
+							input.IntegrationLabel),
+					}
+				}
+
+				if existingIntegration.S3Bucket == input.S3Bucket && existingIntegration.S3Prefix == input.S3Prefix {
+					return &genericapi.InvalidInputError{
+						Message: "An S3 integration with the same S3 bucket and prefix already exists.",
+					}
+				}
+			case models.IntegrationTypeSqs:
+				if existingIntegration.IntegrationLabel == input.IntegrationLabel {
+					// Sqs sources need to have different labels
+					return &genericapi.InvalidInputError{
+						Message: fmt.Sprintf("Integration with label %s already exists", input.IntegrationLabel),
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func normalizeIntegration(item *ddb.Integration, input *models.UpdateIntegrationSettingsInput) error {

--- a/internal/core/source_api/api/update_integration_test.go
+++ b/internal/core/source_api/api/update_integration_test.go
@@ -48,6 +48,7 @@ func TestUpdateIntegrationSettingsAwsScanType(t *testing.T) {
 	}}
 	mockClient.On("GetItem", mock.Anything).Return(getResponse, nil)
 	mockClient.On("PutItem", mock.Anything).Return(&dynamodb.PutItemOutput{}, nil)
+	mockClient.On("Scan", mock.Anything).Return(&dynamodb.ScanOutput{}, nil)
 	mockSQS.On("SendMessage", mock.Anything).Return(&sqs.SendMessageOutput{}, nil)
 
 	result, err := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
@@ -79,6 +80,7 @@ func TestUpdateIntegrationSettingsAwsS3Type(t *testing.T) {
 	}}
 	mockClient.On("GetItem", mock.Anything).Return(getResponse, nil)
 	mockClient.On("PutItem", mock.Anything).Return(&dynamodb.PutItemOutput{}, nil)
+	mockClient.On("Scan", mock.Anything).Return(&dynamodb.ScanOutput{}, nil)
 
 	result, err := apiTest.UpdateIntegrationSettings(&models.UpdateIntegrationSettingsInput{
 		S3Bucket: "test-bucket-1",


### PR DESCRIPTION
## Changes

API prevents creating/updating an s3 integration that doesn't have distinct s3 bucket (and prefix, not user-editable though).

Fixes #1646.

## Testing

Manual QA 

<img width="1281" alt="Screenshot 2020-10-30 at 2 32 27 AM" src="https://user-images.githubusercontent.com/3627869/97646539-9ee23080-1a58-11eb-9670-e5eb934dfb72.png">

