### PR TITLE
Fix gzip files being mis-detected as ms-fontobject

### DIFF
--- a/internal/compliance/resource_processor/processor/analysis_api.go
+++ b/internal/compliance/resource_processor/processor/analysis_api.go
@@ -19,9 +19,9 @@ package processor
  */
 
 import (
-	"github.com/pkg/errors"
 	"time"
 
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/gateway/analysis/client/operations"

--- a/internal/compliance/resource_processor/processor/analysis_api.go
+++ b/internal/compliance/resource_processor/processor/analysis_api.go
@@ -19,6 +19,7 @@ package processor
  */
 
 import (
+	"github.com/pkg/errors"
 	"time"
 
 	"go.uber.org/zap"
@@ -49,8 +50,7 @@ func getPolicies() (policyMap, error) {
 	result, err := analysisClient.Operations.GetEnabledPolicies(
 		&operations.GetEnabledPoliciesParams{HTTPClient: httpClient, Type: string(models.AnalysisTypePOLICY)})
 	if err != nil {
-		zap.L().Error("failed to load policies from analysis-api", zap.Error(err))
-		return nil, err
+		return nil, errors.WithMessage(err, "failed to load policies from analysis-api")
 	}
 	zap.L().Info("successfully loaded enabled policies from analysis-api",
 		zap.Int("policyCount", len(result.Payload.Policies)))

--- a/internal/log_analysis/log_processor/common/common.go
+++ b/internal/log_analysis/log_processor/common/common.go
@@ -83,5 +83,4 @@ type DataStream struct {
 	Source      *models.SourceIntegration
 	S3ObjectKey string
 	S3Bucket    string
-	ContentType string
 }

--- a/internal/log_analysis/log_processor/processor/processor_test.go
+++ b/internal/log_analysis/log_processor/processor/processor_test.go
@@ -69,7 +69,6 @@ var (
 	testSourceID    = "testSource"
 	testSourceLabel = "testSourceLabel"
 	testKey         = "testKey"
-	testContentType = "testContentType"
 )
 
 type testLog struct {
@@ -161,7 +160,7 @@ func TestProcessDataStreamError(t *testing.T) {
 			zap.Any(statsKey, *mockStats),
 
 			// error
-			zap.Error(errors.Wrap(errFailingReader, "failed to ReadString()")), // from run()
+			zap.Error(errors.Wrap(errFailingReader, "failed to read log line")), // from run()
 
 			// standard
 			zap.String("namespace", common.OpLogNamespace),
@@ -500,7 +499,6 @@ func makeDataStream() (dataStream *common.DataStream) {
 		Source:      testSource,
 		S3ObjectKey: testKey,
 		S3Bucket:    testBucket,
-		ContentType: testContentType,
 	}
 	return
 }

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -20,6 +20,7 @@ package sources
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"io"
 	"net/http"
@@ -176,17 +177,16 @@ func readS3Object(s3Object *S3ObjectInfo) (dataStream *common.DataStream, err er
 		// if it's plain text, just return the buffered reader
 		streamReader = bufferedReader
 	} else if strings.HasPrefix(contentType, "application/x-gzip") {
-		var gzipReader *gzip.Reader
-		gzipReader, err = gzip.NewReader(bufferedReader)
+		gzipReader, err := gzip.NewReader(bufferedReader)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to created gzip reader for s3://%s/%s",
 				s3Object.S3Bucket, s3Object.S3ObjectKey)
-			return
+			return nil, err
 		}
 		streamReader = gzipReader
 	} else {
 		err = &ErrUnsupportedFileType{Type: contentType}
-		return
+		return nil, err
 	}
 
 	dataStream = &common.DataStream{
@@ -194,26 +194,30 @@ func readS3Object(s3Object *S3ObjectInfo) (dataStream *common.DataStream, err er
 		Source:      sourceInfo,
 		S3Bucket:    s3Object.S3Bucket,
 		S3ObjectKey: s3Object.S3ObjectKey,
-		ContentType: contentType,
 	}
 	return dataStream, err
 }
 
 func detectContentType(r *bufio.Reader) (string, error) {
-	// We peek into the file header to identify the content type
-	// http.DetectContentType only uses up to the first 512 bytes
-	headerBytes, err := r.Peek(512)
-	if err != nil {
-		switch err {
-		// EOF or ErrBufferFull means file is shorter than n
-		case bufio.ErrBufferFull, io.EOF:
-			// not really an error
-		default:
-			return "", err
-		}
+	sniffLen := 512 // max byte len needed by http.DetectContentType()
+	header, err := r.Peek(sniffLen)
+	if err != nil && err != bufio.ErrBufferFull && err != io.EOF {
+		// EOF / ErrBufferFull means file is shorter than sniffLen, but not all detections need so large data.
+		return "", err
 	}
-	return http.DetectContentType(headerBytes), nil
+
+	// Try gzip first, for two reasons:
+	// 1. Performance: It the most usual file type for logs and there is an exact prefix check we can do to detect it.
+	// No need to wait for all the checks done by http.DetectContentType() before checking for gzip.
+	// 2. http.DetectContentType() has a bug which mis-detects gzip for ms-fontobject.
+	if bytes.HasPrefix(header, gzipSignature) {
+		return "application/x-gzip", nil
+	}
+
+	return http.DetectContentType(header), nil
 }
+
+var gzipSignature = []byte("\x1F\x8B\x08") // https://mimesniff.spec.whatwg.org/#matching-an-archive-type-pattern
 
 // ParseNotification parses a message received
 func ParseNotification(message string) ([]*S3ObjectInfo, error) {


### PR DESCRIPTION
## Background

Sometimes we mis-detect gzipped log files as ms-fontobject.

## Changes

Change the detection code to check directly for the gzip signature instead of relying on the `http.DetectContentType` function. That function checks for many content types and produces a false positive in some cases.

## Testing

- Unit
