### PR TITLE
Rename "Dedup Message" to "Dedup String"

### DIFF
--- a/web/src/components/forms/RuleForm/RuleFormTestResult/RuleFormTestResult.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestResult/RuleFormTestResult.tsx
@@ -88,7 +88,7 @@ const RuleFormTestResult: React.FC<RuleFormTestResultProps> = ({ testResult }) =
             {dedupFunction && (
               <React.Fragment>
                 <Box as="dt" color="navyblue-100">
-                  Dedup Message
+                  Dedup String
                 </Box>
                 {!dedupFunction.error ? (
                   <Text as="dd">{dedupFunction.output}</Text>

--- a/web/src/components/forms/RuleForm/RuleFormTestResult/__snapshots__/RuleFormTestResult.test.tsx.snap
+++ b/web/src/components/forms/RuleForm/RuleFormTestResult/__snapshots__/RuleFormTestResult.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`RuleFormTestResult matches the snapshot 1`] = `
           <dt
             class="panther-2"
           >
-            Dedup Message
+            Dedup String
           </dt>
           <dd
             class="panther-3"


### PR DESCRIPTION
Rename dedup() output label to "Dedup String" (on the rule test results UI)