### PR TITLE
Minor polling fixes

### DIFF
--- a/internal/compliance/aws_event_processor/processor/elbv2.go
+++ b/internal/compliance/aws_event_processor/processor/elbv2.go
@@ -71,7 +71,7 @@ func classifyELBV2(detail gjson.Result, metadata *CloudTrailMetadata) []*resourc
 			resourceARN, err := arn.Parse(resource.Str)
 			if err != nil {
 				zap.L().Error("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(err))
-				return changes
+				return nil
 			}
 			if strings.HasPrefix(resourceARN.Resource, "targetgroup/") {
 				continue
@@ -93,7 +93,7 @@ func classifyELBV2(detail gjson.Result, metadata *CloudTrailMetadata) []*resourc
 			lbARN, err := arn.Parse(lb.Get("loadBalancerArn").Str)
 			if err != nil {
 				zap.L().Error("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(err))
-				return changes
+				return nil
 			}
 			changes = append(changes, &resourceChange{
 				AwsAccountID: metadata.accountID,

--- a/internal/compliance/aws_event_processor/processor/elbv2.go
+++ b/internal/compliance/aws_event_processor/processor/elbv2.go
@@ -130,7 +130,7 @@ func classifyELBV2(detail gjson.Result, metadata *CloudTrailMetadata) []*resourc
 	}
 
 	if parseErr != nil {
-		zap.L().Warn("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Any("event", metadata), zap.Error(parseErr))
+		zap.L().Error("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Any("event", metadata), zap.Error(parseErr))
 		return nil
 	}
 	return []*resourceChange{{

--- a/internal/compliance/aws_event_processor/processor/elbv2.go
+++ b/internal/compliance/aws_event_processor/processor/elbv2.go
@@ -130,7 +130,7 @@ func classifyELBV2(detail gjson.Result, metadata *CloudTrailMetadata) []*resourc
 	}
 
 	if parseErr != nil {
-		zap.L().Warn("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.String("event", metadata), zap.Error(parseErr))
+		zap.L().Warn("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Any("event", metadata), zap.Error(parseErr))
 		return nil
 	}
 	return []*resourceChange{{

--- a/internal/compliance/aws_event_processor/processor/elbv2.go
+++ b/internal/compliance/aws_event_processor/processor/elbv2.go
@@ -130,7 +130,8 @@ func classifyELBV2(detail gjson.Result, metadata *CloudTrailMetadata) []*resourc
 	}
 
 	if parseErr != nil {
-		zap.L().Warn("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(parseErr))
+		zap.L().Warn("elbv2: error parsing ARN", zap.String("eventName", metadata.eventName), zap.String("event", metadata), zap.Error(parseErr))
+		return nil
 	}
 	return []*resourceChange{{
 		AwsAccountID: metadata.accountID,

--- a/internal/compliance/aws_event_processor/processor/rds.go
+++ b/internal/compliance/aws_event_processor/processor/rds.go
@@ -57,7 +57,7 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 		resourceARN, err := arn.Parse(detail.Get("requestParameters.resourceName").Str)
 		if err != nil {
 			zap.L().Error("rds: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(err))
-			return  nil
+			return nil
 		}
 		if strings.HasPrefix(resourceARN.Resource, "db:") {
 			rdsARN = resourceARN

--- a/internal/compliance/aws_event_processor/processor/rds.go
+++ b/internal/compliance/aws_event_processor/processor/rds.go
@@ -57,6 +57,7 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 		resourceARN, err := arn.Parse(detail.Get("requestParameters.resourceName").Str)
 		if err != nil {
 			zap.L().Error("rds: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(err))
+			return  nil
 		}
 		if strings.HasPrefix(resourceARN.Resource, "db:") {
 			rdsARN = resourceARN

--- a/internal/compliance/aws_event_processor/processor/waf-regional.go
+++ b/internal/compliance/aws_event_processor/processor/waf-regional.go
@@ -73,6 +73,7 @@ func classifyWAFRegional(detail gjson.Result, metadata *CloudTrailMetadata) []*r
 		resourceARN, err := arn.Parse(detail.Get("requestParameters.resourceArn").Str)
 		if err != nil {
 			zap.L().Error("waf-regional: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(err))
+			return nil
 		}
 		var changes []*resourceChange
 		if strings.HasPrefix(resourceARN.Resource, "loadbalancer/") {
@@ -106,6 +107,7 @@ func classifyWAFRegional(detail gjson.Result, metadata *CloudTrailMetadata) []*r
 		resourceARN, err := arn.Parse(detail.Get("requestParameters.resourceArn").Str)
 		if err != nil {
 			zap.L().Error("waf-regional: error parsing ARN", zap.String("eventName", metadata.eventName), zap.Error(err))
+			return nil
 		}
 		var changes []*resourceChange
 		if strings.HasPrefix(resourceARN.Resource, "loadbalancer/") {

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/eks.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/eks.go
@@ -31,14 +31,15 @@ import (
 
 // Example Eks API return values
 var (
-	ExampleEksClusterName     = aws.String("example-cluster")
-	ExampleEksClusterArn      = aws.String("arn:aws:eks:us-west-2:123456789012:cluster/example-cluster")
-	ExampleFargateProfileName = aws.String("example-fargate-profile")
-	ExampleNodegroupName      = aws.String("example-nodegroup-name")
-	ExampleNodegroupArn       = aws.String("arn:aws:eks:us-west-2:123456789012:service/example-service")
-	ExampleTags               = map[string]*string{*aws.String("test-tag-key"): aws.String("test-tag-value")}
-	ExampleLabels             = map[string]*string{*aws.String("test-label-key"): aws.String("test-label-value")}
-	ExampleCreatedAt          = aws.Time(time.Unix(1579896067, 0))
+	ExampleEksClusterName      = aws.String("example-cluster")
+	ExampleEksClusterNameMulti = aws.String("example-cluster-multi-profile")
+	ExampleEksClusterArn       = aws.String("arn:aws:eks:us-west-2:123456789012:cluster/example-cluster")
+	ExampleFargateProfileName  = aws.String("example-fargate-profile")
+	ExampleNodegroupName       = aws.String("example-nodegroup-name")
+	ExampleNodegroupArn        = aws.String("arn:aws:eks:us-west-2:123456789012:service/example-service")
+	ExampleTags                = map[string]*string{*aws.String("test-tag-key"): aws.String("test-tag-value")}
+	ExampleLabels              = map[string]*string{*aws.String("test-label-key"): aws.String("test-label-value")}
+	ExampleCreatedAt           = aws.Time(time.Unix(1579896067, 0))
 
 	ExampleEksListClusters = &eks.ListClustersOutput{
 		Clusters: []*string{
@@ -309,7 +310,11 @@ func (m *MockEks) ListFargateProfilesPages(
 	if args.Error(0) != nil {
 		return args.Error(0)
 	}
-	paginationFunction(ExampleListFargateProfile, true)
+	if *in.ClusterName == *ExampleEksClusterNameMulti {
+		paginationFunction(ExampleListFargateProfilesMulti, true)
+	} else {
+		paginationFunction(ExampleListFargateProfile, true)
+	}
 	return args.Error(0)
 }
 

--- a/internal/compliance/snapshot_poller/pollers/aws/eks_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/eks_cluster.go
@@ -24,13 +24,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
-
 	apimodels "github.com/panther-labs/panther/api/lambda/resources/models"
 	awsmodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
 	pollermodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/poller"
 	"github.com/panther-labs/panther/internal/compliance/snapshot_poller/pollers/utils"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 // Set as variables to be overridden in testing
@@ -121,6 +120,12 @@ func getEKSFargateProfiles(eksSvc eksiface.EKSAPI, clusterName *string) ([]*awsm
 		})
 
 	if err != nil {
+			var awsErr awserr.Error
+			if errors.As(err, &awsErr) && awsErr.Code() == "AccessDeniedException" {
+				zap.L().Warn("Error with IAM Permissions - Use the AWS Console or CloudFormation to update the Panther" +
+					"Audit Role policy to include the eks:ListFargateProfiles and eks:DescribeFargateProfile permissions")
+				return nil, nil
+			}
 		return nil, errors.Wrapf(err, "EKS.ListFargateProfilesPages: %s", aws.StringValue(clusterName))
 	}
 
@@ -262,13 +267,7 @@ func buildEksClusterSnapshot(eksSvc eksiface.EKSAPI, clusterName *string) (*awsm
 
 	eksCluster.FargateProfile, err = getEKSFargateProfiles(eksSvc, details.Name)
 	if err != nil {
-		var awsErr awserr.Error
-		if errors.As(err, &awsErr) && awsErr.Code() == eks.ErrorCodeAccessDenied {
-			zap.L().Warn("Error with IAM Permissions - Use the AWS Console or CloudFormation to update the Panther" +
-				"Audit Role policy to include the eks:ListFargateProfiles and eks:DescribeFargateProfile permissions")
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	eksCluster.NodeGroup, err = getEKSNodegroups(eksSvc, details.Name)

--- a/internal/compliance/snapshot_poller/pollers/aws/eks_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/eks_cluster.go
@@ -24,12 +24,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
 	apimodels "github.com/panther-labs/panther/api/lambda/resources/models"
 	awsmodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/aws"
 	pollermodels "github.com/panther-labs/panther/internal/compliance/snapshot_poller/models/poller"
 	"github.com/panther-labs/panther/internal/compliance/snapshot_poller/pollers/utils"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 // Set as variables to be overridden in testing
@@ -120,12 +121,12 @@ func getEKSFargateProfiles(eksSvc eksiface.EKSAPI, clusterName *string) ([]*awsm
 		})
 
 	if err != nil {
-			var awsErr awserr.Error
-			if errors.As(err, &awsErr) && awsErr.Code() == "AccessDeniedException" {
-				zap.L().Warn("Error with IAM Permissions - Use the AWS Console or CloudFormation to update the Panther" +
-					"Audit Role policy to include the eks:ListFargateProfiles and eks:DescribeFargateProfile permissions")
-				return nil, nil
-			}
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == "AccessDeniedException" {
+			zap.L().Warn("Error with IAM Permissions - Use the AWS Console or CloudFormation to update the Panther" +
+				"Audit Role policy to include the eks:ListFargateProfiles and eks:DescribeFargateProfile permissions")
+			return nil, nil
+		}
 		return nil, errors.Wrapf(err, "EKS.ListFargateProfilesPages: %s", aws.StringValue(clusterName))
 	}
 


### PR DESCRIPTION
## Background

Fix two bugs reported in Cloud Security scanning systems.

The first bug was in scanning EKS clusters. We require new permissions for the audit role to scan these systems, so we updated the `PantherAuditRole`. In order to be backwards compatible, we capture permission denied errors on the relevant API call and keep scanning. Unfortunately this was not implemented correctly, so we were still logging permission denied errors when scanning EKS clusters.

The second bug is a weird one. The snapshot-poller received several requests to scan a resource of type `ELBV2.LoadBalancer` with the arn `arn:::::`. Clearly this is incorrect, so I checked the `aws-event-processor` logs and it logged some `WARN`s that it had found and extracted an invalid ARN out of a few CloudTrail logs it was processing related to the `ELBV2:ModifyLoadBalancerAttributes` and `ELBV2:DeleteLoadBalancer` API calls.  In attempting to replicate this bug I created, modified, and deleted a few load balancers but I was not able to replicate these warnings or failed scans.

The bug that I was able to fix is that in this situation it still returned an empty ARN (which is what caused the error in the  poller). Now if it detects that it extracted an invalid ARN, it drops the events instead of returning `arn:::::`. But I was not able to determine why the CloudTrail logs had an invalid ARN to begin with. So at least this should not cause an error in the future, but I have no idea what caused this malformed CloudTrail to be processed in the first place.

Closes https://github.com/panther-labs/panther-enterprise/issues/1186 and https://github.com/panther-labs/panther-enterprise/issues/1219.

Open question: should we sync this to release? I'll go with yes for now, but if anyone has any concerns let me know.

## Changes

- Fix permission denied handling when scanning EKS clusters
- Drop bad ARNs in the `aws-event-processor` for ELBV2 events
  - I looked for the same pattern in ELBV2 events in the other classifiers, and found three other instances where we were failing to parse an ARN then still returning a value. Corrected these as well.

## Testing

- Manually tested fix for EKS cluster scanning
- Added new unit test for EKS cluster scanning
- No testing for ELBV2 issue, was not able to replicate the issue. But in the future this case should be handled correctly now.
