### PR TITLE
Ignoring S3 files from unregistered sources

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -70,16 +70,12 @@ type sourceCache struct {
 
 // LoadS3 loads the source configuration for an S3 object.
 // This will update the cache if needed.
-// It will return error if it encountered an issue retrieving the source information or if the source is not found.
+// It will return error if it encountered an issue retrieving the source information
 func (c *sourceCache) LoadS3(bucketName, objectKey string) (*models.SourceIntegration, error) {
 	if err := c.Sync(time.Now()); err != nil {
 		return nil, err
 	}
-	src := c.FindS3(bucketName, objectKey)
-	if src != nil {
-		return src, nil
-	}
-	return nil, errors.Errorf("source for s3://%s/%s not found", bucketName, objectKey)
+	return c.FindS3(bucketName, objectKey), nil
 }
 
 // Loads the source configuration for an source id.
@@ -203,7 +199,7 @@ func getS3Client(bucketName, objectKey string) (s3iface.S3API, *models.SourceInt
 	}
 
 	if sourceInfo == nil {
-		return nil, nil, errors.Errorf("there is no source configured for S3 object %s/%s", bucketName, objectKey)
+		return nil, nil, nil
 	}
 	var awsCreds *credentials.Credentials // lazy create below
 	roleArn := getSourceLogProcessingRole(sourceInfo)

--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -138,7 +138,7 @@ func TestGetS3ClientUnknownBucket(t *testing.T) {
 	}
 
 	result, sourceInfo, err := getS3Client(s3Object.S3Bucket, s3Object.S3ObjectKey)
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.Nil(t, result)
 	require.Nil(t, sourceInfo)
 

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -189,3 +189,43 @@ func TestHandleS3Folder(t *testing.T) {
 	// Method should not return data stream
 	require.Equal(t, 0, len(dataStreams))
 }
+
+func TestHandleUnregisteredSource(t *testing.T) {
+	resetCaches()
+	// if we encounter an unsupported file type, we should just skip the object
+	lambdaMock := &testutils.LambdaMock{}
+	common.LambdaClient = lambdaMock
+
+	s3Mock := &testutils.S3Mock{}
+
+	//nolint:lll
+	s3Event := "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"1970-01-01T00:00:00.000Z\"," +
+		"\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AIDAJDPLRKLG7UEXAMPLE\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
+		"\"responseElements\":{\"x-amz-request-id\":\"C3D13FE58DE4C810\",\"x-amz-id-2\":\"FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD\"}," +
+		"\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"testConfigRule\"," +
+		"\"bucket\":{\"name\":\"mybucket\",\"ownerIdentity\":{\"principalId\":\"A3NL1KOZZKExample\"},\"arn\":\"arn:aws:s3:::mybucket\"},\"object\":{\"unregistered/key\":\"test\",\"size\":1024," +
+		"\"eTag\":\"d41d8cd98f00b204e9800998ecf8427e\",\"versionId\":\"096fKKXTRTtl3on89fVO.nfljtsv6qko\",\"sequencer\":\"0055AED6DCD90281E5\"}}}]}"
+
+	notification := SnsNotification{}
+	notification.Type = "Notification"
+	notification.Message = s3Event
+	marshaledNotification, err := jsoniter.MarshalToString(notification)
+	require.NoError(t, err)
+
+	marshaledResult, err := jsoniter.Marshal([]*models.SourceIntegration{})
+	require.NoError(t, err)
+	lambdaOutput := &lambda.InvokeOutput{
+		Payload: marshaledResult,
+	}
+
+	// Getting the list of available sources
+	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
+
+	dataStreams, err := ReadSnsMessages([]string{marshaledNotification})
+	// Method shouldn't return error
+	require.NoError(t, err)
+	// Method should not return data stream
+	require.Equal(t, 0, len(dataStreams))
+	lambdaMock.AssertExpectations(t)
+	s3Mock.AssertExpectations(t)
+}


### PR DESCRIPTION
## Background

Sometimes log processor will receive events from unregistered sources. This can happen if e.g. someone has configured bucket-wide SNS notifications but has registered only a subfolder in Panther. 

In those cases it doesn't make sense to fail and retry - just ignore the messages. 

## Changes

- If we receive messages from unregistered S3 path, log a warning and continue

## Testing

- Unit test
