### PR TITLE
fix: add opacity as indication for active tabs

### DIFF
--- a/web/src/pages/RuleDetails/RuleDetails.tsx
+++ b/web/src/pages/RuleDetails/RuleDetails.tsx
@@ -22,6 +22,7 @@ import useRouter from 'Hooks/useRouter';
 import { Alert, Box, Flex, Card, TabList, TabPanel, TabPanels, Tabs } from 'pouncejs';
 import { BorderedTab, BorderTabDivider } from 'Components/BorderedTab';
 import { extractErrorMessage } from 'Helpers/utils';
+import { DEFAULT_SMALL_PAGE_SIZE } from 'Source/constants';
 
 import withSEO from 'Hoc/withSEO';
 import invert from 'lodash/invert';
@@ -33,6 +34,7 @@ import ListRuleAlerts from './RuleAlertsListing';
 import CardDetails from './RuleCardDetails';
 import RuleDetailsInfo from './RuleDetailsInfo';
 import { useRuleDetails } from './graphql/ruleDetails.generated';
+import { useListAlertsForRule } from './graphql/listAlertsForRule.generated';
 
 export interface RuleDetailsPageUrlParams {
   section?: 'details' | 'matches' | 'errors';
@@ -57,6 +59,30 @@ const RuleDetailsPage: React.FC = () => {
     variables: {
       input: {
         ruleId: match.params.id,
+      },
+    },
+  });
+
+  // dry runs for tabs indicator
+
+  const { data: matchesData } = useListAlertsForRule({
+    fetchPolicy: 'cache-and-network',
+    variables: {
+      input: {
+        type: AlertTypesEnum.Rule,
+        ruleId: match.params.id,
+        pageSize: DEFAULT_SMALL_PAGE_SIZE,
+      },
+    },
+  });
+
+  const { data: errorData } = useListAlertsForRule({
+    fetchPolicy: 'cache-and-network',
+    variables: {
+      input: {
+        type: AlertTypesEnum.RuleError,
+        ruleId: match.params.id,
+        pageSize: DEFAULT_SMALL_PAGE_SIZE,
       },
     },
   });
@@ -94,8 +120,16 @@ const RuleDetailsPage: React.FC = () => {
             <Box px={2}>
               <TabList>
                 <BorderedTab>Details</BorderedTab>
-                <BorderedTab>Rule Matches</BorderedTab>
-                <BorderedTab>Rule Errors</BorderedTab>
+                <BorderedTab>
+                  <Box opacity={matchesData?.alerts?.alertSummaries.length > 0 ? 1 : 0.5}>
+                    Rule Matches
+                  </Box>
+                </BorderedTab>
+                <BorderedTab>
+                  <Box opacity={errorData?.alerts?.alertSummaries.length > 0 ? 1 : 0.5}>
+                    Rule Errors
+                  </Box>
+                </BorderedTab>
               </TabList>
               <BorderTabDivider />
               <TabPanels>

--- a/web/src/pages/RuleDetails/RuleDetails.tsx
+++ b/web/src/pages/RuleDetails/RuleDetails.tsx
@@ -121,12 +121,18 @@ const RuleDetailsPage: React.FC = () => {
               <TabList>
                 <BorderedTab>Details</BorderedTab>
                 <BorderedTab>
-                  <Box opacity={matchesData?.alerts?.alertSummaries.length > 0 ? 1 : 0.5}>
+                  <Box
+                    data-testid="rule-matches"
+                    opacity={matchesData?.alerts?.alertSummaries.length > 0 ? 1 : 0.5}
+                  >
                     Rule Matches
                   </Box>
                 </BorderedTab>
                 <BorderedTab>
-                  <Box opacity={errorData?.alerts?.alertSummaries.length > 0 ? 1 : 0.5}>
+                  <Box
+                    data-testid="rule-errors"
+                    opacity={errorData?.alerts?.alertSummaries.length > 0 ? 1 : 0.5}
+                  >
                     Rule Errors
                   </Box>
                 </BorderedTab>


### PR DESCRIPTION
## Background

This is an optional one that shows the tabs in a "pseudo" disabled state when no rule errors or rule matches are in place.

## Changes.

- Fetching rule errors and rule matches upon mounting
- Activate the  tabs that have data.

## Screenshots.
<img width="1432" alt="Screenshot 2020-11-03 at 5 04 27 PM" src="https://user-images.githubusercontent.com/1022166/98011428-81b6b480-1e00-11eb-8259-cd3355783e7a.png">
<img width="1475" alt="Screenshot 2020-11-03 at 5 04 13 PM" src="https://user-images.githubusercontent.com/1022166/98011449-854a3b80-1e00-11eb-87b1-e2d47c28650f.png">


## Testing.

- Added coverage tests.
