### PR TITLE
Tidy config for Athena workgroups

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -436,7 +436,7 @@ Resources:
       RecursiveDeleteOption: true
       WorkGroupConfiguration:
         ResultConfiguration:
-          OutputLocation: !Sub s3://${AthenaResultsBucket}/panther/preview
+          OutputLocation: !Sub s3://${AthenaResultsBucket}/panther/preview/
 
   AthenaWorkGroup:
     Type: AWS::Athena::WorkGroup
@@ -445,8 +445,9 @@ Resources:
       Description: The Panther workgroup
       RecursiveDeleteOption: true
       WorkGroupConfiguration:
+        EnforceWorkGroupConfiguration: false # we want client side overrides
         ResultConfiguration:
-          OutputLocation: !Sub s3://${AthenaResultsBucket}/panther
+          OutputLocation: !Sub s3://${AthenaResultsBucket}/panther/
 
 Outputs:
   AppClientId:


### PR DESCRIPTION
## Changes

- Add `EnforceWorkGroupConfiguration` to the Panther Athena Workgroup to be consistent with Panther Enterprise where we need the Parquet compaction process to override the s3 path
- Add trailing `/` to s3 paths since the console UI enforces that they end in `/`

## Testing

- mage test:ci
- mage deploy, then checked Athena workgroups in console
