### PR TITLE
Remove use of DeployedLogTables()

### DIFF
--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -29,6 +29,8 @@ type LambdaInput struct {
 	ListIntegrations          *ListIntegrationsInput          `json:"listIntegrations"`
 	DeleteIntegration         *DeleteIntegrationInput         `json:"deleteIntegration"`
 
+	ListLogTypes *ListLogTypesInput `json:"listLogTypes"`
+
 	GetIntegrationTemplate *GetIntegrationTemplateInput `json:"getIntegrationTemplate"`
 
 	UpdateIntegrationLastScanEnd   *UpdateIntegrationLastScanEndInput   `json:"updateIntegrationLastScanEnd"`
@@ -114,6 +116,19 @@ type UpdateIntegrationSettingsInput struct {
 // DeleteIntegrationInput is used to delete a specific item from the database.
 type DeleteIntegrationInput struct {
 	IntegrationID string `json:"integrationId" validate:"required,uuid4"`
+}
+
+//
+// ListLogTypes: used to get full list of distinct logType over all integrations
+//
+
+// ListLogTypesInput
+type ListLogTypesInput struct {
+}
+
+// ListLogTypesOutput
+type ListLogTypesOutput struct {
+	LogTypes []string `json:"logTypes" validate:"omitempty"`
 }
 
 //

--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -70,6 +70,11 @@ Parameters:
     Description: Optional versioned custom Python layer for analysis and remediation
     # Example: "arn:aws:lambda:us-west-2:111122223333:layer:panther-analysis:143"
     AllowedPattern: '^(arn:(aws|aws-cn|aws-us-gov):lambda:[a-z]{2}-[a-z]{4,9}-[1-9]:\d{12}:layer:\S+:\d+)?$'
+  SqsKeyId:
+    Type: String
+    Description: KMS key ID for SQS encryption
+    # Example: "484fb80c-4ae5-40d0-b22a-bdd5d0953b3e"
+    AllowedPattern: '^[0-9a-f-]{36}$'
   TracingMode:
     Type: String
     Description: Enable XRay tracing on Lambda and API Gateway
@@ -250,6 +255,14 @@ Resources:
             - Effect: Allow
               Action: s3:Get*
               Resource: arn:aws:s3:::panther-public-cloudformation-templates*
+            - Effect: Allow
+              Action: sqs:SendMessage # this is for sending a message to datacatalog_updater to update/sync Glue tables
+              Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-datacatalog-updater-queue
+            - Effect: Allow
+              Action: # this is for sending a message to datacatalog_updater to update/sync Glue tables
+                - kms:Decrypt
+                - kms:GenerateDataKey
+              Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${SqsKeyId}
 
   # The PantherTeardown resource adds an IAM permission boundary to the custom resource role
   # which blocks future logs.

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -130,6 +130,7 @@ Resources:
       CustomResourceVersion: !Ref CustomResourceVersion
       AthenaWorkGroup: !Ref AthenaWorkGroup
       ProcessedDataBucket: !Ref ProcessedDataBucket
+      DataCatalogUpdaterQueueURL: !Ref UpdaterQueue
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:panther-cfn-custom-resources
 
   InputDataSnsSubscription:

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -225,6 +225,7 @@ Resources:
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
         ProcessedDataBucket: !GetAtt Bootstrap.Outputs.ProcessedDataBucket
         PythonLayerVersionArn: !Ref PythonLayerVersionArn
+        SqsKeyId: !GetAtt Bootstrap.Outputs.QueueEncryptionKeyId
         TracingMode: !Ref TracingMode
         UserPoolId: !GetAtt Bootstrap.Outputs.UserPoolId
       Tags:
@@ -332,6 +333,7 @@ Resources:
           Value: panther-cw-dashboards
 
   LogAnalysis:
+    DependsOn: Core
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: ../../deployments/log_analysis.yml

--- a/internal/core/custom_resources/resources/clients.go
+++ b/internal/core/custom_resources/resources/clients.go
@@ -25,8 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/acm/acmiface"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -47,6 +45,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -56,7 +56,6 @@ var (
 	awsSession = session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(10)))
 
 	acmClient            acmiface.ACMAPI                                         = acm.New(awsSession)
-	athenaClient         athenaiface.AthenaAPI                                   = athena.New(awsSession)
 	cloudWatchClient     cloudwatchiface.CloudWatchAPI                           = cloudwatch.New(awsSession)
 	cloudWatchLogsClient cloudwatchlogsiface.CloudWatchLogsAPI                   = cloudwatchlogs.New(awsSession)
 	cognitoClient        cognitoidentityprovideriface.CognitoIdentityProviderAPI = cognitoidentityprovider.New(awsSession)
@@ -67,6 +66,7 @@ var (
 	iamClient            iamiface.IAMAPI                                         = iam.New(awsSession)
 	lambdaClient         lambdaiface.LambdaAPI                                   = lambda.New(awsSession)
 	s3Client             s3iface.S3API                                           = s3.New(awsSession)
+	sqsClient            sqsiface.SQSAPI                                         = sqs.New(awsSession)
 
 	accountDescription string
 )

--- a/internal/core/custom_resources/resources/log_processor_tables.go
+++ b/internal/core/custom_resources/resources/log_processor_tables.go
@@ -27,18 +27,18 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/panther-labs/panther/internal/log_analysis/athenaviews"
+	"github.com/panther-labs/panther/internal/core/source_api/apifunctions"
 	"github.com/panther-labs/panther/internal/log_analysis/awsglue"
 	"github.com/panther-labs/panther/internal/log_analysis/datacatalog_updater/process"
-	"github.com/panther-labs/panther/internal/log_analysis/gluetables"
 	"github.com/panther-labs/panther/pkg/awsutils"
 )
 
 type UpdateLogProcessorTablesProperties struct {
 	// TablesSignature should change every time the tables change (for CF master.yml this can be the Panther version)
-	TablesSignature     string `validate:"required"`
-	AthenaWorkGroup     string `validate:"required"`
-	ProcessedDataBucket string `validate:"required"`
+	TablesSignature            string `validate:"required"`
+	AthenaWorkGroup            string `validate:"required"`
+	ProcessedDataBucket        string `validate:"required"`
+	DataCatalogUpdaterQueueURL string `validate:"required"`
 }
 
 func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (string, map[string]interface{}, error) {
@@ -51,7 +51,7 @@ func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (strin
 			zap.L().Error("failed to parse resource properties", zap.Error(err))
 			return physicalResourceID, nil, err
 		}
-		if err := updateLogProcessorTables(ctx, &props); err != nil {
+		if err := updateLogProcessorTables(&props); err != nil {
 			zap.L().Error("failed to update glue tables", zap.Error(err))
 			return physicalResourceID, nil, err
 		}
@@ -73,7 +73,7 @@ func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (strin
 	}
 }
 
-func updateLogProcessorTables(ctx context.Context, props *UpdateLogProcessorTablesProperties) error {
+func updateLogProcessorTables(props *UpdateLogProcessorTablesProperties) error {
 	// ensure databases are all there
 	for pantherDatabase, pantherDatabaseDescription := range awsglue.PantherDatabases {
 		zap.L().Info("creating database", zap.String("database", pantherDatabase))
@@ -86,47 +86,14 @@ func updateLogProcessorTables(ctx context.Context, props *UpdateLogProcessorTabl
 		}
 	}
 
-	// update schemas for tables that are deployed
-	deployedLogTables, err := gluetables.DeployedLogTables(glueClient)
+	// update schemas and views for tables that are deployed
+	logTypes, err := apifunctions.ListLogTypes(lambdaClient)
 	if err != nil {
 		return err
 	}
-	logTypes := make([]string, len(deployedLogTables))
-	for i, logTable := range deployedLogTables {
-		zap.L().Info("updating table", zap.String("database", logTable.DatabaseName()), zap.String("table", logTable.TableName()))
-
-		// update catalog
-		// NOTE: This function updates all tables, not only the log tables
-		_, err := gluetables.CreateOrUpdateGlueTables(glueClient, props.ProcessedDataBucket, logTable)
-		if err != nil {
-			return err
-		}
-
-		// collect the log types
-		logTypes[i] = logTable.LogType()
+	m := process.CreateTablesMessage{
+		LogTypes: logTypes,
+		Sync:     true, // force a partition sync
 	}
-
-	// update the views with the new tables
-	err = athenaviews.CreateOrReplaceViews(athenaClient, props.AthenaWorkGroup, deployedLogTables)
-	if err != nil {
-		return errors.Wrap(err, "failed creating views")
-	}
-
-	// sync partitions via recursive lambda to avoid blocking the deployment
-	if len(logTypes) > 0 {
-		err = process.InvokeBackgroundSync(ctx, lambdaClient, &process.SyncEvent{
-			DatabaseNames: []string{
-				awsglue.LogProcessingDatabaseName,
-				awsglue.RuleMatchDatabaseName,
-				awsglue.RuleErrorsDatabaseName,
-			},
-			LogTypes: logTypes,
-			DryRun:   false,
-		})
-		if err != nil {
-			return errors.Wrap(err, "failed invoking sync")
-		}
-	}
-
-	return nil
+	return m.Send(sqsClient, props.DataCatalogUpdaterQueueURL)
 }

--- a/internal/core/custom_resources/resources/log_processor_tables.go
+++ b/internal/core/custom_resources/resources/log_processor_tables.go
@@ -51,7 +51,7 @@ func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (strin
 			zap.L().Error("failed to parse resource properties", zap.Error(err))
 			return physicalResourceID, nil, err
 		}
-		if err := updateLogProcessorTables(&props); err != nil {
+		if err := updateLogProcessorTables(ctx, &props); err != nil {
 			zap.L().Error("failed to update glue tables", zap.Error(err))
 			return physicalResourceID, nil, err
 		}
@@ -73,7 +73,7 @@ func customUpdateLogProcessorTables(ctx context.Context, event cfn.Event) (strin
 	}
 }
 
-func updateLogProcessorTables(props *UpdateLogProcessorTablesProperties) error {
+func updateLogProcessorTables(ctx context.Context, props *UpdateLogProcessorTablesProperties) error {
 	// ensure databases are all there
 	for pantherDatabase, pantherDatabaseDescription := range awsglue.PantherDatabases {
 		zap.L().Info("creating database", zap.String("database", pantherDatabase))
@@ -87,7 +87,7 @@ func updateLogProcessorTables(props *UpdateLogProcessorTablesProperties) error {
 	}
 
 	// update schemas and views for tables that are deployed
-	logTypes, err := apifunctions.ListLogTypes(lambdaClient)
+	logTypes, err := apifunctions.ListLogTypes(ctx, lambdaClient)
 	if err != nil {
 		return err
 	}

--- a/internal/core/source_api/api/list_logtypes.go
+++ b/internal/core/source_api/api/list_logtypes.go
@@ -1,0 +1,57 @@
+package api
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/panther-labs/panther/api/lambda/source/models"
+)
+
+// ListLogTypes gets the current set of logTypes in use
+func (api *API) ListLogTypes(_ *models.ListLogTypesInput) (*models.ListLogTypesOutput, error) {
+	// this simply wraps the ListListIntegrations call
+	listOutput, err := api.ListIntegrations(&models.ListIntegrationsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.ListLogTypesOutput{
+		LogTypes: collectLogTypes(listOutput),
+	}, nil
+}
+
+func collectLogTypes(listOutput []*models.SourceIntegration) []string {
+	// collect them all in a set to ensure uniqueness
+	logTypesSet := make(map[string]struct{})
+	for _, integration := range listOutput {
+		switch integration.IntegrationType {
+		// types related to log processing
+		case models.IntegrationTypeAWS3, models.IntegrationTypeSqs:
+			for _, logType := range integration.LogTypes {
+				logTypesSet[logType] = struct{}{}
+			}
+		}
+	}
+
+	// make slice from map
+	logTypes := make([]string, 0, len(logTypesSet))
+	for logType := range logTypesSet {
+		logTypes = append(logTypes, logType)
+	}
+	return logTypes
+}

--- a/internal/core/source_api/api/list_logtypes.go
+++ b/internal/core/source_api/api/list_logtypes.go
@@ -39,12 +39,8 @@ func collectLogTypes(listOutput []*models.SourceIntegration) []string {
 	// collect them all in a set to ensure uniqueness
 	logTypesSet := make(map[string]struct{})
 	for _, integration := range listOutput {
-		switch integration.IntegrationType {
-		// types related to log processing
-		case models.IntegrationTypeAWS3, models.IntegrationTypeSqs:
-			for _, logType := range integration.LogTypes {
-				logTypesSet[logType] = struct{}{}
-			}
+		for _, logType := range integration.RequiredLogTypes() {
+			logTypesSet[logType] = struct{}{}
 		}
 	}
 

--- a/internal/core/source_api/api/vars.go
+++ b/internal/core/source_api/api/vars.go
@@ -36,11 +36,14 @@ import (
 )
 
 const (
+	LambdaName = "panther-source-api"
+
 	maxElapsedTime       = 5 * time.Second
 	templateBucketRegion = endpoints.UsWest2RegionID
 )
 
 var (
+	// FIXME: move globals into API struct
 	env        envConfig
 	awsSession *session.Session
 

--- a/internal/core/source_api/apifunctions/apifunctions.go
+++ b/internal/core/source_api/apifunctions/apifunctions.go
@@ -19,29 +19,28 @@ package apifunctions
  */
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
+	"github.com/pkg/errors"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/internal/core/source_api/api"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
 // Below are function call entry points to the api that allow callers easily use the lambda interface.
 // There are no referenced external packages (other than `models`) to minimize pulling in unneeded code.
 
-const (
-	LambdaName = "panther-source-api"
-)
-
 // ListLogTypes gets the current set of logTypes in use
-func ListLogTypes(lambdaClient lambdaiface.LambdaAPI) ([]string, error) {
+func ListLogTypes(_ context.Context, lambdaClient lambdaiface.LambdaAPI) ([]string, error) {
 	var listLogTypesOutput models.ListLogTypesOutput
 	var listLogTypesInput = &models.LambdaInput{
 		ListLogTypes: &models.ListLogTypesInput{},
 	}
-	if err := genericapi.Invoke(lambdaClient, LambdaName, listLogTypesInput, &listLogTypesOutput); err != nil {
-		return nil, fmt.Errorf("error calling source-api to list logTypes: %v", err)
+	// FIXME: extend genericapi to use context
+	if err := genericapi.Invoke(lambdaClient, api.LambdaName, listLogTypesInput, &listLogTypesOutput); err != nil {
+		return nil, errors.Wrap(err, "error calling source-api to list logTypes")
 	}
 
 	return listLogTypesOutput.LogTypes, nil

--- a/internal/core/source_api/apifunctions/apifunctions.go
+++ b/internal/core/source_api/apifunctions/apifunctions.go
@@ -1,4 +1,4 @@
-package main
+package apifunctions
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
@@ -19,32 +19,30 @@ package main
  */
 
 import (
-	"context"
+	"fmt"
 
-	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
-	"github.com/panther-labs/panther/internal/core/source_api/api"
 	"github.com/panther-labs/panther/pkg/genericapi"
-	"github.com/panther-labs/panther/pkg/lambdalogger"
 )
 
-var router *genericapi.Router
+// Below are function call entry points to the api that allow callers easily use the lambda interface.
+// There are no referenced external packages (other than `models`) to minimize pulling in unneeded code.
 
-func init() {
-	validator, err := models.Validator()
-	if err != nil {
-		panic(err)
+const (
+	LambdaName = "panther-source-api"
+)
+
+// ListLogTypes gets the current set of logTypes in use
+func ListLogTypes(lambdaClient lambdaiface.LambdaAPI) ([]string, error) {
+	var listLogTypesOutput models.ListLogTypesOutput
+	var listLogTypesInput = &models.LambdaInput{
+		ListLogTypes: &models.ListLogTypesInput{},
 	}
-	router = genericapi.NewRouter("api", "sources", validator, &api.API{})
-}
+	if err := genericapi.Invoke(lambdaClient, LambdaName, listLogTypesInput, &listLogTypesOutput); err != nil {
+		return nil, fmt.Errorf("error calling source-api to list logTypes: %v", err)
+	}
 
-func lambdaHandler(ctx context.Context, request *models.LambdaInput) (interface{}, error) {
-	lambdalogger.ConfigureGlobal(ctx, nil)
-	return router.Handle(request)
-}
-
-func main() {
-	api.Setup()
-	lambda.Start(lambdaHandler)
+	return listLogTypesOutput.LogTypes, nil
 }

--- a/internal/log_analysis/gluetables/gluetables.go
+++ b/internal/log_analysis/gluetables/gluetables.go
@@ -29,15 +29,66 @@ import (
 	"github.com/aws/aws-sdk-go/service/glue/glueiface"
 	"github.com/pkg/errors"
 
-	"github.com/panther-labs/panther/internal/log_analysis/awsglue"
+	cloudsecGlue "github.com/panther-labs/panther/internal/compliance/awsglue"
+	loganalysisGlue "github.com/panther-labs/panther/internal/log_analysis/awsglue"
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/registry"
 	"github.com/panther-labs/panther/pkg/awsutils"
 )
 
-// DeployedLogTables returns the glue tables from the registry that have been deployed
-func DeployedLogTables(glueClient glueiface.GlueAPI) (deployedLogTables []*awsglue.GlueTableMetadata, err error) {
+// DeployedLogTypes scans glue API to filter log types with deployed tables
+func DeployedLogTypes(ctx context.Context, glueClient glueiface.GlueAPI, logTypes []string) ([]string, error) {
+	dbNames := []string{loganalysisGlue.LogProcessingDatabaseName, cloudsecGlue.CloudSecurityDatabase}
+	index := make(map[string]string, len(logTypes))
+	deployed := make([]string, 0, len(logTypes))
+
+	// set up filter via map
+	for _, logType := range logTypes {
+		tableName := loganalysisGlue.GetTableName(logType)
+		index[tableName] = logType
+	}
+
+	// collects logTypes
+	scan := func(page *glue.GetTablesOutput, _ bool) bool {
+		for _, table := range page.TableList {
+			tableName := aws.StringValue(table.Name)
+			logType, ok := index[tableName]
+			if ok {
+				deployed = append(deployed, logType)
+			}
+		}
+		return true
+	}
+
+	// loop over each database, collecting the logTypes
+	for i := range dbNames {
+		input := glue.GetTablesInput{
+			DatabaseName: &dbNames[i],
+		}
+		err := glueClient.GetTablesPagesWithContext(ctx, &input, scan)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return deployed, nil
+}
+
+// DeployedTablesSignature returns a string "signature" for the schema of the deployed native tables used to detect change
+func DeployedTablesSignature(glueClient glueiface.GlueAPI) (deployedLogTablesSignature string, err error) {
+	deployedLogTables, err := deployedNativeLogTables(glueClient)
+	if err != nil {
+		return "", err
+	}
+
+	allTables := ExpandLogTables(deployedLogTables...)
+
+	return BuildSignature(allTables...)
+}
+
+// deployedNativeLogTables returns the glue tables from the registry that have been deployed (possibly with schema updates)
+func deployedNativeLogTables(glueClient glueiface.GlueAPI) (deployedLogTables []*loganalysisGlue.GlueTableMetadata, err error) {
 	for _, gm := range registry.AvailableTables() {
-		_, err := awsglue.GetTable(glueClient, gm.DatabaseName(), gm.TableName())
+		_, err := loganalysisGlue.GetTable(glueClient, gm.DatabaseName(), gm.TableName())
 		if err != nil {
 			if awsutils.IsAnyError(err, glue.ErrCodeEntityNotFoundException) {
 				continue
@@ -52,52 +103,11 @@ func DeployedLogTables(glueClient glueiface.GlueAPI) (deployedLogTables []*awsgl
 	return deployedLogTables, nil
 }
 
-// DeployedLogTypes scans glue API to filter log types with deployed tables
-func DeployedLogTypes(ctx context.Context, glueClient glueiface.GlueAPI, logTypes []string) ([]string, error) {
-	dbName := awsglue.LogProcessingDatabaseName
-	index := make(map[string]string, len(logTypes))
-	deployed := make([]string, 0, len(logTypes))
-	for _, logType := range logTypes {
-		tableName := awsglue.GetTableName(logType)
-		index[tableName] = logType
-	}
-	scan := func(page *glue.GetTablesOutput, _ bool) bool {
-		for _, table := range page.TableList {
-			tableName := aws.StringValue(table.Name)
-			logType, ok := index[tableName]
-			if ok {
-				deployed = append(deployed, logType)
-			}
-		}
-		return true
-	}
-	input := glue.GetTablesInput{
-		DatabaseName: &dbName,
-	}
-	err := glueClient.GetTablesPagesWithContext(ctx, &input, scan)
-	if err != nil {
-		return nil, err
-	}
-	return deployed, nil
-}
-
-// DeployedTablesSignature returns a string "signature" for the schema of the deployed tables used to detect change
-func DeployedTablesSignature(glueClient glueiface.GlueAPI) (deployedLogTablesSignature string, err error) {
-	deployedLogTables, err := DeployedLogTables(glueClient)
-	if err != nil {
-		return "", err
-	}
-
-	allTables := ExpandLogTables(deployedLogTables...)
-
-	return BuildSignature(allTables...)
-}
-
 // Expand log tables expands tables from the log processing database to include additional tables (rules, ruleErrors)
-func ExpandLogTables(tables ...*awsglue.GlueTableMetadata) (expanded []*awsglue.GlueTableMetadata) {
-	expanded = make([]*awsglue.GlueTableMetadata, 0, 3*len(tables))
+func ExpandLogTables(tables ...*loganalysisGlue.GlueTableMetadata) (expanded []*loganalysisGlue.GlueTableMetadata) {
+	expanded = make([]*loganalysisGlue.GlueTableMetadata, 0, 3*len(tables))
 	for _, table := range tables {
-		if table.DatabaseName() != awsglue.LogProcessingDatabaseName {
+		if table.DatabaseName() != loganalysisGlue.LogProcessingDatabaseName {
 			continue
 		}
 		expanded = append(expanded, table, table.RuleTable(), table.RuleErrorTable())
@@ -105,7 +115,7 @@ func ExpandLogTables(tables ...*awsglue.GlueTableMetadata) (expanded []*awsglue.
 	return
 }
 
-func BuildSignature(tables ...*awsglue.GlueTableMetadata) (string, error) {
+func BuildSignature(tables ...*loganalysisGlue.GlueTableMetadata) (string, error) {
 	tableSignatures := make([]string, 0, len(tables))
 	for _, table := range tables {
 		sig, err := table.Signature()
@@ -123,14 +133,14 @@ func BuildSignature(tables ...*awsglue.GlueTableMetadata) (string, error) {
 }
 
 type TablesForLogType struct {
-	LogTable       *awsglue.GlueTableMetadata
-	RuleTable      *awsglue.GlueTableMetadata
-	RuleErrorTable *awsglue.GlueTableMetadata
+	LogTable       *loganalysisGlue.GlueTableMetadata
+	RuleTable      *loganalysisGlue.GlueTableMetadata
+	RuleErrorTable *loganalysisGlue.GlueTableMetadata
 }
 
 // CreateOrUpdateGlueTables, given a log meta data table, creates all tables related to this log table in the glue catalog.
 func CreateOrUpdateGlueTables(glueClient glueiface.GlueAPI, bucket string,
-	logTable *awsglue.GlueTableMetadata) (*TablesForLogType, error) {
+	logTable *loganalysisGlue.GlueTableMetadata) (*TablesForLogType, error) {
 
 	// Create the log table
 	err := logTable.CreateOrUpdateTable(glueClient, bucket)

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -100,6 +100,15 @@ func (m *LambdaMock) Invoke(input *lambda.InvokeInput) (*lambda.InvokeOutput, er
 	return args.Get(0).(*lambda.InvokeOutput), args.Error(1)
 }
 
+func (m *LambdaMock) InvokeWithContext(
+	ctx aws.Context,
+	input *lambda.InvokeInput,
+	options ...request.Option) (*lambda.InvokeOutput, error) {
+
+	args := m.Called(ctx, input, options)
+	return args.Get(0).(*lambda.InvokeOutput), args.Error(1)
+}
+
 func (m *LambdaMock) CreateEventSourceMapping(
 	input *lambda.CreateEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error) {
 


### PR DESCRIPTION
## Background

This PR removes use of `DeployedLogTables()` and consolidates all the management of Glue tables behind the `datacatalog_updater` lambda.

This refactor is needed in Panther Enterprise to support inclusion of custom logs with Parquet and Snowflake integrations.

There was only 1 use of `DeployedLogTables()` in the custom resource used to update schemas during deployment.
This was replaced by a call to get the deployed logTypes from the source api and then calling the `datacatalog_updater`  to update the related tables. All of the code to update the tables and views had already been moved into the `datacatalog_updater` . One change was added to allow an optional `Sync` flag to kick of a sync of the partitions after the tables and views have been updated.

## Changes

- update custom resource that manages glue tables on deployment to send message to `datacatalog_updater`
- added `ListLogTypes` method to the `source_api`
- updated `DeployedLogTypes()` to include the cloudsec database
- fix stack dependencies in mage deploy that were not correct

## Testing

- mage test:ci
- mage deploy and wait for partitions on the self onboarded log types
- mage deploy + add a column to 3 log parsers + mage deploy and then check that the tables and partitions updated
- mage deploy + remove above column add to 3 log parsers + mage deploy and then check that the tables and partitions updated

