### PR TITLE
Hardcode source-api version

### DIFF
--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -785,7 +785,7 @@ Resources:
           LOG_PROCESSOR_QUEUE_ARN: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:panther-input-data-notifications-queue
           SNAPSHOT_POLLERS_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/panther-snapshot-queue
           TABLE_NAME: !Ref IntegrationsTable
-          VERSION: !Ref CustomResourceVersion
+          VERSION: v1.13.0 # hardcoded for this release, it needs to match published aux template versions
       FunctionName: panther-source-api
       # <cfndoc>
       # The `panther-source-api` lambda manages Cloud Security and Log Analysis sources. This includes


### PR DESCRIPTION
## Background

The `source-api` is now using versioned aux templates, but the version being used is the `CUSTOM_RESOURCE_VERSION` CloudFormation parameter, which was not designed for this purpose. This has different values when doing `mage deploy` vs `mage master:deploy`. For a VERSION file which contained "v1.13.0-RC" as the base version:

* `mage deploy` was setting `v1.13.0` as the CUSTOM_RESOURCE_VERSION because of a string split on `-`
* `mage master:deploy` uses the full version string `v1.13.0-RC-(branch)-(commit)`

Neither of these are correct - the template version comes from the VERSION file, so it should have been `v1.13.0-RC`

----

The quick fix for right now is to literally just hardcode the version in the `source-api` environment.

Longer term fixes in progress:

* I will put up a PR to use versioning consistently (based on https://github.com/panther-labs/panther/pull/2158), and to pass panther version separately from custom resource version.
* Working on removing the old deployment model, which will prevent discrepancies like this one caused by having two different deploy methods

## Changes

- Hardcode version environment variable for `source-api`

## Testing

- `mage master:deploy` of current `release-1.13` branch, verified bug still exists:

![Screen Shot 2020-11-30 at 2 20 49 PM](https://user-images.githubusercontent.com/3608925/100672782-446a1780-3317-11eb-8e81-3da5ebbbae6b.png)

- `mage master:deploy` after this fix: templates can be generated and the error goes away (I already published the `v1.13.0` aux templates)
- `mage deploy` to confirm the same fix works for source deployments