### PR TITLE
fix: reverse mini-chart for TimeSeries charts

### DIFF
--- a/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
@@ -125,12 +125,19 @@ const TimeSeriesChart: React.FC<TimeSeriesLinesProps> = ({
         itemStyle: {
           color: theme.colors[severityColors[label]] || stringToPaleColor(label),
         },
-        data: values.map((v, i) => {
-          return {
-            name: label,
-            value: [timestamps[i], v],
-          };
-        }),
+        data: values
+          .map((v, i) => {
+            return {
+              name: label,
+              value: [timestamps[i], v],
+            };
+          })
+          /* This reverse is needed cause data provided by API are coming by descending timestamp.
+           * Although data are displayed correctly on the graph because are ordered by timestamp,
+           * echarts dont seem to apply the same logic when displaying the mini-chart, this reverse only
+           * affects that feature
+           */
+          .reverse(),
       };
     });
 


### PR DESCRIPTION
## Background

The mini-graph below all charts are displayed in reverse. The cause of this is that `seriesData` are coming from backend in descending timestamp order. While that didn't affect charts cause they are ordered on charts based on timestamp, echarts dont seem to apply the same logic on the mini-chart.

This PR fixes the issue (check before & after screenshot below), the alternative would be to change the API so that it returns data in ascending order.

### Before Screenshot
![Screenshot 2020-11-09 at 7 05 28 PM](https://user-images.githubusercontent.com/14179917/98573005-f9805580-22be-11eb-88d4-f42676270517.png)
### After Screenshot
![Screenshot 2020-11-09 at 7 04 58 PM](https://user-images.githubusercontent.com/14179917/98573030-01d89080-22bf-11eb-8a1d-bcb8b415f3b3.png)

## Changes

- Reversed data before passing it to echart

## Testing

- Locally
