### PR TITLE
add displayName to data models

### DIFF
--- a/api/gateway/analysis/api.yml
+++ b/api/gateway/analysis/api.yml
@@ -1436,6 +1436,8 @@ definitions:
         $ref: '#/definitions/userId'
       description:
         $ref: '#/definitions/description'
+      displayName:
+        $ref: '#/definitions/displayName'
       enabled:
         $ref: '#/definitions/enabled'
       id:
@@ -1469,6 +1471,8 @@ definitions:
         $ref: '#/definitions/body'
       description:
         $ref: '#/definitions/description'
+      displayName:
+        $ref: '#/definitions/displayName'
       enabled:
         $ref: '#/definitions/enabled'
       id:

--- a/api/gateway/analysis/models/data_model.go
+++ b/api/gateway/analysis/models/data_model.go
@@ -50,6 +50,9 @@ type DataModel struct {
 	// description
 	Description Description `json:"description,omitempty"`
 
+	// display name
+	DisplayName DisplayName `json:"displayName,omitempty"`
+
 	// enabled
 	// Required: true
 	Enabled Enabled `json:"enabled"`
@@ -97,6 +100,10 @@ func (m *DataModel) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDisplayName(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -183,6 +190,22 @@ func (m *DataModel) validateDescription(formats strfmt.Registry) error {
 	if err := m.Description.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("description")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *DataModel) validateDisplayName(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DisplayName) { // not required
+		return nil
+	}
+
+	if err := m.DisplayName.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("displayName")
 		}
 		return err
 	}

--- a/api/gateway/analysis/models/update_data_model.go
+++ b/api/gateway/analysis/models/update_data_model.go
@@ -41,6 +41,9 @@ type UpdateDataModel struct {
 	// description
 	Description Description `json:"description,omitempty"`
 
+	// display name
+	DisplayName DisplayName `json:"displayName,omitempty"`
+
 	// enabled
 	// Required: true
 	Enabled Enabled `json:"enabled"`
@@ -70,6 +73,10 @@ func (m *UpdateDataModel) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDisplayName(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -124,6 +131,22 @@ func (m *UpdateDataModel) validateDescription(formats strfmt.Registry) error {
 	if err := m.Description.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("description")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *UpdateDataModel) validateDisplayName(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DisplayName) { // not required
+		return nil
+	}
+
+	if err := m.DisplayName.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("displayName")
 		}
 		return err
 	}

--- a/internal/core/analysis_api/handlers/dynamo.go
+++ b/internal/core/analysis_api/handlers/dynamo.go
@@ -203,6 +203,7 @@ func (r *tableItem) DataModel() *models.DataModel {
 		Body:           r.Body,
 		CreatedAt:      r.CreatedAt,
 		CreatedBy:      r.CreatedBy,
+		DisplayName:    r.DisplayName,
 		Description:    r.Description,
 		Enabled:        r.Enabled,
 		ID:             r.ID,

--- a/internal/core/analysis_api/handlers/modify_datamodel.go
+++ b/internal/core/analysis_api/handlers/modify_datamodel.go
@@ -37,6 +37,7 @@ func ModifyDataModel(request *events.APIGatewayProxyRequest) *events.APIGatewayP
 	item := &tableItem{
 		Body:          input.Body,
 		Description:   input.Description,
+		DisplayName:   input.DisplayName,
 		Enabled:       input.Enabled,
 		ID:            input.ID,
 		Mappings:      input.Mappings,


### PR DESCRIPTION
## Background

Add DisplayName to DataModel, similar to Rules/Policies. This allows users to change the default name displayed with various DataModels. 

## Changes

- Added new `DisplayName` field to `UpdateDataModel` object

## Testing

- `mage test:ci` 
