### PR TITLE
GraphQL: Use undocumented `Long` scalar

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2,6 +2,7 @@ scalar AWSEmail
 scalar AWSDateTime
 scalar AWSTimestamp
 scalar AWSJSON
+scalar Long
 
 schema {
   query: Query
@@ -411,9 +412,9 @@ type OrganizationStatsResponse {
   topFailingResources: [ResourceSummary]
 }
 
-type Series {
-  label: String
-  values: [Int]
+type LongSeries {
+  label: String!
+  values: [Long!]!
 }
 
 type FloatSeries {
@@ -421,14 +422,11 @@ type FloatSeries {
   values: [Float!]!
 }
 
-type SeriesData {
-  timestamps: [AWSDateTime]
-  series: [Series]
-}
+union Series = LongSeries | FloatSeries
 
-type FloatSeriesData {
+type SeriesData {
   timestamps: [AWSDateTime!]!
-  series: [FloatSeries!]!
+  series: [Series!]!
 }
 
 type SingleValue {
@@ -439,7 +437,7 @@ type SingleValue {
 type LogAnalysisMetricsResponse {
   eventsProcessed: SeriesData!
   alertsBySeverity: SeriesData!
-  eventsLatency: FloatSeriesData!
+  eventsLatency: SeriesData!
   totalAlertsDelta: [SingleValue!]!
   alertsByRuleID: [SingleValue!]!
   fromDate: AWSDateTime!

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -417,16 +417,19 @@ type LongSeries {
   values: [Long!]!
 }
 
+type LongSeriesData {
+  timestamps: [AWSDateTime!]!
+  series: [LongSeries!]!
+}
+
 type FloatSeries {
   label: String!
   values: [Float!]!
 }
 
-union Series = LongSeries | FloatSeries
-
-type SeriesData {
+type FloatSeriesData {
   timestamps: [AWSDateTime!]!
-  series: [Series!]!
+  series: [FloatSeries!]!
 }
 
 type SingleValue {
@@ -435,9 +438,9 @@ type SingleValue {
 }
 
 type LogAnalysisMetricsResponse {
-  eventsProcessed: SeriesData!
-  alertsBySeverity: SeriesData!
-  eventsLatency: SeriesData!
+  eventsProcessed: LongSeriesData!
+  alertsBySeverity: LongSeriesData!
+  eventsLatency: FloatSeriesData!
   totalAlertsDelta: [SingleValue!]!
   alertsByRuleID: [SingleValue!]!
   fromDate: AWSDateTime!

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -18,7 +18,6 @@
 
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Maybe<T> = T | null;
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } &
   { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
@@ -362,6 +361,12 @@ export type FloatSeries = {
   values: Array<Scalars['Float']>;
 };
 
+export type FloatSeriesData = {
+  __typename?: 'FloatSeriesData';
+  timestamps: Array<Scalars['AWSDateTime']>;
+  series: Array<FloatSeries>;
+};
+
 export type GeneralSettings = {
   __typename?: 'GeneralSettings';
   displayName?: Maybe<Scalars['String']>;
@@ -614,9 +619,9 @@ export type LogAnalysisMetricsInput = {
 
 export type LogAnalysisMetricsResponse = {
   __typename?: 'LogAnalysisMetricsResponse';
-  eventsProcessed: SeriesData;
-  alertsBySeverity: SeriesData;
-  eventsLatency: SeriesData;
+  eventsProcessed: LongSeriesData;
+  alertsBySeverity: LongSeriesData;
+  eventsLatency: FloatSeriesData;
   totalAlertsDelta: Array<SingleValue>;
   alertsByRuleID: Array<SingleValue>;
   fromDate: Scalars['AWSDateTime'];
@@ -630,6 +635,12 @@ export type LongSeries = {
   __typename?: 'LongSeries';
   label: Scalars['String'];
   values: Array<Scalars['Long']>;
+};
+
+export type LongSeriesData = {
+  __typename?: 'LongSeriesData';
+  timestamps: Array<Scalars['AWSDateTime']>;
+  series: Array<LongSeries>;
 };
 
 export type ModifyGlobalPythonModuleInput = {
@@ -1134,14 +1145,6 @@ export type SendTestAlertInput = {
   outputIds: Array<Scalars['ID']>;
 };
 
-export type Series = LongSeries | FloatSeries;
-
-export type SeriesData = {
-  __typename?: 'SeriesData';
-  timestamps: Array<Scalars['AWSDateTime']>;
-  series: Array<Series>;
-};
-
 export enum SeverityEnum {
   Info = 'INFO',
   Low = 'LOW',
@@ -1562,12 +1565,10 @@ export type ResolversTypes = {
   ScannedResourceStats: ResolverTypeWrapper<ScannedResourceStats>;
   LogAnalysisMetricsInput: LogAnalysisMetricsInput;
   LogAnalysisMetricsResponse: ResolverTypeWrapper<LogAnalysisMetricsResponse>;
-  SeriesData: ResolverTypeWrapper<
-    Omit<SeriesData, 'series'> & { series: Array<ResolversTypes['Series']> }
-  >;
-  Series: ResolversTypes['LongSeries'] | ResolversTypes['FloatSeries'];
+  LongSeriesData: ResolverTypeWrapper<LongSeriesData>;
   LongSeries: ResolverTypeWrapper<LongSeries>;
   Long: ResolverTypeWrapper<Scalars['Long']>;
+  FloatSeriesData: ResolverTypeWrapper<FloatSeriesData>;
   FloatSeries: ResolverTypeWrapper<FloatSeries>;
   Float: ResolverTypeWrapper<Scalars['Float']>;
   SingleValue: ResolverTypeWrapper<SingleValue>;
@@ -1719,10 +1720,10 @@ export type ResolversParentTypes = {
   ScannedResourceStats: ScannedResourceStats;
   LogAnalysisMetricsInput: LogAnalysisMetricsInput;
   LogAnalysisMetricsResponse: LogAnalysisMetricsResponse;
-  SeriesData: Omit<SeriesData, 'series'> & { series: Array<ResolversParentTypes['Series']> };
-  Series: ResolversParentTypes['LongSeries'] | ResolversParentTypes['FloatSeries'];
+  LongSeriesData: LongSeriesData;
   LongSeries: LongSeries;
   Long: Scalars['Long'];
+  FloatSeriesData: FloatSeriesData;
   FloatSeries: FloatSeries;
   Float: Scalars['Float'];
   SingleValue: SingleValue;
@@ -2051,6 +2052,15 @@ export type FloatSeriesResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
+export type FloatSeriesDataResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['FloatSeriesData'] = ResolversParentTypes['FloatSeriesData']
+> = {
+  timestamps?: Resolver<Array<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
+  series?: Resolver<Array<ResolversTypes['FloatSeries']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
 export type GeneralSettingsResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['GeneralSettings'] = ResolversParentTypes['GeneralSettings']
@@ -2195,9 +2205,9 @@ export type LogAnalysisMetricsResponseResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['LogAnalysisMetricsResponse'] = ResolversParentTypes['LogAnalysisMetricsResponse']
 > = {
-  eventsProcessed?: Resolver<ResolversTypes['SeriesData'], ParentType, ContextType>;
-  alertsBySeverity?: Resolver<ResolversTypes['SeriesData'], ParentType, ContextType>;
-  eventsLatency?: Resolver<ResolversTypes['SeriesData'], ParentType, ContextType>;
+  eventsProcessed?: Resolver<ResolversTypes['LongSeriesData'], ParentType, ContextType>;
+  alertsBySeverity?: Resolver<ResolversTypes['LongSeriesData'], ParentType, ContextType>;
+  eventsLatency?: Resolver<ResolversTypes['FloatSeriesData'], ParentType, ContextType>;
   totalAlertsDelta?: Resolver<Array<ResolversTypes['SingleValue']>, ParentType, ContextType>;
   alertsByRuleID?: Resolver<Array<ResolversTypes['SingleValue']>, ParentType, ContextType>;
   fromDate?: Resolver<ResolversTypes['AWSDateTime'], ParentType, ContextType>;
@@ -2227,6 +2237,15 @@ export type LongSeriesResolvers<
 > = {
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['Long']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type LongSeriesDataResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['LongSeriesData'] = ResolversParentTypes['LongSeriesData']
+> = {
+  timestamps?: Resolver<Array<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
+  series?: Resolver<Array<ResolversTypes['LongSeries']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -2845,22 +2864,6 @@ export type ScannedResourceStatsResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type SeriesResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Series'] = ResolversParentTypes['Series']
-> = {
-  __resolveType: TypeResolveFn<'LongSeries' | 'FloatSeries', ParentType, ContextType>;
-};
-
-export type SeriesDataResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['SeriesData'] = ResolversParentTypes['SeriesData']
-> = {
-  timestamps?: Resolver<Array<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
-  series?: Resolver<Array<ResolversTypes['Series']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
 export type SingleValueResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['SingleValue'] = ResolversParentTypes['SingleValue']
@@ -3081,6 +3084,7 @@ export type Resolvers<ContextType = any> = {
   DetectionTestDefinition?: DetectionTestDefinitionResolvers<ContextType>;
   Error?: ErrorResolvers<ContextType>;
   FloatSeries?: FloatSeriesResolvers<ContextType>;
+  FloatSeriesData?: FloatSeriesDataResolvers<ContextType>;
   GeneralSettings?: GeneralSettingsResolvers<ContextType>;
   GithubConfig?: GithubConfigResolvers<ContextType>;
   GlobalPythonModule?: GlobalPythonModuleResolvers<ContextType>;
@@ -3098,6 +3102,7 @@ export type Resolvers<ContextType = any> = {
   LogIntegration?: LogIntegrationResolvers;
   Long?: GraphQLScalarType;
   LongSeries?: LongSeriesResolvers<ContextType>;
+  LongSeriesData?: LongSeriesDataResolvers<ContextType>;
   MsTeamsConfig?: MsTeamsConfigResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OpsgenieConfig?: OpsgenieConfigResolvers<ContextType>;
@@ -3116,8 +3121,6 @@ export type Resolvers<ContextType = any> = {
   S3LogIntegrationHealth?: S3LogIntegrationHealthResolvers<ContextType>;
   ScannedResources?: ScannedResourcesResolvers<ContextType>;
   ScannedResourceStats?: ScannedResourceStatsResolvers<ContextType>;
-  Series?: SeriesResolvers;
-  SeriesData?: SeriesDataResolvers<ContextType>;
   SingleValue?: SingleValueResolvers<ContextType>;
   SlackConfig?: SlackConfigResolvers<ContextType>;
   SnsConfig?: SnsConfigResolvers<ContextType>;

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -50,7 +50,6 @@ import {
   DetectionTestDefinitionInput,
   Error,
   FloatSeries,
-  FloatSeriesData,
   GeneralSettings,
   GetAlertInput,
   GetComplianceIntegrationTemplateInput,
@@ -81,6 +80,7 @@ import {
   ListRulesResponse,
   LogAnalysisMetricsInput,
   LogAnalysisMetricsResponse,
+  LongSeries,
   ModifyGlobalPythonModuleInput,
   MsTeamsConfig,
   MsTeamsConfigInput,
@@ -106,7 +106,6 @@ import {
   ScannedResources,
   ScannedResourceStats,
   SendTestAlertInput,
-  Series,
   SeriesData,
   SingleValue,
   SlackConfig,
@@ -150,6 +149,7 @@ import {
   ListResourcesSortFieldsEnum,
   ListRulesSortFieldsEnum,
   LogIntegration,
+  Series,
   SeverityEnum,
   SortDirEnum,
 } from '../../__generated__/schema';
@@ -589,14 +589,6 @@ export const buildFloatSeries = (overrides: Partial<FloatSeries> = {}): FloatSer
   };
 };
 
-export const buildFloatSeriesData = (overrides: Partial<FloatSeriesData> = {}): FloatSeriesData => {
-  return {
-    __typename: 'FloatSeriesData',
-    timestamps: 'timestamps' in overrides ? overrides.timestamps : ['2020-04-22T20:42:06.736Z'],
-    series: 'series' in overrides ? overrides.series : [buildFloatSeries()],
-  };
-};
-
 export const buildGeneralSettings = (overrides: Partial<GeneralSettings> = {}): GeneralSettings => {
   return {
     __typename: 'GeneralSettings',
@@ -938,13 +930,21 @@ export const buildLogAnalysisMetricsResponse = (
     eventsProcessed: 'eventsProcessed' in overrides ? overrides.eventsProcessed : buildSeriesData(),
     alertsBySeverity:
       'alertsBySeverity' in overrides ? overrides.alertsBySeverity : buildSeriesData(),
-    eventsLatency: 'eventsLatency' in overrides ? overrides.eventsLatency : buildFloatSeriesData(),
+    eventsLatency: 'eventsLatency' in overrides ? overrides.eventsLatency : buildSeriesData(),
     totalAlertsDelta:
       'totalAlertsDelta' in overrides ? overrides.totalAlertsDelta : [buildSingleValue()],
     alertsByRuleID: 'alertsByRuleID' in overrides ? overrides.alertsByRuleID : [buildSingleValue()],
     fromDate: 'fromDate' in overrides ? overrides.fromDate : '2020-06-15T22:39:08.690Z',
     toDate: 'toDate' in overrides ? overrides.toDate : '2020-06-29T16:49:54.582Z',
     intervalMinutes: 'intervalMinutes' in overrides ? overrides.intervalMinutes : 670,
+  };
+};
+
+export const buildLongSeries = (overrides: Partial<LongSeries> = {}): LongSeries => {
+  return {
+    __typename: 'LongSeries',
+    label: 'label' in overrides ? overrides.label : 'envisioneer',
+    values: 'values' in overrides ? overrides.values : [95698],
   };
 };
 
@@ -1302,19 +1302,11 @@ export const buildSendTestAlertInput = (
   };
 };
 
-export const buildSeries = (overrides: Partial<Series> = {}): Series => {
-  return {
-    __typename: 'Series',
-    label: 'label' in overrides ? overrides.label : 'Idaho',
-    values: 'values' in overrides ? overrides.values : [371],
-  };
-};
-
 export const buildSeriesData = (overrides: Partial<SeriesData> = {}): SeriesData => {
   return {
     __typename: 'SeriesData',
     timestamps: 'timestamps' in overrides ? overrides.timestamps : ['2020-10-18T14:12:28.273Z'],
-    series: 'series' in overrides ? overrides.series : [buildSeries()],
+    series: 'series' in overrides ? overrides.series : [buildFloatSeries()],
   };
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -50,6 +50,7 @@ import {
   DetectionTestDefinitionInput,
   Error,
   FloatSeries,
+  FloatSeriesData,
   GeneralSettings,
   GetAlertInput,
   GetComplianceIntegrationTemplateInput,
@@ -81,6 +82,7 @@ import {
   LogAnalysisMetricsInput,
   LogAnalysisMetricsResponse,
   LongSeries,
+  LongSeriesData,
   ModifyGlobalPythonModuleInput,
   MsTeamsConfig,
   MsTeamsConfigInput,
@@ -106,7 +108,6 @@ import {
   ScannedResources,
   ScannedResourceStats,
   SendTestAlertInput,
-  SeriesData,
   SingleValue,
   SlackConfig,
   SlackConfigInput,
@@ -149,7 +150,6 @@ import {
   ListResourcesSortFieldsEnum,
   ListRulesSortFieldsEnum,
   LogIntegration,
-  Series,
   SeverityEnum,
   SortDirEnum,
 } from '../../__generated__/schema';
@@ -589,6 +589,14 @@ export const buildFloatSeries = (overrides: Partial<FloatSeries> = {}): FloatSer
   };
 };
 
+export const buildFloatSeriesData = (overrides: Partial<FloatSeriesData> = {}): FloatSeriesData => {
+  return {
+    __typename: 'FloatSeriesData',
+    timestamps: 'timestamps' in overrides ? overrides.timestamps : ['2020-04-22T20:42:06.736Z'],
+    series: 'series' in overrides ? overrides.series : [buildFloatSeries()],
+  };
+};
+
 export const buildGeneralSettings = (overrides: Partial<GeneralSettings> = {}): GeneralSettings => {
   return {
     __typename: 'GeneralSettings',
@@ -927,10 +935,11 @@ export const buildLogAnalysisMetricsResponse = (
 ): LogAnalysisMetricsResponse => {
   return {
     __typename: 'LogAnalysisMetricsResponse',
-    eventsProcessed: 'eventsProcessed' in overrides ? overrides.eventsProcessed : buildSeriesData(),
+    eventsProcessed:
+      'eventsProcessed' in overrides ? overrides.eventsProcessed : buildLongSeriesData(),
     alertsBySeverity:
-      'alertsBySeverity' in overrides ? overrides.alertsBySeverity : buildSeriesData(),
-    eventsLatency: 'eventsLatency' in overrides ? overrides.eventsLatency : buildSeriesData(),
+      'alertsBySeverity' in overrides ? overrides.alertsBySeverity : buildLongSeriesData(),
+    eventsLatency: 'eventsLatency' in overrides ? overrides.eventsLatency : buildFloatSeriesData(),
     totalAlertsDelta:
       'totalAlertsDelta' in overrides ? overrides.totalAlertsDelta : [buildSingleValue()],
     alertsByRuleID: 'alertsByRuleID' in overrides ? overrides.alertsByRuleID : [buildSingleValue()],
@@ -945,6 +954,14 @@ export const buildLongSeries = (overrides: Partial<LongSeries> = {}): LongSeries
     __typename: 'LongSeries',
     label: 'label' in overrides ? overrides.label : 'envisioneer',
     values: 'values' in overrides ? overrides.values : [95698],
+  };
+};
+
+export const buildLongSeriesData = (overrides: Partial<LongSeriesData> = {}): LongSeriesData => {
+  return {
+    __typename: 'LongSeriesData',
+    timestamps: 'timestamps' in overrides ? overrides.timestamps : ['2020-05-29T02:52:10.141Z'],
+    series: 'series' in overrides ? overrides.series : [buildLongSeries()],
   };
 };
 
@@ -1299,14 +1316,6 @@ export const buildSendTestAlertInput = (
   return {
     outputIds:
       'outputIds' in overrides ? overrides.outputIds : ['900d0911-ac12-4720-a1a9-89d6f1995c9f'],
-  };
-};
-
-export const buildSeriesData = (overrides: Partial<SeriesData> = {}): SeriesData => {
-  return {
-    __typename: 'SeriesData',
-    timestamps: 'timestamps' in overrides ? overrides.timestamps : ['2020-10-18T14:12:28.273Z'],
-    series: 'series' in overrides ? overrides.series : [buildFloatSeries()],
   };
 };
 

--- a/web/codegen.yml
+++ b/web/codegen.yml
@@ -32,6 +32,7 @@ generates:
         AWSTimestamp: number
         AWSDateTime: string
         AWSJSON: string
+        Long: number
 
   web/__tests__/__mocks__/builders.generated.ts:
     plugins:

--- a/web/codegen/buildGraphqlResourcesPlugin.js
+++ b/web/codegen/buildGraphqlResourcesPlugin.js
@@ -97,6 +97,8 @@ const getNamedType = (typeName, fieldName, types, namedType) => {
                 return wrapWithQuotes(faker_1.default.date.past().toISOString());
               case 'AWSJSON':
                 return wrapWithQuotes(JSON.stringify(faker_1.default.random.objectElement()));
+              case 'Long':
+                return faker_1.default.random.number();
               default:
                 throw new Error(`Found unknown Scalar: ${foundType.name}`);
             }

--- a/web/codegen/buildGraphqlResourcesPlugin.ts
+++ b/web/codegen/buildGraphqlResourcesPlugin.ts
@@ -110,6 +110,8 @@ const getNamedType = (
                 return wrapWithQuotes(faker.date.past().toISOString());
               case 'AWSJSON':
                 return wrapWithQuotes(JSON.stringify(faker.random.objectElement()));
+              case 'Long':
+                return faker.random.number();
               default:
                 throw new Error(`Found unknown Scalar: ${foundType.name}`);
             }

--- a/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Box, Flex, Text, useTheme } from 'pouncejs';
 import { formatTime, formatDatetime, remToPx, capitalize } from 'Helpers/utils';
-import { SeriesData } from 'Generated/schema';
+import { FloatSeriesData, LongSeriesData, FloatSeries, LongSeries } from 'Generated/schema';
 import { EChartOption, ECharts } from 'echarts';
 import mapKeys from 'lodash/mapKeys';
 import { SEVERITY_COLOR_MAP } from 'Source/constants';
@@ -30,7 +30,7 @@ import ScaleControls from '../ScaleControls';
 
 interface TimeSeriesLinesProps {
   /** The data for the time series */
-  data: SeriesData;
+  data: LongSeriesData | FloatSeriesData;
 
   /**
    * The number of segments that the X-axis is split into
@@ -99,10 +99,10 @@ const TimeSeriesChart: React.FC<TimeSeriesLinesProps> = ({
    */
   const chartOptions = React.useMemo(() => {
     /*
-     *  Timestamps are common for all series since everything has the same interval
+     *  Timestamps & Series are common for all series since everything has the same interval
      *  and the same time frame
      */
-    const { timestamps, series } = data;
+    const series = data.series as (LongSeries | FloatSeries)[];
     /*
      * 'legendData' must be an array of values that matches 'series.name'in order
      * to display them in correct order and color
@@ -129,7 +129,7 @@ const TimeSeriesChart: React.FC<TimeSeriesLinesProps> = ({
           .map((v, i) => {
             return {
               name: label,
-              value: [timestamps[i], v],
+              value: [data.timestamps[i], v],
             };
           })
           /* This reverse is needed cause data provided by API are coming by descending timestamp.

--- a/web/src/pages/LogAnalysisOverview/AlertsBySeverity/AlertsBySeverity.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsBySeverity/AlertsBySeverity.tsx
@@ -20,10 +20,10 @@ import React from 'react';
 import { Box, Flex } from 'pouncejs';
 import TimeSeriesChart from 'Components/charts/TimeSeriesChart';
 import { capitalize } from 'Helpers/utils';
-import { SeriesData } from 'Generated/schema';
+import { LongSeriesData } from 'Generated/schema';
 
 interface AlertsBySeverityProps {
-  alerts: SeriesData;
+  alerts: LongSeriesData;
 }
 
 const AlertsBySeverity: React.FC<AlertsBySeverityProps> = ({ alerts: { series, timestamps } }) => {

--- a/web/src/pages/LogAnalysisOverview/AlertsCharts/AlertsCharts.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsCharts/AlertsCharts.tsx
@@ -19,14 +19,14 @@
 import React from 'react';
 import { Box, Card, Flex, TabList, TabPanel, TabPanels, Tabs } from 'pouncejs';
 import { BorderedTab, BorderTabDivider } from 'Components/BorderedTab';
-import { SeriesData, SingleValue } from 'Generated/schema';
+import { LongSeriesData, SingleValue } from 'Generated/schema';
 import AlertSummary from 'Pages/LogAnalysisOverview/AlertSummary';
 import AlertsBySeverity from 'Pages/LogAnalysisOverview/AlertsBySeverity/AlertsBySeverity';
 import MostActiveRules from 'Pages/LogAnalysisOverview/MostActiveRules/MostActiveRules';
 
 interface LogTypeChartsProps {
   totalAlertsDelta: SingleValue[];
-  alertsBySeverity: SeriesData;
+  alertsBySeverity: LongSeriesData;
   alertsByRuleID: SingleValue[];
 }
 

--- a/web/src/pages/LogAnalysisOverview/EventsByLatency/EventsByLatency.tsx
+++ b/web/src/pages/LogAnalysisOverview/EventsByLatency/EventsByLatency.tsx
@@ -19,10 +19,10 @@
 import React from 'react';
 import { Flex } from 'pouncejs';
 import TimeSeriesChart from 'Components/charts/TimeSeriesChart';
-import { SeriesData } from 'Generated/schema';
+import { FloatSeriesData } from 'Generated/schema';
 
 interface EventsByLatencyProps {
-  events: SeriesData;
+  events: FloatSeriesData;
 }
 
 const EventsByLatency: React.FC<EventsByLatencyProps> = ({ events: { timestamps, series } }) => {

--- a/web/src/pages/LogAnalysisOverview/EventsByLogType/EventsByLogType.tsx
+++ b/web/src/pages/LogAnalysisOverview/EventsByLogType/EventsByLogType.tsx
@@ -19,10 +19,10 @@
 import React from 'react';
 import { Flex } from 'pouncejs';
 import TimeSeriesChart from 'Components/charts/TimeSeriesChart';
-import { SeriesData } from 'Generated/schema';
+import { LongSeriesData } from 'Generated/schema';
 
 interface EventsByLogTypesProps {
-  events: SeriesData;
+  events: LongSeriesData;
 }
 
 const EventsByLogTypes: React.FC<EventsByLogTypesProps> = ({ events }) => {

--- a/web/src/pages/LogAnalysisOverview/LogTypeCharts/LogTypeCharts.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogTypeCharts/LogTypeCharts.tsx
@@ -20,12 +20,12 @@ import React from 'react';
 import { Box, Card, TabList, TabPanel, TabPanels, Tabs } from 'pouncejs';
 import { BorderedTab, BorderTabDivider } from 'Components/BorderedTab';
 import EventsByLogType from 'Pages/LogAnalysisOverview/EventsByLogType/EventsByLogType';
-import { SeriesData } from 'Generated/schema';
+import { LongSeriesData, FloatSeriesData } from 'Generated/schema';
 import EventsByLatency from '../EventsByLatency';
 
 interface LogTypeChartsProps {
-  eventsProcessed: SeriesData;
-  eventsLatency: SeriesData;
+  eventsProcessed: LongSeriesData;
+  eventsLatency: FloatSeriesData;
 }
 
 const LogTypeCharts: React.FC<LogTypeChartsProps> = ({ eventsProcessed, eventsLatency }) => {

--- a/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.generated.ts
+++ b/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.generated.ts
@@ -30,13 +30,13 @@ export type GetLogAnalysisMetricsVariables = {
 export type GetLogAnalysisMetrics = {
   getLogAnalysisMetrics: Pick<Types.LogAnalysisMetricsResponse, 'intervalMinutes'> & {
     eventsProcessed: Pick<Types.SeriesData, 'timestamps'> & {
-      series?: Types.Maybe<Array<Types.Maybe<Pick<Types.Series, 'label' | 'values'>>>>;
+      series: Array<Pick<Types.LongSeries, 'label' | 'values'>>;
     };
-    eventsLatency: Pick<Types.FloatSeriesData, 'timestamps'> & {
+    eventsLatency: Pick<Types.SeriesData, 'timestamps'> & {
       series: Array<Pick<Types.FloatSeries, 'label' | 'values'>>;
     };
     alertsBySeverity: Pick<Types.SeriesData, 'timestamps'> & {
-      series?: Types.Maybe<Array<Types.Maybe<Pick<Types.Series, 'label' | 'values'>>>>;
+      series: Array<Pick<Types.LongSeries, 'label' | 'values'>>;
     };
     totalAlertsDelta: Array<Pick<Types.SingleValue, 'label' | 'value'>>;
     alertsByRuleID: Array<Pick<Types.SingleValue, 'label' | 'value'>>;
@@ -48,22 +48,28 @@ export const GetLogAnalysisMetricsDocument = gql`
     getLogAnalysisMetrics(input: $input) {
       eventsProcessed {
         series {
-          label
-          values
+          ... on LongSeries {
+            label
+            values
+          }
         }
         timestamps
       }
       eventsLatency {
         series {
-          label
-          values
+          ... on FloatSeries {
+            label
+            values
+          }
         }
         timestamps
       }
       alertsBySeverity {
         series {
-          label
-          values
+          ... on LongSeries {
+            label
+            values
+          }
         }
         timestamps
       }

--- a/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.generated.ts
+++ b/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.generated.ts
@@ -29,13 +29,13 @@ export type GetLogAnalysisMetricsVariables = {
 
 export type GetLogAnalysisMetrics = {
   getLogAnalysisMetrics: Pick<Types.LogAnalysisMetricsResponse, 'intervalMinutes'> & {
-    eventsProcessed: Pick<Types.SeriesData, 'timestamps'> & {
+    eventsProcessed: Pick<Types.LongSeriesData, 'timestamps'> & {
       series: Array<Pick<Types.LongSeries, 'label' | 'values'>>;
     };
-    eventsLatency: Pick<Types.SeriesData, 'timestamps'> & {
+    eventsLatency: Pick<Types.FloatSeriesData, 'timestamps'> & {
       series: Array<Pick<Types.FloatSeries, 'label' | 'values'>>;
     };
-    alertsBySeverity: Pick<Types.SeriesData, 'timestamps'> & {
+    alertsBySeverity: Pick<Types.LongSeriesData, 'timestamps'> & {
       series: Array<Pick<Types.LongSeries, 'label' | 'values'>>;
     };
     totalAlertsDelta: Array<Pick<Types.SingleValue, 'label' | 'value'>>;
@@ -48,28 +48,22 @@ export const GetLogAnalysisMetricsDocument = gql`
     getLogAnalysisMetrics(input: $input) {
       eventsProcessed {
         series {
-          ... on LongSeries {
-            label
-            values
-          }
+          label
+          values
         }
         timestamps
       }
       eventsLatency {
         series {
-          ... on FloatSeries {
-            label
-            values
-          }
+          label
+          values
         }
         timestamps
       }
       alertsBySeverity {
         series {
-          ... on LongSeries {
-            label
-            values
-          }
+          label
+          values
         }
         timestamps
       }

--- a/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.graphql
+++ b/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.graphql
@@ -2,22 +2,28 @@ query GetLogAnalysisMetrics($input: LogAnalysisMetricsInput!) {
   getLogAnalysisMetrics(input: $input) {
     eventsProcessed {
       series {
-        label
-        values
+        ... on LongSeries {
+          label
+          values
+        }
       }
       timestamps
     }
     eventsLatency {
       series {
-        label
-        values
+        ... on FloatSeries {
+          label
+          values
+        }
       }
       timestamps
     }
     alertsBySeverity {
       series {
-        label
-        values
+        ... on LongSeries {
+          label
+          values
+        }
       }
       timestamps
     }

--- a/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.graphql
+++ b/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.graphql
@@ -2,28 +2,22 @@ query GetLogAnalysisMetrics($input: LogAnalysisMetricsInput!) {
   getLogAnalysisMetrics(input: $input) {
     eventsProcessed {
       series {
-        ... on LongSeries {
-          label
-          values
-        }
+        label
+        values
       }
       timestamps
     }
     eventsLatency {
       series {
-        ... on FloatSeries {
-          label
-          values
-        }
+        label
+        values
       }
       timestamps
     }
     alertsBySeverity {
       series {
-        ... on LongSeries {
-          label
-          values
-        }
+        label
+        values
       }
       timestamps
     }


### PR DESCRIPTION
## Background

Currently, we use `Int` and `Float`  as GraphQL scalars whenever we want to depict a numerical value. AppSync uses an 32bit `Int` and `Float` JavaLang representation under the hood, causing some big values ( > 2,000,000,000) to crash our system.

This hasn't been identified so far, because our test data didn't come near to those numbers. AppSync doesn't have any publicly documented scalars (other than `Int` and `Float`) and it doesn't allow you to specify your own custom scalars. The need for a `Long` type has been heavily requested [for more than a year](https://github.com/aws/aws-appsync-community/issues/21), but so far there haven't been any updates from AWS.

Due to the fact that AppSync uses Java under the hood (that's why it can parse VTL templates as well), I took advantage of that and used a `Long` type, knowing that `graphql-java` would map it to a [`Java Long`](https://docs.oracle.com/javase/7/docs/api/java/lang/Long.html) under the hood.

This is an  **undocumented feature**, but it serves our goal until we migrate away from Appsync (cc @austinbyers). A `Long` in java is a 64bit number.

## Changes

- Define a `Long` scalar our GraphQL documents
- Utilize `Long` scalar in our schema
- Update our schema, codegen and builders to let them be aware of this new scalar

## Testing

- `npm run test`

## Notes

I've checked all of the other `Int` declarations in our schema and verified that the OSS doesn't have any additional fields, where such an exception could occur
