### PR TITLE
Validate instance IDs exist before sending

### DIFF
--- a/internal/compliance/aws_event_processor/processor/rds.go
+++ b/internal/compliance/aws_event_processor/processor/rds.go
@@ -52,7 +52,12 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 	case "AddRoleToDBInstance", "CreateDBInstance", "CreateDBSnapshot", "DeleteDBInstance", "ModifyDBInstance",
 		"PromoteReadReplica", "RebootDBInstance", "RemoveRoleFromDBInstance", "RestoreDBInstanceFromDBSnapshot",
 		"RestoreDBInstanceFromS3", "StartDBInstance", "StopDBInstance":
-		rdsARN.Resource += detail.Get("requestParameters.dBInstanceIdentifier").Str
+		instanceID := detail.Get("requestParameters.dBInstanceIdentifier")
+		if !instanceID.Exists() {
+			zap.L().Warn("unable to extract dBInstanceIdentifier from event", zap.Any("requestParameters", detail.Get("requestParameters").Raw))
+			return nil
+		}
+		rdsARN.Resource += instanceID.Str
 	case "AddTagsToResource", "RemoveTagsFromResource":
 		resourceARN, err := arn.Parse(detail.Get("requestParameters.resourceName").Str)
 		if err != nil {
@@ -81,6 +86,7 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 		instanceID := detail.Get("responseElements.dBSnapshot.dBInstanceIdentifier")
 		// This can happen when a snapshot for a DB that no longer exists is changed
 		if !instanceID.Exists() {
+			zap.L().Warn("unable to extract dBInstanceIdentifier from event", zap.Any("responseElements", detail.Get("responseElements").Raw))
 			return nil
 		}
 		rdsARN.Resource += instanceID.Str
@@ -111,7 +117,12 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 			ResourceType: schemas.Ec2VpcSchema,
 		}}
 	case "DeleteDBInstanceAutomatedBackup":
-		rdsARN.Resource += detail.Get("responseElements.dBInstanceAutomatedBackup.dBInstanceIdentifier").Str
+		instanceID := detail.Get("responseElements.dBInstanceAutomatedBackup.dBInstanceIdentifier")
+		if !instanceID.Exists() {
+			zap.L().Warn("unable to extract dBInstanceIdentifier from event", zap.Any("responseElements", detail.Get("responseElements").Raw))
+			return nil
+		}
+		rdsARN.Resource += instanceID.Str
 	case "ModifyDBSnapshotAttribute":
 		// Since we can't tie this back to the corresponding RDS Instance with just the context of
 		// this event, we send the panther-snapshot-poller the ID of the db snapshot and let the

--- a/internal/compliance/aws_event_processor/processor/rds.go
+++ b/internal/compliance/aws_event_processor/processor/rds.go
@@ -54,7 +54,7 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 		"RestoreDBInstanceFromS3", "StartDBInstance", "StopDBInstance":
 		instanceID := detail.Get("requestParameters.dBInstanceIdentifier")
 		if !instanceID.Exists() {
-			zap.L().Warn("unable to extract dBInstanceIdentifier from event", zap.Any("requestParameters", detail.Get("requestParameters").Raw))
+			zap.L().Info("unable to extract dBInstanceIdentifier from event", zap.Any("requestParameters", detail.Get("requestParameters").Raw))
 			return nil
 		}
 		rdsARN.Resource += instanceID.Str
@@ -86,7 +86,7 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 		instanceID := detail.Get("responseElements.dBSnapshot.dBInstanceIdentifier")
 		// This can happen when a snapshot for a DB that no longer exists is changed
 		if !instanceID.Exists() {
-			zap.L().Warn("unable to extract dBInstanceIdentifier from event", zap.Any("responseElements", detail.Get("responseElements").Raw))
+			zap.L().Info("unable to extract dBInstanceIdentifier from event", zap.Any("responseElements", detail.Get("responseElements").Raw))
 			return nil
 		}
 		rdsARN.Resource += instanceID.Str
@@ -119,7 +119,7 @@ func classifyRDS(detail gjson.Result, metadata *CloudTrailMetadata) []*resourceC
 	case "DeleteDBInstanceAutomatedBackup":
 		instanceID := detail.Get("responseElements.dBInstanceAutomatedBackup.dBInstanceIdentifier")
 		if !instanceID.Exists() {
-			zap.L().Warn("unable to extract dBInstanceIdentifier from event", zap.Any("responseElements", detail.Get("responseElements").Raw))
+			zap.L().Info("unable to extract dBInstanceIdentifier from event", zap.Any("responseElements", detail.Get("responseElements").Raw))
 			return nil
 		}
 		rdsARN.Resource += instanceID.Str


### PR DESCRIPTION
## Background

The `aws-event-processor` processes AWS CloudTrail logs and determines if scans need to happen as a result of these logs. Part of the responsibility of the `aws-event-processor` is to extract the `resourceID` (typically the ARN) of the resource being changed and include that in the scan request.

For certain AWS RDS instance related events, the instance ID may not be present in the log if the instance no longer exists.  This is common, for example, when changes happen to RDS instance snapshots of instances that no longer exist.

We were previously passing along these "blank" arns that were causing issues in the `panther-snapshot-poller`.  This change extends some validation of the instance ID extraction to all branches when evaluating RDS Instance related events.

Discovered while investigating on call incidents.

## Changes

- Always validate that the RDS instance ID we extracted exists before returning a scan request

## Testing

- None
