### PR TITLE
Add parsers for Duo logs

### DIFF
--- a/internal/log_analysis/log_processor/logtypes/logtesting/logtesting.go
+++ b/internal/log_analysis/log_processor/logtypes/logtesting/logtesting.go
@@ -174,7 +174,7 @@ func TestResult(t *testing.T, expect string, actual *pantherlog.Result, indicato
 // EqualTimestamp is a helper that checks timestamps for equality with human readable message
 func EqualTimestamp(t *testing.T, expect, actual time.Time, msgAndArgs ...interface{}) {
 	t.Helper()
-	require.False(t, actual.IsZero(), "zero timestamp")
+	require.NotZero(t, actual, msgAndArgs...)
 	require.Equal(t, expect.UTC().Format(time.RFC3339Nano), actual.UTC().Format(time.RFC3339Nano), msgAndArgs...)
 }
 

--- a/internal/log_analysis/log_processor/parsers/duologs/administrator.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/administrator.go
@@ -1,0 +1,36 @@
+package duologs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+
+const TypeAdministrator = "Duo.Administrator"
+
+// nolint:lll
+type AdministratorLog struct {
+	//TODO: This event has the same fields as OfflineEnrollmentLog. To distinguish them, we validate that Action below
+	// doesn't contain the values that OfflineEnrollmentLog.Action can take. If, however, Duo adds a value to the
+	// values OfflineEnrollmentLog.Action can take, these events will be misclassified until we update our schemas.
+	Action       pantherlog.String `json:"action" panther:"required" validate:"excludes=o2fa_user_provisioned o2fa_user_deprovisioned o2fa_user_reenrolled" description:"The type of change that was performed."`
+	Description  pantherlog.String `json:"description" description:"String detailing what changed, either as free-form text or serialized JSON."`
+	ISOTimestamp pantherlog.Time   `json:"isotimestamp" panther:"required" event_time:"true" tcodec:"rfc3339" description:"ISO8601 timestamp of the event."`
+	Object       pantherlog.String `json:"object" panther:"required" description:"The object that was acted on. For example: \"jsmith\" (for users), \"(555) 713-6275 x456\" (for phones), or \"HOTP 8-digit 123456\" (for tokens)."`
+	Timestamp    pantherlog.Time   `json:"timestamp" tcodec:"unix" description:"Unix timestamp of the event."`
+	UserName     pantherlog.String `json:"username" panther:"required" description:"The full name of the administrator who performed the action in the Duo Admin Panel. If the action was performed with the API this will be \"API\". Automatic actions like deletion of inactive users have \"System\" for the username. Changes synchronized from Directory Sync will have a username of the form (example) \"AD Sync: name of directory\"."`
+}

--- a/internal/log_analysis/log_processor/parsers/duologs/authentication.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/authentication.go
@@ -1,0 +1,86 @@
+package duologs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+
+const TypeAuthentication = "Duo.Authentication"
+
+// nolint:lll
+type AuthenticationLog struct {
+	AccessDevice *AccessDevice     `json:"access_device" description:"Browser, plugin, and operating system information for the endpoint used to access the Duo-protected resource. Values present only when the application accessed features Duo’s inline browser prompt."`
+	Alias        pantherlog.String `json:"alias" description:"The username alias used to log in. No value if the user logged in with their username instead of a username alias."`
+	Application  *Application      `json:"application" description:"Information about the application accessed."`
+	AuthDevice   *AuthDevice       `json:"auth_device" description:"Information about the device used to approve or deny authentication."`
+	Email        pantherlog.String `json:"email" description:"The email address of the user, if known to Duo, otherwise none."`
+	EventType    pantherlog.String `json:"event_type" description:"The type of activity logged. one of: \"authentication\" or \"enrollment\"."`
+	Factor       pantherlog.String `json:"factor" description:"The authentication factor. One of: \"phone_call\", \"passcode\", \"yubikey_passcode\", \"digipass_go_7_token\", \"hardware_token\", \"duo_mobile_passcode\", \"bypass_code\", \"sms_passcode\", \"sms_refresh\", \"duo_push\", \"u2f_token\", \"remembered_device\", or \"trusted_network\"."`
+	ISOTimestamp pantherlog.Time   `json:"isotimestamp" panther:"required" event_time:"true" tcodec:"rfc3339" description:"ISO8601 timestamp of the event."`
+	OODSoftware  pantherlog.String `json:"ood_software" description:"If authentication was denied due to out-of-date software, shows the name of the software, i.e. \"Chrome\", \"Flash\", etc. No value if authentication was successful or authentication denial was not due to out-of-date software."`
+	Reason       pantherlog.String `json:"reason" description:"Provide the reason for the authentication attempt result.\nIf result is \"SUCCESS\" then one of: \"allow_unenrolled_user\", \"allowed_by_policy\", \"allow_unenrolled_user_on_trusted_network\", \"bypass_user\", \"remembered_device\", \"trusted_location\", \"trusted_network\", \"user_approved\", \"valid_passcode\".\n\nIf result is \"FAILURE\" then one of: \"anonymous_ip\", \"anomalous_push\", \"could_not_determine_if_endpoint_was_trusted\", \"denied_by_policy\", \"denied_network\", \"deny_unenrolled_user\", \"endpoint_is_not_in_management_system\", \"endpoint_failed_google_verification\", \"endpoint_is_not_trusted\", \"factor_restricted\", \"invalid_management_certificate_collection_state\", \"invalid_device\", \"invalid_passcode\", \"invalid_referring_hostname_provided\", \"location_restricted\", \"locked_out\", \"no_activated_duo_mobile_account\", \"no_disk_encryption\", \"no_duo_certificate_present\", \"touchid_disabled\", \"no_referring_hostname_provided\", \"no_response\", \"no_screen_lock\", \"no_web_referer_match\", \"out_of_date\", \"platform_restricted\", \"rooted_device\", \"software_restricted\", \"user_cancelled\", \"user_disabled\", \"user_mistake\", \"user_not_in_permitted_group\", \"user_provided_invalid_certificate\", or \"version_restricted\".\n\nIf result is \"ERROR\" then: \"error\".\n\nIf result is \"FRAUD\" then: \"user_marked_fraud\"."`
+	Result       pantherlog.String `json:"result" description:"The result of the authentication attempt. One of: \"SUCCESS\", \"FAILURE\", \"ERROR\", or \"FRAUD\"."`
+	Timestamp    pantherlog.Time   `json:"timestamp" tcodec:"unix" description:"Unix timestamp of the event."`
+	TxID         pantherlog.String `json:"txid" panther:"required" description:"The transaction ID of the event."`
+	User         User              `json:"user" description:"Information about the authenticating user."`
+}
+
+// nolint:lll
+type AccessDevice struct {
+	Browser        pantherlog.String `json:"browser" description:"The web browser used for access."`
+	BrowserVersion pantherlog.String `json:"browser_version" description:"The browser version."`
+	FlashVersion   pantherlog.String `json:"flash_version" description:"The Flash plugin version used, if present, otherwise \"uninstalled\"."`
+	Hostname       pantherlog.String `json:"hostname" panther:"hostname" description:"The hostname, if present, otherwise \"null\"."`
+	IP             pantherlog.String `json:"ip" panther:"ip" description:"The access device's IP address, if present, otherwise \"null\"."`
+	//TODO: These fields are declared bool, but their description contradicts. Fix them when we hear back from Duo.
+	IsEncryptionEnabled pantherlog.Bool     `json:"is_encryption_enabled" description:"Reports the disk encryption state as detected by the Duo Device Health app. One of \"true\", \"false\", or \"unknown\"."`
+	IsFirewallEnabled   pantherlog.Bool     `json:"is_firewall_enabled" description:"Reports the firewall state as detected by the Duo Device Health app. One of \"true\", \"false\", or \"unknown\"."`
+	IsPasswordSet       pantherlog.Bool     `json:"is_password_set" description:"Reports the system password state as detected by the Duo Device Health app. One of \"true\", \"false\", or \"unknown\"."`
+	JavaVersion         pantherlog.String   `json:"java_version" description:"The Java plugin version used, if present, otherwise \"uninstalled\"."`
+	Location            *Location           `json:"location" description:"The GeoIP location of the access device, if available. The response may not include all location parameters."`
+	OS                  pantherlog.String   `json:"os" description:"The device operating system name."`
+	OSVersion           pantherlog.String   `json:"os_version" description:"The device operating system version."`
+	SecurityAgents      []pantherlog.String `json:"security_agents" description:"Reports the security agents present on the endpoint as detected by the Duo Device Health app."`
+}
+
+// nolint:lll
+type Location struct {
+	City    pantherlog.String `json:"city" description:"The city name."`
+	Country pantherlog.String `json:"country" description:"The country code."`
+	State   pantherlog.String `json:"state" description:"The state, county, province, or prefecture."`
+}
+
+// nolint:lll
+type Application struct {
+	Key  pantherlog.String `json:"key" description:"The application's integration_key."`
+	Name pantherlog.String `json:"name" description:"The application's name."`
+}
+
+// nolint:lll
+type AuthDevice struct {
+	IP       pantherlog.String `json:"ip" panther:"ip" description:"The IP address of the authentication device."`
+	Location *Location         `json:"location" description:"The GeoIP location of the authentication device, if available. May not include all location parameters."`
+	Name     pantherlog.String `json:"name" description:"The name of the authentication device."`
+}
+
+// nolint:lll
+type User struct {
+	Groups []pantherlog.String `json:"groups" description:"Duo group membership information for the user."`
+	Key    pantherlog.String   `json:"key" description:"The user's user_id."`
+	Name   pantherlog.String   `json:"name" description:"The user's username."`
+}

--- a/internal/log_analysis/log_processor/parsers/duologs/duologs.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/duologs.go
@@ -1,0 +1,70 @@
+package duologs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/logtypes"
+)
+
+func LogTypes() logtypes.Group {
+	return logTypes
+}
+
+// We use an immediately called function to register the time decoder before building the logtype entries.
+var logTypes = func() logtypes.Group {
+	return logtypes.Must("Duo",
+		logtypes.ConfigJSON{
+			Name: TypeAuthentication,
+			// nolint:lll
+			Description:  `Duo authentication log events(v2).`,
+			ReferenceURL: `https://duo.com/docs/adminapi#authentication-logs`,
+			NewEvent: func() interface{} {
+				return &AuthenticationLog{}
+			},
+		},
+
+		logtypes.ConfigJSON{
+			Name: TypeAdministrator,
+			// nolint:lll
+			Description:  `Duo administrator log events.`,
+			ReferenceURL: `https://duo.com/docs/adminapi#administrator-logs`,
+			NewEvent: func() interface{} {
+				return &AdministratorLog{}
+			},
+		},
+		logtypes.ConfigJSON{
+			Name: TypeTelephony,
+			// nolint:lll
+			Description:  `Duo telephony log events.`,
+			ReferenceURL: `https://duo.com/docs/adminapi#telephony-logs`,
+			NewEvent: func() interface{} {
+				return &TelephonyLog{}
+			},
+		},
+		logtypes.ConfigJSON{
+			Name: TypeOfflineEnrollment,
+			// nolint:lll
+			Description:  `Duo Authentication for Windows Logon offline enrollment events.`,
+			ReferenceURL: `https://duo.com/docs/adminapi#offline-enrollment-logs`,
+			NewEvent: func() interface{} {
+				return &OfflineEnrollmentLog{}
+			},
+		},
+	)
+}()

--- a/internal/log_analysis/log_processor/parsers/duologs/duologs_test.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/duologs_test.go
@@ -1,0 +1,29 @@
+package duologs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/logtypes/logtesting"
+)
+
+func TestDuoParsers(t *testing.T) {
+	logtesting.RunTestsFromYAML(t, LogTypes(), "./testdata/duologs_test.yml")
+}

--- a/internal/log_analysis/log_processor/parsers/duologs/offline_enrollment.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/offline_enrollment.go
@@ -1,0 +1,40 @@
+package duologs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+
+const TypeOfflineEnrollment = "Duo.OfflineEnrollment"
+
+// nolint:lll
+type OfflineEnrollmentLog struct {
+	Action       pantherlog.String `json:"action" validate:"oneof=o2fa_user_provisioned o2fa_user_deprovisioned o2fa_user_reenrolled" description:"The offline enrollment operation. One of \"o2fa_user_provisioned\", \"o2fa_user_deprovisioned\", or \"o2fa_user_reenrolled\"."`
+	Description  pantherlog.String `json:"description" description:"Information about the Duo Windows Logon client system as reported by the application."`
+	ISOTimestamp pantherlog.Time   `json:"isotimestamp" panther:"required" event_time:"true" tcodec:"rfc3339" description:"ISO8601 timestamp of the event."`
+	Object       pantherlog.String `json:"object" panther:"required" description:"The Duo Windows Logon integration's name."`
+	Timestamp    pantherlog.Time   `json:"timestamp" tcodec:"unix" description:"Unix timestamp of the event."`
+	UserName     pantherlog.String `json:"username" panther:"required" description:"The Duo username."`
+}
+
+// nolint:lll
+type Description struct {
+	UserAgent pantherlog.String `json:"user_agent" description:"The Duo Windows Logon application version information and the Windows OS version and platform information."`
+	HostName  pantherlog.String `json:"hostname" description:" The host name of the system where Duo Windows Logon is installed."`
+	Factor    pantherlog.String `json:"factor" description:" The type of authenticator used for offline access. One of \"duo_otp\" or \"security_key\"."`
+}

--- a/internal/log_analysis/log_processor/parsers/duologs/telephony.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/telephony.go
@@ -1,0 +1,33 @@
+package duologs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+
+const TypeTelephony = "Duo.Telephony"
+
+// nolint:lll
+type TelephonyLog struct {
+	Context      pantherlog.String `json:"context" description:"How this telephony event was initiated. One of: \"administrator login\", \"authentication\", \"enrollment\", or \"verify\"."`
+	Credits      pantherlog.Int32  `json:"credits" description:"How many telephony credits this event cost."`
+	ISOTimestamp pantherlog.Time   `json:"isotimestamp" panther:"required" event_time:"true" tcodec:"rfc3339" description:"ISO8601 timestamp of the event."`
+	Phone        pantherlog.String `json:"phone" panther:"required" description:"The phone number that initiated this event."`
+	Timestamp    pantherlog.Time   `json:"timestamp" tcodec:"unix" description:"Unix timestamp of the event."`
+	Type         pantherlog.String `json:"type" panther:"required" description:" The event type. Either \"sms\" or \"phone\"."`
+}

--- a/internal/log_analysis/log_processor/parsers/duologs/testdata/duologs_test.yml
+++ b/internal/log_analysis/log_processor/parsers/duologs/testdata/duologs_test.yml
@@ -1,0 +1,178 @@
+# Panther is a Cloud-Native SIEM for the Modern Security Team.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+name: authentication logs
+logType: Duo.Authentication
+input: |
+  {
+    "access_device": {
+      "browser": "Chrome",
+      "browser_version": "67.0.3396.99",
+      "flash_version": "uninstalled",
+      "hostname": "example.com",
+      "ip": "169.232.89.219",
+      "is_encryption_enabled": true,
+      "is_firewall_enabled": true,
+      "is_password_set": true,
+      "java_version": "uninstalled",
+      "location": {
+        "city": "Ann Arbor",
+        "country": "United States",
+        "state": "Michigan"
+      },
+      "os": "Mac OS X",
+      "os_version": "10.14.1",
+      "security_agents": []
+    },
+    "alias": "",
+    "application": {
+      "key": "DIY231J8BR23QK4UKBY8",
+      "name": "Microsoft Azure Active Directory"
+    },
+    "auth_device": {
+      "ip": "192.168.225.254",
+      "location": {
+        "city": "Ann Arbor",
+        "country": "United States",
+        "state": "Michigan"
+      },
+      "name": "My iPhone X (734-555-2342)"
+    },
+    "email": "narroway@example.com",
+    "event_type": "authentication",
+    "factor": "duo_push",
+    "isotimestamp": "2020-02-13T18:56:20.351346+00:00",
+    "ood_software": "null",
+    "reason": "user_approved",
+    "result": "success",
+    "timestamp": 1581620180,
+    "txid": "340a23e3-23f3-23c1-87dc-1491a23dfdbb",
+    "user": {
+      "groups": [
+        "Duo Users",
+        "CorpHQ Users"
+      ],
+      "key": "DU3KC77WJ06Y5HIV7XKQ",
+      "name": "narroway@example.com"
+    }
+  }
+result: |
+  {
+    "access_device": {
+      "browser": "Chrome",
+      "browser_version": "67.0.3396.99",
+      "flash_version": "uninstalled",
+      "hostname": "example.com",
+      "ip": "169.232.89.219",
+      "is_encryption_enabled": true,
+      "is_firewall_enabled": true,
+      "is_password_set": true,
+      "java_version": "uninstalled",
+      "location": {
+        "city": "Ann Arbor",
+        "country": "United States",
+        "state": "Michigan"
+      },
+      "os": "Mac OS X",
+      "os_version": "10.14.1"
+    },
+    "alias": "",
+    "application": {
+      "key": "DIY231J8BR23QK4UKBY8",
+      "name": "Microsoft Azure Active Directory"
+    },
+    "auth_device": {
+      "ip": "192.168.225.254",
+      "location": {
+        "city": "Ann Arbor",
+        "country": "United States",
+        "state": "Michigan"
+      },
+      "name": "My iPhone X (734-555-2342)"
+    },
+    "email": "narroway@example.com",
+    "event_type": "authentication",
+    "factor": "duo_push",
+    "isotimestamp": "2020-02-13T18:56:20.351346Z",
+    "ood_software": "null",
+    "reason": "user_approved",
+    "result": "success",
+    "timestamp": 1581620180,
+    "txid": "340a23e3-23f3-23c1-87dc-1491a23dfdbb",
+    "user": {
+      "groups": [
+        "Duo Users",
+        "CorpHQ Users"
+      ],
+      "key": "DU3KC77WJ06Y5HIV7XKQ",
+      "name": "narroway@example.com"
+    },
+
+    "p_log_type": "Duo.Authentication",
+    "p_event_time":"2020-02-13T18:56:20.351346Z",
+    "p_any_domain_names":["example.com"],
+    "p_any_ip_addresses": ["169.232.89.219", "192.168.225.254"]
+  }
+
+---
+name: administrator logs
+logType: Duo.Administrator
+input: |
+  {
+        "action": "user_update",
+        "description": "{\"notes\": \"Joe asked for their nickname to be displayed instead of Joseph.\", \"realname\": \"Joe Smith\"}",
+        "isotimestamp": "2020-01-24T15:09:42+00:00",
+        "object": "jsmith",
+        "timestamp": 1579878582,
+        "username": "admin"
+    }
+result: |
+  {
+        "action": "user_update",
+        "description": "{\"notes\": \"Joe asked for their nickname to be displayed instead of Joseph.\", \"realname\": \"Joe Smith\"}",
+        "isotimestamp": "2020-01-24T15:09:42Z",
+        "object": "jsmith",
+        "timestamp": 1579878582,
+        "username": "admin",
+
+        "p_log_type": "Duo.Administrator",
+        "p_event_time": "2020-01-24T15:09:42Z"
+  }
+
+---
+name: offline enrollment logs
+logType: Duo.OfflineEnrollment
+input: |
+  {
+    "action": "o2fa_user_provisioned",
+    "description": "{\"user_agent\": \"DuoCredProv/4.0.6.413 (Windows NT 6.3.9600; x64; Server)\", \"hostname\": \"WKSW10x64\", \"factor\": \"duo_otp\"}",
+    "isotimestamp": "2019-08-30T16:10:05+02:00",
+    "object": "Acme Laptop Windows Logon",
+    "timestamp": 1567181405,
+    "username": "narroway"
+  }
+result: |
+  {
+    "action": "o2fa_user_provisioned",
+    "description": "{\"user_agent\": \"DuoCredProv/4.0.6.413 (Windows NT 6.3.9600; x64; Server)\", \"hostname\": \"WKSW10x64\", \"factor\": \"duo_otp\"}",
+    "isotimestamp": "2019-08-30T16:10:05+02:00",
+    "object": "Acme Laptop Windows Logon",
+    "timestamp": 1567181405,
+    "username": "narroway",
+
+    "p_log_type": "Duo.OfflineEnrollment",
+    "p_event_time": "2019-08-30T14:10:05Z"
+  }

--- a/internal/log_analysis/log_processor/registry/init.go
+++ b/internal/log_analysis/log_processor/registry/init.go
@@ -27,6 +27,7 @@ import (
 	boxlogs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/boxlogs"
 	cloudflarelogs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/cloudflarelogs"
 	crowdstrikelogs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/crowdstrikelogs"
+	duologs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/duologs"
 	fastlylogs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/fastlylogs"
 	fluentdsyslogs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/fluentdsyslogs"
 	gcplogs "github.com/panther-labs/panther/internal/log_analysis/log_processor/parsers/gcplogs"
@@ -61,6 +62,8 @@ func init() {
 		cloudflarelogs.LogTypes(),
 
 		crowdstrikelogs.LogTypes(),
+
+		duologs.LogTypes(),
 
 		fastlylogs.LogTypes(),
 


### PR DESCRIPTION
## Background

Add parsers for Duo logs.
https://duo.com/docs/adminapi#logs

## Changes

- Add parsers for Duo authentication (v2), administrator, telephony logs.

## Testing

-  Unit