### PR TITLE
Opsgenie incorrect region display

### DIFF
--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -108,7 +108,9 @@ func redactOutput(outputConfig *models.OutputConfig) {
 
 func configureOutputFallbacks(outputConfig *models.OutputConfig) {
 	if outputConfig.Opsgenie != nil {
-		outputConfig.Opsgenie.ServiceRegion = outputs.OpsgenieServiceRegionUS
+		if outputConfig.Opsgenie.ServiceRegion == "" {
+			outputConfig.Opsgenie.ServiceRegion = outputs.OpsgenieServiceRegionUS
+		}
 	}
 }
 


### PR DESCRIPTION
## Background

Creating an Opsgenie EU config works; however, upon refreshing the page the config shows it was set for the US region. This is because the check had a bug and overwrote the region to always be "US".

## Changes

- return "US" iff the region was an empty string ("")

## Testing

- N/A
