### PR TITLE
fix: opsgenie default value

### DIFF
--- a/internal/core/alert_delivery/outputs/opsgenie.go
+++ b/internal/core/alert_delivery/outputs/opsgenie.go
@@ -63,7 +63,7 @@ func (client *OutputClient) Opsgenie(
 		AuthorizationHTTPHeader: authorization,
 	}
 
-	requestEndpoint := GetOpsGenieRegion(config.ServiceRegion)
+	requestEndpoint := GetOpsGenieRegionalEndpoint(config.ServiceRegion)
 
 	postInput := &PostInput{
 		url:     requestEndpoint,

--- a/internal/core/alert_delivery/outputs/opsgenie_test.go
+++ b/internal/core/alert_delivery/outputs/opsgenie_test.go
@@ -69,7 +69,7 @@ func TestOpsgenieAlert(t *testing.T) {
 		AuthorizationHTTPHeader: authorization,
 	}
 
-	requestEndpoint := GetOpsGenieRegion(opsgenieConfig.ServiceRegion)
+	requestEndpoint := GetOpsGenieRegionalEndpoint(opsgenieConfig.ServiceRegion)
 
 	expectedPostInput := &PostInput{
 		url:     requestEndpoint,
@@ -88,6 +88,6 @@ func TestOpsgenieServiceRegion(t *testing.T) {
 	//nolint:lll
 	expectedEndpoints := []string{"https://api.opsgenie.com/v2/alerts", "https://api.opsgenie.com/v2/alerts", "https://api.eu.opsgenie.com/v2/alerts"}
 	for i, serviceRegion := range opsGenieRegions {
-		assert.Equal(t, expectedEndpoints[i], GetOpsGenieRegion(serviceRegion))
+		assert.Equal(t, expectedEndpoints[i], GetOpsGenieRegionalEndpoint(serviceRegion))
 	}
 }

--- a/internal/core/alert_delivery/outputs/utils.go
+++ b/internal/core/alert_delivery/outputs/utils.go
@@ -99,7 +99,7 @@ func mapSQSSendMessageErrorCodeToStatusCode(awsErr awserr.Error) int {
 		return 500
 	}
 }
-func GetOpsGenieRegion(serviceRegion string) string {
+func GetOpsGenieRegionalEndpoint(serviceRegion string) string {
 	switch serviceRegion {
 	case OpsgenieServiceRegionUS:
 		return "https://api.opsgenie.com/v2/alerts"

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -108,7 +108,7 @@ func redactOutput(outputConfig *models.OutputConfig) {
 
 func configureOutputFallbacks(outputConfig *models.OutputConfig) {
 	if outputConfig.Opsgenie != nil {
-		outputConfig.Opsgenie.ServiceRegion = outputs.GetOpsGenieRegion(outputConfig.Opsgenie.ServiceRegion)
+		outputConfig.Opsgenie.ServiceRegion = outputs.OpsgenieServiceRegionUS
 	}
 }
 


### PR DESCRIPTION
## Background

Default value for opsgenie service region is wrong. This PR fixes it and assigns it the value `US`

## Changes

- refactor utility function name
- correct default opsgenie service region value

## Testing

`mage test:go`