### PR TITLE
Fixing ddb filtering

### DIFF
--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -96,7 +96,7 @@ Parameters:
 Mappings:
   Functions:
     AlertsApi:
-      Memory: 256
+      Memory: 512
       Timeout: 60
     AlertsForwarder:
       Memory: 128

--- a/internal/log_analysis/alerts_api/table/list.go
+++ b/internal/log_analysis/alerts_api/table/list.go
@@ -82,7 +82,6 @@ func (table *AlertsTable) ListAll(input *models.ListAlertsInput) (
 		KeyConditionExpression:    queryExpression.KeyCondition(),
 		ExclusiveStartKey:         queryExclusiveStartKey,
 		IndexName:                 index,
-		Limit:                     aws.Int64(*queryResultsLimit * 4), //optimization accounting for filtering
 	}
 
 	var lastKey DynamoItem


### PR DESCRIPTION
## Background

Found this issue while looking at the code today. This could result in alerts-api returning partial results to the FE. 

According to description: 
```
	// The maximum number of items to evaluate (not necessarily the number of matching
	// items). If DynamoDB processes the number of items up to the limit while processing
	// the results, it stops the operation and returns the matching values up to
	// that point, and a key in LastEvaluatedKey to apply in a subsequent operation,
	// so that you can pick up where you left off. Also, if the processed dataset
	// size exceeds 1 MB before DynamoDB reaches this limit, it stops the operation
	// and returns the matching values up to the limit, and a key in LastEvaluatedKey
	// to apply in a subsequent operation to continue the operation. For more information,
	// see Query and Scan (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html)
	// in the Amazon DynamoDB Developer Guide.
	Limit *int64 `min:"1" type:"integer"`

```

We however do some filtering on DDB side, so we are potentially "evaluating" a lot more results. 

## Changes

- Fixing bug where we could return partial alert results 

## Testing

- mage test:ci
