### PR TITLE
fix: broken redirect after sign-in

### DIFF
--- a/web/src/apollo/createErrorLink.ts
+++ b/web/src/apollo/createErrorLink.ts
@@ -48,6 +48,7 @@ const createErrorLink = (history: History<LocationErrorState>) => {
         history.replace({
           ...history.location,
           state: {
+            ...history.location.state,
             errorType: error.errorType,
           },
         });

--- a/web/src/components/GuardedRoute/GuardedRoute.tsx
+++ b/web/src/components/GuardedRoute/GuardedRoute.tsx
@@ -51,7 +51,7 @@ const GuardedRoute: React.FC<GuardedRouteProps> = ({ limitAccessTo, ...rest }) =
   if (limitAccessTo === 'authenticated') {
     redirectData = {
       pathname: urls.account.auth.signIn(),
-      state: { referrer: location },
+      state: { ...location.state, referrer: location },
     };
     // This one means that an authenticated user is trying to access an anonymous only page. What we
     // do is redirect them to a referrer page if it existed or just the base page. Now why the
@@ -64,6 +64,7 @@ const GuardedRoute: React.FC<GuardedRouteProps> = ({ limitAccessTo, ...rest }) =
     // referrer will exist)
   } else {
     redirectData = {
+      ...location.state.referrer,
       pathname: location?.state?.referrer?.pathname || '/',
       state: undefined,
     };


### PR DESCRIPTION
## Background

Currently when a user gets redirected to the sign-in page, he/she sometimes doesn't get redirected back where he/she was after the sign-in. 

This happens only when a session gets expired and nott when a session doesn't exist at all. This PR fixes that

## Changes

- Maintain location referrer state accross redirects
- maintain/restore `search` and `hash` params on the redirect URL

## Testing

- Manually
