### PR TITLE
Add `username` and `email` indicators to `pantherlog`

### DIFF
--- a/internal/log_analysis/log_processor/pantherlog/meta.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta.go
@@ -76,7 +76,7 @@ const (
 
 // ScanValues implements ValueScanner interface
 func (id FieldID) ScanValues(w ValueWriter, input string) {
-	w.WriteValues(id, input)
+	w.WriteValues(id, strings.TrimSpace(input))
 }
 
 // CoreFields are the 'core' fields Panther adds to each log.

--- a/internal/log_analysis/log_processor/pantherlog/meta.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta.go
@@ -71,6 +71,7 @@ const (
 	FieldAWSARN
 	FieldAWSTag
 	FieldEmail
+	FieldUsername
 )
 
 // ScanValues implements ValueScanner interface
@@ -202,15 +203,20 @@ func init() {
 		NameJSON:    "p_any_emails",
 		Description: "Panther added field with collection of email addresses associated with the row",
 	})
-	MustRegisterScanner("ip", ValueScannerFunc(ScanIPAddress), FieldIPAddress)
+	MustRegisterIndicator(FieldUsername, FieldMeta{
+		Name:        "PantherAnyUsernames",
+		NameJSON:    "p_any_usernames",
+		Description: "Panther added field with collection of usernames associated with the row",
+	})
+	MustRegisterScannerFunc("ip", ScanIPAddress, FieldIPAddress)
 	MustRegisterScanner("domain", FieldDomainName, FieldDomainName)
 	MustRegisterScanner("md5", FieldMD5Hash, FieldMD5Hash)
 	MustRegisterScanner("sha1", FieldSHA1Hash, FieldSHA1Hash)
 	MustRegisterScanner("sha256", FieldSHA256Hash, FieldSHA256Hash)
-	MustRegisterScanner("hostname", ValueScannerFunc(ScanHostname), FieldDomainName, FieldIPAddress)
-	MustRegisterScanner("url", ValueScannerFunc(ScanURL), FieldDomainName, FieldIPAddress)
+	MustRegisterScannerFunc("hostname", ScanHostname, FieldDomainName, FieldIPAddress)
+	MustRegisterScannerFunc("url", ScanURL, FieldDomainName, FieldIPAddress)
 	MustRegisterScanner("trace_id", FieldTraceID, FieldTraceID)
-	MustRegisterScanner("net_addr", ValueScannerFunc(ScanNetworkAddress), FieldIPAddress, FieldDomainName)
+	MustRegisterScannerFunc("net_addr", ScanNetworkAddress, FieldIPAddress, FieldDomainName)
 	MustRegisterScannerFunc("aws_arn", ScanARN,
 		FieldAWSARN,
 		FieldAWSInstanceID,
@@ -220,6 +226,7 @@ func init() {
 	MustRegisterScannerFunc("aws_instance_id", ScanAWSInstanceID, FieldAWSInstanceID)
 	MustRegisterScannerFunc("aws_tag", ScanAWSTag, FieldAWSTag)
 	MustRegisterScannerFunc("email", ScanEmail, FieldEmail)
+	MustRegisterScanner("username", FieldUsername, FieldUsername)
 }
 
 // MustRegisterIndicator allows modules to define their own indicator fields.

--- a/internal/log_analysis/log_processor/pantherlog/meta.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta.go
@@ -70,6 +70,7 @@ const (
 	FieldAWSInstanceID
 	FieldAWSARN
 	FieldAWSTag
+	FieldEmail
 )
 
 // ScanValues implements ValueScanner interface
@@ -196,6 +197,11 @@ func init() {
 		NameJSON:    "p_any_aws_tags",
 		Description: "Panther added field with collection of AWS Tags associated with the row",
 	})
+	MustRegisterIndicator(FieldEmail, FieldMeta{
+		Name:        "PantherAnyEmails",
+		NameJSON:    "p_any_emails",
+		Description: "Panther added field with collection of email addresses associated with the row",
+	})
 	MustRegisterScanner("ip", ValueScannerFunc(ScanIPAddress), FieldIPAddress)
 	MustRegisterScanner("domain", FieldDomainName, FieldDomainName)
 	MustRegisterScanner("md5", FieldMD5Hash, FieldMD5Hash)
@@ -213,6 +219,7 @@ func init() {
 	MustRegisterScannerFunc("aws_account_id", ScanAWSAccountID, FieldAWSAccountID)
 	MustRegisterScannerFunc("aws_instance_id", ScanAWSInstanceID, FieldAWSInstanceID)
 	MustRegisterScannerFunc("aws_tag", ScanAWSTag, FieldAWSTag)
+	MustRegisterScannerFunc("email", ScanEmail, FieldEmail)
 }
 
 // MustRegisterIndicator allows modules to define their own indicator fields.

--- a/internal/log_analysis/log_processor/pantherlog/scanners.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners.go
@@ -181,3 +181,10 @@ func (m multiScanner) ScanValues(w ValueWriter, input string) {
 		scanner.ScanValues(w, input)
 	}
 }
+
+func ScanEmail(w ValueWriter, input string) {
+	if pos := strings.IndexByte(input, '@'); pos != -1 {
+		input = strings.TrimSpace(input)
+		w.WriteValues(FieldEmail, input)
+	}
+}

--- a/internal/log_analysis/log_processor/pantherlog/scanners.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners.go
@@ -118,6 +118,7 @@ func LookupScanner(name string) (scanner ValueScanner, fields []FieldID) {
 
 // ScanURL scans a URL string for domain or ip address
 func ScanURL(dest ValueWriter, input string) {
+	input = strings.TrimSpace(input)
 	if input == "" {
 		return
 	}
@@ -130,6 +131,7 @@ func ScanURL(dest ValueWriter, input string) {
 
 // ScanHostname scans `input` for either an ip address or a domain name value.
 func ScanHostname(w ValueWriter, input string) {
+	input = strings.TrimSpace(input)
 	if checkIPAddress(input) {
 		w.WriteValues(FieldIPAddress, input)
 	} else {

--- a/internal/log_analysis/log_processor/pantherlog/scanners_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners_test.go
@@ -1,8 +1,9 @@
 package pantherlog
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 /**

--- a/internal/log_analysis/log_processor/pantherlog/scanners_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners_test.go
@@ -1,5 +1,10 @@
 package pantherlog
 
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
  * Copyright (C) 2020 Panther Labs Inc
@@ -17,3 +22,85 @@ package pantherlog
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+func TestScanIPAddress(t *testing.T) {
+	assert := require.New(t)
+	w := &ValueBuffer{}
+
+	ScanIPAddress(w, "foo")
+	assert.True(w.IsEmpty())
+	ScanIPAddress(w, "")
+	assert.True(w.IsEmpty())
+	ScanIPAddress(w, " ")
+	assert.True(w.IsEmpty())
+	ScanIPAddress(w, "foo@bar.baz")
+	assert.True(w.IsEmpty())
+	ScanIPAddress(w, "23.23.23.23")
+	assert.False(w.IsEmpty())
+	assert.Equal([]string{"23.23.23.23"}, w.Get(FieldIPAddress))
+}
+
+func TestScanHostname(t *testing.T) {
+	assert := require.New(t)
+	w := &ValueBuffer{}
+
+	ScanHostname(w, "")
+	assert.True(w.IsEmpty())
+	ScanHostname(w, " ")
+	assert.True(w.IsEmpty())
+	ScanHostname(w, "23.23.23.23")
+	assert.False(w.IsEmpty())
+	assert.Equal([]string{"23.23.23.23"}, w.Get(FieldIPAddress))
+	w.Reset()
+	ScanHostname(w, "foo ")
+	assert.False(w.IsEmpty())
+	assert.Equal([]string{"foo"}, w.Get(FieldDomainName))
+}
+
+func TestScanURL(t *testing.T) {
+	assert := require.New(t)
+	w := &ValueBuffer{}
+	ScanURL(w, "")
+	assert.True(w.IsEmpty())
+	ScanURL(w, " ")
+	assert.True(w.IsEmpty())
+	ScanURL(w, "23.23.23.23")
+	assert.True(w.IsEmpty())
+	ScanURL(w, "http://23.23.23.23/foo")
+	assert.Equal([]string{"23.23.23.23"}, w.Get(FieldIPAddress))
+	w.Reset()
+	ScanURL(w, "foo ")
+	assert.True(w.IsEmpty())
+	ScanURL(w, "http://foo")
+	assert.False(w.IsEmpty())
+	assert.Equal([]string{"foo"}, w.Get(FieldDomainName))
+}
+
+func TestScanEmail(t *testing.T) {
+	assert := require.New(t)
+	w := &ValueBuffer{}
+	ScanEmail(w, "foo")
+	assert.True(w.IsEmpty())
+	ScanEmail(w, "")
+	assert.True(w.IsEmpty())
+	ScanEmail(w, "  ")
+	assert.True(w.IsEmpty())
+	ScanEmail(w, "23.23.23.23")
+	assert.True(w.IsEmpty())
+	ScanEmail(w, "foo@bar.baz")
+	assert.False(w.IsEmpty())
+	ScanEmail(w, "foo@bar.baz ")
+	assert.Equal([]string{"foo@bar.baz"}, w.Get(FieldEmail))
+}
+
+func TestScanDomain(t *testing.T) {
+	assert := require.New(t)
+	w := &ValueBuffer{}
+	FieldDomainName.ScanValues(w, "")
+	assert.True(w.IsEmpty())
+	FieldDomainName.ScanValues(w, "  ")
+	assert.True(w.IsEmpty())
+	FieldDomainName.ScanValues(w, "foo ")
+	assert.False(w.IsEmpty())
+	assert.Equal([]string{"foo"}, w.Get(FieldDomainName))
+}


### PR DESCRIPTION
## Background

This PR is related to #1321

## Changes

- Adds `username` indicator scanner and field
- Adds `email` indicator scanner and field
- Adds `username` tag to `AWS.CloudTrail`

## Testing

- mage test:go
