### PR TITLE
Removed lastEventReceived from S3 & SQS card

### DIFF
--- a/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.test.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.test.tsx
@@ -33,7 +33,6 @@ describe('S3LogSourceCard', () => {
     expect(getByText(source.s3Bucket)).toBeInTheDocument();
     expect(getByText(source.kmsKey)).toBeInTheDocument();
     expect(getByText(formatDatetime(source.createdAtTime, true))).toBeInTheDocument();
-    expect(getByText(formatDatetime(source.lastEventReceived, true))).toBeInTheDocument();
     source.logTypes.forEach(logType => {
       expect(getByText(logType)).toBeInTheDocument();
     });

--- a/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.tsx
@@ -40,10 +40,6 @@ const S3LogSourceCard: React.FC<S3LogSourceCardProps> = ({ source }) => {
         label="Date Created"
         value={formatDatetime(source.createdAtTime, true)}
       />
-      <GenericItemCard.Value
-        label="Last Received Events At"
-        value={source.lastEventReceived ? formatDatetime(source.lastEventReceived, true) : 'Never'}
-      />
       <GenericItemCard.LineBreak />
       <GenericItemCard.Value
         label="Log Types"

--- a/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.test.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.test.tsx
@@ -38,7 +38,6 @@ describe('SqsLogSourceCard', () => {
       expect(getByText(arn)).toBeInTheDocument();
     });
     expect(getByText(formatDatetime(source.createdAtTime, true))).toBeInTheDocument();
-    expect(getByText(formatDatetime(source.lastEventReceived, true))).toBeInTheDocument();
     source.sqsConfig.logTypes.forEach(logType => {
       expect(getByText(logType)).toBeInTheDocument();
     });

--- a/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.tsx
@@ -62,10 +62,6 @@ const SqsLogSourceCard: React.FC<SqsLogSourceCardProps> = ({ source }) => {
         label="Date Created"
         value={formatDatetime(source.createdAtTime, true)}
       />
-      <GenericItemCard.Value
-        label="Last Received Events At"
-        value={source.lastEventReceived ? formatDatetime(source.lastEventReceived, true) : 'Never'}
-      />
       <GenericItemCard.LineBreak />
       <GenericItemCard.Value
         label="Log Types"


### PR DESCRIPTION
## Background

During the latest refactor of log source cards, we added `lastEventReceived` information to the top right corner but we left out the pre-existing field displaying this info on cards for S3 & SQS

Closes #2146 
## Changes

-  Removed `lastEventReceived` field from card body
- Updated tests

## Testing

- Locally
