### PR TITLE
Keep only 1 required field for each Cloudflare log type

### DIFF
--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/cloudflarelogs.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/cloudflarelogs.go
@@ -37,24 +37,27 @@ var logTypes = func() logtypes.Group {
 	))
 	return logtypes.Must("Cloudflare",
 		logtypes.ConfigJSON{
-			Name:         "Cloudflare.HttpRequest",
-			Description:  `Cloudflare http request logs`,
+			Name: "Cloudflare.HttpRequest",
+			// nolint:lll
+			Description:  `Cloudflare http request logs. When selecting event fields on the Cloudflare UI, make sure you include the "EdgeStartTimestamp" field as it is required by Panther.`,
 			ReferenceURL: `https://developers.cloudflare.com/logs/log-fields#http-requests`,
 			NewEvent: func() interface{} {
 				return &HTTPRequest{}
 			},
 		},
 		logtypes.ConfigJSON{
-			Name:         "Cloudflare.Spectrum",
-			Description:  `Cloudflare Spectrum logs`,
+			Name: "Cloudflare.Spectrum",
+			// nolint:lll
+			Description:  `Cloudflare Spectrum logs. When selecting event fields on the Cloudflare UI, make sure you include the "Timestamp" field as it is required by Panther.`,
 			ReferenceURL: `https://developers.cloudflare.com/logs/log-fields#spectrum-events`,
 			NewEvent: func() interface{} {
 				return &SpectrumEvent{}
 			},
 		},
 		logtypes.ConfigJSON{
-			Name:         "Cloudflare.Firewall",
-			Description:  `Cloudflare Firewall logs`,
+			Name: "Cloudflare.Firewall",
+			// nolint:lll
+			Description:  `Cloudflare Firewall logs. When selecting event fields on the Cloudflare UI, make sure you include the "Datetime" field as it is required by Panther.`,
 			ReferenceURL: `https://developers.cloudflare.com/logs/log-fields#firewall-events`,
 			NewEvent: func() interface{} {
 				return &FirewallEvent{}

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/firewall.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/firewall.go
@@ -22,7 +22,6 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 )
 
-// Note: No field is marked "required" because Cloudflare allows the user to select which fields to include in the logs.
 // nolint:lll,maligned
 type FirewallEvent struct {
 	Action                 pantherlog.String                `json:"Action" description:"The code of the first-class action the Cloudflare Firewall took on this request"`
@@ -37,7 +36,7 @@ type FirewallEvent struct {
 	ClientRefererScheme    pantherlog.String                `json:"ClientRefererScheme" description:"The referer url scheme requested by the visitor"`
 	ClientRequestHost      pantherlog.String                `json:"ClientRequestHost" panther:"hostname" description:"The HTTP hostname requested by the visitor"`
 	ClientRequestMethod    pantherlog.String                `json:"ClientRequestMethod" description:"The HTTP method used by the visitor"`
-	ClientRequestPath      pantherlog.String                `json:"ClientRequestPath" validate:"required" description:"The path requested by visitor"`
+	ClientRequestPath      pantherlog.String                `json:"ClientRequestPath" description:"The path requested by visitor"`
 	ClientRequestProtocol  pantherlog.String                `json:"ClientRequestProtocol" description:"The version of HTTP protocol requested by the visitor"`
 	ClientRequestQuery     pantherlog.String                `json:"ClientRequestQuery" description:"The query-string was requested by the visitor"`
 	ClientRequestScheme    pantherlog.String                `json:"ClientRequestScheme" description:"The url scheme requested by the visitor"`

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/http_request.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/http_request.go
@@ -22,7 +22,6 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 )
 
-// Note: No field is marked "required" because Cloudflare allows the user to select which fields to include in the logs.
 // nolint:lll,maligned
 type HTTPRequest struct {
 	BotScore                       pantherlog.Int64   `json:"BotScore" description:"Cloudflare Bot Score (available for Bot Management customers; please contact your account team to enable)"`
@@ -39,7 +38,7 @@ type HTTPRequest struct {
 	ClientRequestBytes             pantherlog.Int64   `json:"ClientRequestBytes" description:"Number of bytes in the client request"`
 	ClientRequestHost              pantherlog.String  `json:"ClientRequestHost" panther:"hostname" description:"Host requested by the client"`
 	ClientRequestMethod            pantherlog.String  `json:"ClientRequestMethod" description:"HTTP method of client request"`
-	ClientRequestPath              pantherlog.String  `json:"ClientRequestPath" validate:"required" description:"URI path requested by the client"`
+	ClientRequestPath              pantherlog.String  `json:"ClientRequestPath" description:"URI path requested by the client"`
 	ClientRequestProtocol          pantherlog.String  `json:"ClientRequestProtocol" description:"HTTP protocol of client request"`
 	ClientRequestReferer           pantherlog.String  `json:"ClientRequestReferer" panther:"hostname" description:"HTTP request referrer"`
 	ClientRequestURI               pantherlog.String  `json:"ClientRequestURI" description:"URI requested by the client"`

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/spectrum.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/spectrum.go
@@ -22,7 +22,6 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 )
 
-// Note: No field is marked "required" because Cloudflare allows the user to select which fields to include in the logs.
 // nolint:lll,maligned
 type SpectrumEvent struct {
 	Application                    pantherlog.String `json:"Application" description:"The unique public ID of the application on which the event occurred"`
@@ -41,7 +40,7 @@ type SpectrumEvent struct {
 	ColoCode                       pantherlog.String `json:"ColoCode" description:"IATA airport code of data center that received the request"`
 	ConnectTimestamp               pantherlog.Time   `json:"ConnectTimestamp" tcodec:"cloudflare" description:"Timestamp at which both legs of the connection (client/edge, edge/origin or nexthop) were established"`
 	DisconnectTimestamp            pantherlog.Time   `json:"DisconnectTimestamp" tcodec:"cloudflare" description:"Timestamp at which the connection was closed"`
-	Event                          pantherlog.String `json:"Event" validate:"required" description:"connect | disconnect | clientFiltered | tlsError | resolveOrigin | originError"`
+	Event                          pantherlog.String `json:"Event" description:"connect | disconnect | clientFiltered | tlsError | resolveOrigin | originError"`
 	IPFirewall                     pantherlog.Bool   `json:"IpFirewall" description:"Whether IP Firewall was enabled at time of connection"`
 	OriginBytes                    pantherlog.Int64  `json:"OriginBytes" description:"The number of bytes read from the origin by Spectrum"`
 	OriginIP                       pantherlog.String `json:"OriginIP" panther:"ip" description:"Origin IP address"`

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/testdata/cloudflare_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/testdata/cloudflare_tests.yml
@@ -91,6 +91,19 @@ result: |
   }
 
 ---
+name: firewall required fields only
+logType: Cloudflare.Firewall
+input: |
+  {
+    "Datetime": "2020-09-17T18:00:00Z"
+  }
+result: |
+  {
+    "Datetime": "2020-09-17T18:00:00Z",
+    "p_log_type": "Cloudflare.Firewall",
+    "p_event_time":"2020-09-17T18:00:00Z"
+  }
+---
 name: http_request
 logType: Cloudflare.HttpRequest
 input: |
@@ -229,6 +242,20 @@ result: |
   	"p_any_trace_ids": ["parent-ray-id", "ray-id"]
   }
 ---
+name: httprequest required fields only
+logType: Cloudflare.HttpRequest
+input: |
+  {
+    "EdgeStartTimestamp": "2020-09-17T18:00:00Z"
+  }
+result: |
+  {
+    "EdgeStartTimestamp": "2020-09-17T18:00:00Z",
+    "p_log_type": "Cloudflare.HttpRequest",
+    "p_event_time":"2020-09-17T18:00:00Z"
+  }
+
+---
 name: spectrum
 logType: Cloudflare.Spectrum
 input: |
@@ -302,4 +329,18 @@ result: |
   	"p_log_type": "Cloudflare.Spectrum",
   	"p_event_time":"2020-09-17T18:49:46.194526741Z",
   	"p_any_ip_addresses": ["127.127.127.127", "128.128.128.128"]
+  }
+
+---
+name: spectrum required fields only
+logType: Cloudflare.Spectrum
+input: |
+  {
+    "Timestamp": "2020-09-17T18:00:00Z"
+  }
+result: |
+  {
+    "Timestamp": "2020-09-17T18:00:00Z",
+    "p_log_type": "Cloudflare.Spectrum",
+    "p_event_time":"2020-09-17T18:00:00Z"
   }


### PR DESCRIPTION
## Background

Cloudflare allows users to select which fields should be included
in the events, meaning we can't arbitrarily tag fields as required.

## Changes

Keeps only 1 timestamp field as required for every Cloudflare log type.

## Testing

- unit tests
