### PR TITLE
Fix bug that prevented successful check of EnsureDatabase()

### DIFF
--- a/internal/log_analysis/awsglue/wrappers.go
+++ b/internal/log_analysis/awsglue/wrappers.go
@@ -182,5 +182,5 @@ func EnsureDatabase(ctx context.Context, client glueiface.GlueAPI, name, descrip
 	if err != nil && !awsutils.IsAnyError(err, glue.ErrCodeAlreadyExistsException) {
 		return err
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
## Background

`@message	
failed to create databases: AlreadyExistsException: Database already exists.; AlreadyExistsException: Database already exists.; AlreadyExistsException: Database already exists.; AlreadyExistsException: Database already exists.; AlreadyExistsException: Database already exists.: withStack
null`

Current setup prevents successful check of EnsureDatabase by returning an error if "database already exists" error is returned, which is not what we want. 

## Changes

Replaced err with nil in the EnsureDatabase function

## Testing

- Deployed branch, no errors