### PR TITLE
Add default sortBy for policies and data models

### DIFF
--- a/internal/core/analysis_api/handlers/list.go
+++ b/internal/core/analysis_api/handlers/list.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	defaultSortBy   = "displayName"
 	defaultSortDir  = "ascending"
 	defaultPage     = 1
 	defaultPageSize = 25

--- a/internal/core/analysis_api/handlers/list_data_models.go
+++ b/internal/core/analysis_api/handlers/list_data_models.go
@@ -36,6 +36,9 @@ func (API) ListDataModels(input *models.ListDataModelsInput) *events.APIGatewayP
 	if input.PageSize == 0 {
 		input.PageSize = defaultPageSize
 	}
+	if input.SortBy == "" {
+		input.SortBy = "id"
+	}
 	if input.SortDir == "" {
 		input.SortDir = defaultSortDir
 	}

--- a/internal/core/analysis_api/handlers/list_policies.go
+++ b/internal/core/analysis_api/handlers/list_policies.go
@@ -106,6 +106,9 @@ func stdPolicyListInput(input *models.ListPoliciesInput) {
 	if input.PageSize == 0 {
 		input.PageSize = defaultPageSize
 	}
+	if input.SortBy == "" {
+		input.SortBy = "id"
+	}
 	if input.SortDir == "" {
 		input.SortDir = defaultSortDir
 	}

--- a/internal/core/analysis_api/handlers/list_rules.go
+++ b/internal/core/analysis_api/handlers/list_rules.go
@@ -75,7 +75,7 @@ func stdRuleListInput(input *models.ListRulesInput) {
 		input.PageSize = defaultPageSize
 	}
 	if input.SortBy == "" {
-		input.SortBy = defaultSortBy
+		input.SortBy = "displayName"
 	}
 	if input.SortDir == "" {
 		input.SortDir = defaultSortDir


### PR DESCRIPTION
## Background

#2087 broke `ListPolicies` and `ListDataModels`. Both the backend and the web app started reporting `analysis-api` panics with the message "unexpected SortBy: "

The problem was that we changed how the list operations handle the default sortBy when none is specified: it used to be handled as the default in a switch statement, but now we expect each List handler to provide their own defaults.

This error would have been caught when running integration tests for #2087 , but I forgot to have Alex run those, so that's my bad.

## Changes

- Add default `sortBy` for policies and data models

## Testing

- Deployed, verified fix to policy list page in the web app
- CloudWatch alarms for `analysis-api` and `resource-processor` were resolved after the fix
- @AlexPanther is working on fixing the `analysis-api` integration tests, where it will be tested more thoroughly
