### PR TITLE
Minor Athena/Glue Tidies

### DIFF
--- a/internal/compliance/awsglue/awsglue.go
+++ b/internal/compliance/awsglue/awsglue.go
@@ -37,11 +37,11 @@ const (
 	// FIXME: Update the description when the DDB connector is GA
 	ResourcesTableDDB         = "panther-resources"
 	ResourcesTable            = "resources"
-	ResourcesTableDescription = "(ddb.panther_cloudsecurity.panther-resources) The resources discovered by Panther scanning"
+	ResourcesTableDescription = "(ddb.panther_cloudsecurity.resources) The resources discovered by Panther scanning"
 
 	ComplianceTableDDB         = "panther-compliance"
 	ComplianceTable            = "compliance"
-	ComplianceTableDescription = "(ddb.panther_cloudsecurity.panther-compliance) The policies and statuses from Panther scanning"
+	ComplianceTableDescription = "(ddb.panther_cloudsecurity.compliance) The policies and statuses from Panther scanning"
 )
 
 var (

--- a/internal/core/custom_resources/resources/log_processor_tables.go
+++ b/internal/core/custom_resources/resources/log_processor_tables.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-lambda-go/cfn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -61,8 +60,7 @@ func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (strin
 		for pantherDatabase := range awsglue.PantherDatabases {
 			zap.L().Info("deleting database", zap.String("database", pantherDatabase))
 			if _, err := awsglue.DeleteDatabase(glueClient, pantherDatabase); err != nil {
-				var awsErr awserr.Error
-				if errors.As(err, &awsErr) && awsErr.Code() == glue.ErrCodeEntityNotFoundException {
+				if awsutils.IsAnyError(err, glue.ErrCodeEntityNotFoundException) {
 					zap.L().Info("already deleted", zap.String("database", pantherDatabase))
 				} else {
 					return "", nil, errors.Wrapf(err, "failed deleting %s", pantherDatabase)

--- a/internal/log_analysis/athenaviews/athenaviews.go
+++ b/internal/log_analysis/athenaviews/athenaviews.go
@@ -43,7 +43,7 @@ func CreateOrReplaceViews(athenaClient athenaiface.AthenaAPI, workgroup string, 
 		return err
 	}
 	for _, sql := range sqlStatements {
-		_, err := awsathena.RunQuery(athenaClient, workgroup, awsglue.ViewsDatabaseName, sql, nil) // use default bucket
+		_, err := awsathena.RunQuery(athenaClient, workgroup, awsglue.ViewsDatabaseName, sql)
 		if err != nil {
 			return errors.Wrap(err, "CreateOrReplaceViews() failed")
 		}

--- a/pkg/awsathena/integration_test.go
+++ b/pkg/awsathena/integration_test.go
@@ -52,7 +52,7 @@ func TestIntegrationAthenaQuery(t *testing.T) {
 		t.Skip()
 	}
 
-	queryResult, err := RunQuery(athena.New(awsSession), workgroup, "panther_logs", "select 1 as c", nil)
+	queryResult, err := RunQuery(athena.New(awsSession), workgroup, "panther_logs", "select 1 as c")
 	require.NoError(t, err)
 	expectedCol := "c"
 	expectedResult := "1"
@@ -67,7 +67,7 @@ func TestIntegrationAthenaQueryBadSQLParse(t *testing.T) {
 		t.Skip()
 	}
 
-	_, err := RunQuery(athena.New(awsSession), workgroup, "panther_logs", "wwwww", nil)
+	_, err := RunQuery(athena.New(awsSession), workgroup, "panther_logs", "wwwww")
 	require.Error(t, err)
 }
 
@@ -79,17 +79,16 @@ func TestIntegrationAthenaQueryBadSQLExecution(t *testing.T) {
 	// to force an execution failure we need to create an error AFTER the SQL planner, create a table with a non-existent bucket
 	badTable := `panther_temp.test_table_with_bad_s3path`
 	_, err := RunQuery(athena.New(awsSession), workgroup, "panther_logs",
-		`create external table if not exists `+badTable+` (col1 string) location 's3://panthernosuchbucket/nosuchtable/'`,
-		nil)
+		`create external table if not exists `+badTable+` (col1 string) location 's3://panthernosuchbucket/nosuchtable/'`)
 	require.NoError(t, err)
 
 	// now query bad table
-	_, err = RunQuery(athena.New(awsSession), workgroup, "panther_logs", `select * from `+badTable, nil)
+	_, err = RunQuery(athena.New(awsSession), workgroup, "panther_logs", `select * from `+badTable)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "query execution failed:")) // confirm we came thru correct code path
 
 	// clean up (best effort)
-	_, _ = RunQuery(athena.New(awsSession), workgroup, "panther_logs", `drop table `+badTable, nil)
+	_, _ = RunQuery(athena.New(awsSession), workgroup, "panther_logs", `drop table `+badTable)
 }
 
 func TestIntegrationAthenaQueryStop(t *testing.T) {
@@ -99,7 +98,7 @@ func TestIntegrationAthenaQueryStop(t *testing.T) {
 
 	athenaClient := athena.New(awsSession)
 
-	startOutput, err := StartQuery(athenaClient, workgroup, "panther_logs", "select 1 as c", nil)
+	startOutput, err := StartQuery(athenaClient, workgroup, "panther_logs", "select 1 as c")
 	require.NoError(t, err)
 
 	_, err = StopQuery(athenaClient, *startOutput.QueryExecutionId)

--- a/pkg/awsathena/query.go
+++ b/pkg/awsathena/query.go
@@ -31,15 +31,15 @@ const (
 )
 
 // RunQuery executes query, blocking until done
-func RunQuery(client athenaiface.AthenaAPI, workgroup, database, sql string, s3Path *string) (*athena.GetQueryResultsOutput, error) {
-	startOutput, err := StartQuery(client, workgroup, database, sql, s3Path)
+func RunQuery(client athenaiface.AthenaAPI, workgroup, database, sql string) (*athena.GetQueryResultsOutput, error) {
+	startOutput, err := StartQuery(client, workgroup, database, sql)
 	if err != nil {
 		return nil, err
 	}
 	return WaitForResults(client, *startOutput.QueryExecutionId)
 }
 
-func StartQuery(client athenaiface.AthenaAPI, workgroup, database, sql string, s3Path *string) (*athena.StartQueryExecutionOutput, error) {
+func StartQuery(client athenaiface.AthenaAPI, workgroup, database, sql string) (*athena.StartQueryExecutionOutput, error) {
 	var startInput athena.StartQueryExecutionInput
 	startInput.SetWorkGroup(workgroup)
 	startInput.SetQueryString(sql)
@@ -49,9 +49,6 @@ func StartQuery(client athenaiface.AthenaAPI, workgroup, database, sql string, s
 	startInput.SetQueryExecutionContext(&startContext)
 
 	var resultConfig athena.ResultConfiguration
-	if s3Path != nil {
-		resultConfig.SetOutputLocation(*s3Path)
-	}
 	startInput.SetResultConfiguration(&resultConfig)
 
 	return client.StartQueryExecution(&startInput)


### PR DESCRIPTION
## Background

These are small changes from previous PR feedback and from the enterprise sync/merge of the change where we removed the custom resource that configured Athena WorkGroups (they are now supported in CF)

## Changes

- Use `awsutils.IsAnyError()` where appropriate in custom glue resources
- Fix typo in descriptions of new tables
- Remove the optional s3 path in `pkg/awsathena` since this is no longer used now that proper WorkGroups are functional

## Testing

- mage fmt test:ci
- mage deploy, checked the athena views worked and table meta data
- mage test:integration

