### PR TITLE
Don't fail the full batch in case of partial failures

### DIFF
--- a/internal/log_analysis/log_processor/processor/stream.go
+++ b/internal/log_analysis/log_processor/processor/stream.go
@@ -116,7 +116,7 @@ func pollEvents(
 			for _, msg := range messages {
 				dataStreams, err := generateDataStreamsFunc(aws.StringValue(msg.Body))
 				if err != nil {
-					zap.L().Warn("Unable to process event", zap.Error(err))
+					zap.L().Warn("Skipping event due to error", zap.Error(err))
 					continue
 				}
 				for _, dataStream := range dataStreams {

--- a/internal/log_analysis/log_processor/processor/stream.go
+++ b/internal/log_analysis/log_processor/processor/stream.go
@@ -80,6 +80,7 @@ func pollEvents(
 
 		// continue to read until either there are no sqs messages or we have exceeded the processing time/file limit
 		highMemoryCounter := 0
+
 		for len(accumulatedMessageReceipts) < processingMaxFilesLimit {
 			select {
 			case <-ctx.Done():
@@ -115,7 +116,7 @@ func pollEvents(
 				dataStreams, err := generateDataStreamsFunc(aws.StringValue(msg.Body))
 				if err != nil {
 					zap.L().Warn("Unable to process event", zap.Error(err))
-					return
+					continue
 				}
 				for _, dataStream := range dataStreams {
 					streamChan <- dataStream

--- a/internal/log_analysis/log_processor/processor/stream_test.go
+++ b/internal/log_analysis/log_processor/processor/stream_test.go
@@ -133,12 +133,14 @@ func TestStreamEventsProcessErrorAndReadEventError(t *testing.T) {
 	sqsMock := &testutils.SqsMock{}
 	sqsMock.On("ReceiveMessageWithContext", mock.Anything, mock.Anything, mock.Anything).
 		Return(streamTestReceiveMessageOutput, nil).Once() // Should be called only once because operation fails
+	sqsMock.On("ReceiveMessageWithContext", mock.Anything, mock.Anything, mock.Anything).
+		Return(&sqs.ReceiveMessageOutput{}, nil).Once() // this one return 0 messages, which breaks the loop
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	count, err := pollEvents(ctx, sqsMock, failProcessorFunc, failGenerateDataStream)
 	require.Error(t, err)
-	assert.Equal(t, "processError", err.Error()) // expect the processError NOT readEventError
+	assert.Equal(t, "processError", err.Error())
 	require.Equal(t, 0, count)
 
 	sqsMock.AssertExpectations(t)

--- a/internal/log_analysis/log_processor/processor/stream_test.go
+++ b/internal/log_analysis/log_processor/processor/stream_test.go
@@ -79,8 +79,6 @@ func TestStreamEvents(t *testing.T) {
 func TestStreamEventsProcessingTimeLimitExceeded(t *testing.T) {
 	t.Parallel()
 	sqsMock := &testutils.SqsMock{}
-	sqsMock.On("ReceiveMessageWithContext", mock.Anything, mock.Anything, mock.Anything).
-		Return(&sqs.ReceiveMessageOutput{}, nil).Maybe()
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now()) // set to current time so code exits immediately
 	defer cancel()

--- a/internal/log_analysis/log_processor/processor/stream_test.go
+++ b/internal/log_analysis/log_processor/processor/stream_test.go
@@ -80,6 +80,9 @@ func TestStreamEventsProcessingTimeLimitExceeded(t *testing.T) {
 	t.Parallel()
 	sqsMock := &testutils.SqsMock{}
 
+	sqsMock.On("ReceiveMessageWithContext", mock.Anything, mock.Anything, mock.Anything).
+		Return(&sqs.ReceiveMessageOutput{}, nil).Maybe()
+
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now()) // set to current time so code exits immediately
 	defer cancel()
 	sqsMessageCount, err := pollEvents(ctx, sqsMock, noopProcessorFunc, noopGenerateDataStream)


### PR DESCRIPTION
## Background

Currently the log processor pulls a lot of events through SQS, processes them, and if everything has succeeded, the messages are deleted from the SQS queue. However if any of the following errors occur, the FULL BATCH will fail and all of the messages will be reprocessed. 

The failures can occur: 
1. Polling new messages from SQS queue
2. Accessing the S3 objects & reading first chunk of the S3 objects
3. Reading the full S3 objects
4. Writing to the output

With this PR, I make sure that failures No1, and No2 don't cause the batch to fail. No3 and No4 could be addressed in separate PR and are indeed more complicated. They are also less common - especially No2 can happen very frequently in case of permissions misconfiguration.

## Changes

- See above
- Updated flaky test

## Testing

- Unit tests
