### PR TITLE
Add EU regions for publishing

### DIFF
--- a/tools/mage/master/deploy.go
+++ b/tools/mage/master/deploy.go
@@ -42,7 +42,7 @@ const (
 	defaultStackName      = "panther"
 )
 
-var publishRegions = []string{"us-east-1", "us-east-2", "us-west-2"}
+var publishRegions = []string{"us-east-1", "us-east-2", "us-west-2", "eu-central-1", "eu-west-1"}
 
 // Deploy single master template nesting all other stacks.
 //


### PR DESCRIPTION
## Background

We now support publishing Panther to EU regions. I already manually published 1.12.1 to those regions, so we need to get the new regions into 1.13 as well.

This is a PR directly against the release branch; the associated change in `master` is already in #2096

Please merge on approval

## Changes

- Add `eu-west-1` and `eu-central-1` to the region publication set for `mage master:publish`

## Testing

- `mage master:publish` for 1.12.1
