### PR TITLE
fix: sort rules by enabled/disabled status

### DIFF
--- a/web/src/pages/ListRules/ListRulesFilters/ListRulesFilters.tsx
+++ b/web/src/pages/ListRules/ListRulesFilters/ListRulesFilters.tsx
@@ -87,16 +87,16 @@ const sortingOpts: SortingOptions = [
     },
   },
   {
-    opt: 'Status Ascending',
+    opt: 'Enabled',
     resolution: {
-      sortBy: 'status' as ListRulesSortFieldsEnum,
+      sortBy: 'enabled' as ListRulesSortFieldsEnum,
       sortDir: 'ascending' as SortDirEnum,
     },
   },
   {
-    opt: 'Status Descending',
+    opt: 'Disabled',
     resolution: {
-      sortBy: 'status' as ListRulesSortFieldsEnum,
+      sortBy: 'enabled' as ListRulesSortFieldsEnum,
       sortDir: 'descending' as SortDirEnum,
     },
   },


### PR DESCRIPTION
## Background

Fixes sorting by `status` which does not exist for rules. Instead, this should be sorting on enabled/disabled status.

## Changes

- Change sorting `status` filter for rules to be `enabled`

## Testing

- Visually
