### PR TITLE
Bump warn threshold for custom resources lambda

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -291,7 +291,7 @@ Resources:
       FunctionMemoryMB: !FindInMap [Functions, CustomResource, Memory]
       FunctionName: !Ref CustomResourceFunction
       FunctionTimeoutSec: !FindInMap [Functions, CustomResource, Timeout]
-      LoggedWarnThreshold: 1
+      LoggedWarnThreshold: 10
       ThrottleThreshold: 0
       ServiceToken: !GetAtt CustomResourceFunction.Arn
 


### PR DESCRIPTION
## Background

Every time we upgrade Panther, we get a handful of `WARN` messages logged by the `panther-cfn-custom-resources` lambda function (see below for examples). Since we're seeing these for every deployment, we're getting paged on every upgrade. I have increased the threshold from 1 to 10 to prevent these pages.

This particular  `WARN` alarm had overwritten the default threshold of I believe 15, and explicitly set it to 1. But there were no comments/documentation on why this was set this way, so I wasn't sure if we were good to increase it. But since we apparently aren't getting any good signal out of it at it's current level, I decided to bump it.

## Changes

- Changed the `WARN` threshold for the custom lambda alarms resource for the `panther-cfn-custom-resources` lambda from 1 to 10

## Testing

- None

## Example messages

This change is made on the assumption that the below messages (or ones similar) are not page worthy. If that assumption is incorrect (which I'm leaning on @austinbyers or @rleighton to weigh in on) then perhaps we shouldn't raise this alarm but could instead address the core issue. We saw these two `WARN` messages in each account that's been upgraded:

```
{
    "level": "warn",
    "ts": <...>,
    "caller": "main/lambda.go:42",
    "msg": "skipping delete for unsupported resource type",
    "application": "panther",
    "physicalResourceId": "custom:glue:update-tables",
    "requestId": "<...>",
    "requestType": "Delete",
    "resourceType": "Custom::UpdateGlueTables"
}
```

```
{
    "level": "warn",
    "ts": "<...>",
    "caller": "main/lambda.go:42",
    "msg": "skipping delete for unsupported resource type",
    "application": "panther",
    "physicalResourceId": "custom:athena:init",
    "requestId": "<...>",
    "requestType": "Delete",
    "resourceType": "Custom::AthenaInit"
}
```