### PR TITLE
Fix uuid validation and case-insensitive filtering

### DIFF
--- a/api/lambda/analysis/models/api.go
+++ b/api/lambda/analysis/models/api.go
@@ -71,7 +71,7 @@ type UnitTest struct {
 
 type BulkUploadInput struct {
 	Data   string `json:"data" validate:"required"` // base64-encoded zipfile
-	UserID string `json:"userId" validate:"uuid4"`
+	UserID string `json:"userId" validate:"required"`
 }
 
 type BulkUploadOutput struct {

--- a/api/lambda/analysis/models/data_models.go
+++ b/api/lambda/analysis/models/data_models.go
@@ -62,7 +62,7 @@ type UpdateDataModelInput struct {
 	ID          string             `json:"id" validate:"required,max=1000,excludesall='<>&\""`
 	LogTypes    []string           `json:"logTypes" validate:"len=1,dive,required,max=500"` // for now, only one logtype allowed
 	Mappings    []DataModelMapping `json:"mappings" validate:"min=1,max=500,dive"`
-	UserID      string             `json:"userId" validate:"uuid4"`
+	UserID      string             `json:"userId" validate:"required"`
 }
 
 type DataModel struct {

--- a/api/lambda/analysis/models/globals.go
+++ b/api/lambda/analysis/models/globals.go
@@ -49,7 +49,7 @@ type UpdateGlobalInput struct {
 	Description string   `json:"description" validate:"max=10000"`
 	ID          string   `json:"id" validate:"required,max=1000,excludesall='<>&\""`
 	Tags        []string `json:"tags" validate:"max=500,dive,required,max=1000"`
-	UserID      string   `json:"userId" validate:"uuid4"`
+	UserID      string   `json:"userId" validate:"required"`
 }
 
 type Global struct {

--- a/api/lambda/analysis/models/policies.go
+++ b/api/lambda/analysis/models/policies.go
@@ -143,7 +143,7 @@ type UpdatePolicyInput struct {
 	Suppressions              []string            `json:"suppressions" validate:"max=500,dive,required,max=1000"`
 	Tags                      []string            `json:"tags" validate:"max=500,dive,required,max=1000"`
 	Tests                     []UnitTest          `json:"tests" validate:"max=500,dive"`
-	UserID                    string              `json:"userId" validate:"uuid4"`
+	UserID                    string              `json:"userId" validate:"required"`
 }
 
 // The validate tags here are used by BulkUpload

--- a/api/lambda/analysis/models/rules.go
+++ b/api/lambda/analysis/models/rules.go
@@ -116,7 +116,7 @@ type UpdateRuleInput struct {
 	Tags               []string            `json:"tags" validate:"max=500,dive,required,max=1000"`
 	Tests              []UnitTest          `json:"tests" validate:"max=500,dive"`
 	Threshold          int                 `json:"threshold" validate:"min=0"`
-	UserID             string              `json:"userId" validate:"uuid4"`
+	UserID             string              `json:"userId" validate:"required"`
 }
 
 type Rule struct {

--- a/internal/core/analysis_api/handlers/list.go
+++ b/internal/core/analysis_api/handlers/list.go
@@ -84,7 +84,7 @@ func pythonListFilters(enabled *bool, nameContains, severity string, types, tags
 
 	if nameContains != "" {
 		filters = append(filters, expression.Contains(expression.Name("lowerId"), nameContains).
-			Or(expression.Contains(expression.Name("lowerDisplayName"), strings.ToLower(nameContains))))
+			Or(expression.Contains(expression.Name("lowerDisplayName"), nameContains)))
 	}
 
 	if len(types) > 0 {
@@ -149,29 +149,29 @@ func sortByDisplayName(items []tableItem, ascending bool) {
 		left, right := items[i], items[j]
 
 		var leftName, rightName string
-		leftName, rightName = left.DisplayName, right.DisplayName
+		leftName, rightName = left.LowerDisplayName, right.LowerDisplayName
 
 		// The frontend shows display name *or* ID (when there is no display name)
 		// So we sort the same way it is shown to the user - displayName if available, otherwise ID
 		if leftName == "" {
-			leftName = left.ID
+			leftName = left.LowerID
 		}
 		if rightName == "" {
-			rightName = right.ID
+			rightName = right.LowerID
 		}
 
 		if leftName != rightName {
 			if ascending {
-				return strings.ToLower(leftName) < strings.ToLower(rightName)
+				return leftName < rightName
 			}
-			return strings.ToLower(leftName) > strings.ToLower(rightName)
+			return leftName > rightName
 		}
 
 		// Same display name: sort by ID
 		if ascending {
-			return strings.ToLower(left.ID) < strings.ToLower(right.ID)
+			return left.LowerID < right.LowerID
 		}
-		return strings.ToLower(left.ID) > strings.ToLower(right.ID)
+		return left.LowerID > right.LowerID
 	})
 }
 

--- a/internal/core/analysis_api/handlers/list_data_models.go
+++ b/internal/core/analysis_api/handlers/list_data_models.go
@@ -32,7 +32,8 @@ import (
 )
 
 func (API) ListDataModels(input *models.ListDataModelsInput) *events.APIGatewayProxyResponse {
-	// Set defaults
+	// Standardize input
+	input.NameContains = strings.ToLower(input.NameContains)
 	if input.Page == 0 {
 		input.Page = defaultPage
 	}
@@ -89,7 +90,7 @@ func dataModelScanInput(input *models.ListDataModelsInput) (*dynamodb.ScanInput,
 
 	if input.NameContains != "" {
 		filters = append(filters, expression.Contains(expression.Name("lowerId"), input.NameContains).
-			Or(expression.Contains(expression.Name("lowerDisplayName"), strings.ToLower(input.NameContains))))
+			Or(expression.Contains(expression.Name("lowerDisplayName"), input.NameContains)))
 	}
 
 	if len(input.LogTypes) > 0 {

--- a/internal/core/analysis_api/handlers/list_policies.go
+++ b/internal/core/analysis_api/handlers/list_policies.go
@@ -100,6 +100,7 @@ func (API) ListPolicies(input *models.ListPoliciesInput) *events.APIGatewayProxy
 
 // Set defaults and standardize input request
 func stdPolicyListInput(input *models.ListPoliciesInput) {
+	input.NameContains = strings.ToLower(input.NameContains)
 	if input.Page == 0 {
 		input.Page = defaultPage
 	}

--- a/internal/core/analysis_api/handlers/list_rules.go
+++ b/internal/core/analysis_api/handlers/list_rules.go
@@ -20,6 +20,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -68,6 +69,7 @@ func (API) ListRules(input *models.ListRulesInput) *events.APIGatewayProxyRespon
 
 // Set defaults and standardize input request
 func stdRuleListInput(input *models.ListRulesInput) {
+	input.NameContains = strings.ToLower(input.NameContains)
 	if input.Page == 0 {
 		input.Page = defaultPage
 	}

--- a/internal/core/analysis_api/handlers/list_test.go
+++ b/internal/core/analysis_api/handlers/list_test.go
@@ -66,43 +66,43 @@ func TestPagePoliciesPageOutOfBounds(t *testing.T) {
 
 func TestPagePoliciesDisplayNameSort(t *testing.T) {
 	items := []tableItem{
-		{ID: "a", DisplayName: "z"},
-		{ID: "h", DisplayName: "b"},
-		{ID: "c", DisplayName: "y"},
-		{ID: "e", DisplayName: "a"},
-		{ID: "g", DisplayName: "b"},
-		{ID: "d", DisplayName: ""},
+		{LowerID: "a", LowerDisplayName: "z"},
+		{LowerID: "h", LowerDisplayName: "b"},
+		{LowerID: "c", LowerDisplayName: "y"},
+		{LowerID: "e", LowerDisplayName: "a"},
+		{LowerID: "g", LowerDisplayName: "b"},
+		{LowerID: "d", LowerDisplayName: ""},
 	}
 
 	sortByDisplayName(items, true)
 
 	expected := []tableItem{
-		{ID: "e", DisplayName: "a"},
-		{ID: "g", DisplayName: "b"},
-		{ID: "h", DisplayName: "b"},
-		{ID: "d", DisplayName: ""},
-		{ID: "c", DisplayName: "y"},
-		{ID: "a", DisplayName: "z"},
+		{LowerID: "e", LowerDisplayName: "a"},
+		{LowerID: "g", LowerDisplayName: "b"},
+		{LowerID: "h", LowerDisplayName: "b"},
+		{LowerID: "d", LowerDisplayName: ""},
+		{LowerID: "c", LowerDisplayName: "y"},
+		{LowerID: "a", LowerDisplayName: "z"},
 	}
 	assert.Equal(t, expected, items)
 }
 
 func TestPagePoliciesDisplayNameSortReverse(t *testing.T) {
 	items := []tableItem{
-		{ID: "e", DisplayName: "a"},
-		{ID: "a", DisplayName: "z"},
-		{ID: "c", DisplayName: "y"},
-		{ID: "g", DisplayName: "b"},
-		{ID: "d", DisplayName: "y"},
+		{LowerID: "e", LowerDisplayName: "a"},
+		{LowerID: "a", LowerDisplayName: "z"},
+		{LowerID: "c", LowerDisplayName: "y"},
+		{LowerID: "g", LowerDisplayName: "b"},
+		{LowerID: "d", LowerDisplayName: "y"},
 	}
 	sortByDisplayName(items, false)
 
 	expected := []tableItem{
-		{ID: "a", DisplayName: "z"},
-		{ID: "d", DisplayName: "y"},
-		{ID: "c", DisplayName: "y"},
-		{ID: "g", DisplayName: "b"},
-		{ID: "e", DisplayName: "a"},
+		{LowerID: "a", LowerDisplayName: "z"},
+		{LowerID: "d", LowerDisplayName: "y"},
+		{LowerID: "c", LowerDisplayName: "y"},
+		{LowerID: "g", LowerDisplayName: "b"},
+		{LowerID: "e", LowerDisplayName: "a"},
 	}
 	assert.Equal(t, expected, items)
 }

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -55,7 +55,7 @@ var (
 	integrationTest bool
 	apiClient       gatewayapi.API
 
-	userID = "521a1c7b-273f-4a03-99a7-5c661de5b0e8"
+	userID = "test-panther-user" // does NOT need to be a uuid4
 
 	// NOTE: this gets changed by the bulk upload!
 	policy = &models.Policy{


### PR DESCRIPTION
## Background

Our release QA revealed a few bugs with the `analysis-api`, which isn't that surprising since we removed the analysis-api gateway in this release.

Fortunately, the fixes are small and easy

## Changes

- Do not require userIDs to be UUID4s: they just need to be non-empty
    - In the community edition, userIDs happen to always be uuids, but that's not always true in enterprise
    - Updated the integration test with a non-uuid userID as a regression test
- ID filtering is now correctly case-insensitive
    - We were lowercasing the display name search, but not the ID search
- Related minor performance improvement: when sorting by display name / ID, we can use the existing dynamo columns "LowerID" and "LowerDisplayName" to avoid having to recompute the lowercase string on each comparison

## Testing

- Deployed to dev account, verified rule/policy case-insensitive filtering by display name and ID
- Fixes verified in release QA environment
- `analysis-api` integration tests
