### PR TITLE
Using regional STS endpoint

### DIFF
--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -23,9 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -77,10 +75,9 @@ func TestGetS3Client(t *testing.T) {
 	s3Mock.On("GetBucketLocation", expectedGetBucketLocationInput).Return(
 		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
 
-	newCredentialsFunc =
-		func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-			return &credentials.Credentials{}
-		}
+	newCredentialsFunc = func(roleArn string) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
 
 	s3Object := &S3ObjectInfo{
 		S3Bucket:    "test-bucket",
@@ -127,10 +124,9 @@ func TestGetS3ClientUnknownBucket(t *testing.T) {
 
 	lambdaMock.On("Invoke", mock.Anything).Return(lambdaOutput, nil).Once()
 
-	newCredentialsFunc =
-		func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-			return &credentials.Credentials{}
-		}
+	newCredentialsFunc = func(roleArn string) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
 
 	s3Object := &S3ObjectInfo{
 		S3Bucket:    "test-bucket-unknown",
@@ -181,10 +177,9 @@ func TestGetS3ClientSourceNoPrefix(t *testing.T) {
 	s3Mock.On("GetBucketLocation", expectedGetBucketLocationInput).Return(
 		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
 
-	newCredentialsFunc =
-		func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-			return &credentials.Credentials{}
-		}
+	newCredentialsFunc = func(roleArn string) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
 
 	s3Object := &S3ObjectInfo{
 		S3Bucket:    "test-bucket",

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -24,9 +24,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -148,10 +146,9 @@ func TestHandleUnsupportedFileType(t *testing.T) {
 	s3Mock.On("GetBucketLocation", mock.Anything).Return(
 		&s3.GetBucketLocationOutput{LocationConstraint: aws.String("us-west-2")}, nil).Once()
 
-	newCredentialsFunc =
-		func(c client.ConfigProvider, roleARN string, options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
-			return &credentials.Credentials{}
-		}
+	newCredentialsFunc = func(roleArn string) *credentials.Credentials {
+		return &credentials.Credentials{}
+	}
 
 	objectData := []byte(`<?xml version="1.0" encoding="UTF-8" standalone="no" ?>`)
 	getObjectOutput := &s3.GetObjectOutput{Body: ioutil.NopCloser(bytes.NewReader(objectData))}


### PR DESCRIPTION
## Background

Using regional STS endpoint. This gives few benefits: 
- Improved latency
- Support opt-in regions

We are doing this fix also for the snapshot poller: https://github.com/panther-labs/panther/pull/1929

## Changes

- Using local STS endpoint when getting STS credentials for accessing data in S3 buckets

## Testing

- mage test:ci
