### PR TITLE
fix: date color on generic item card

### DIFF
--- a/web/src/components/GenericItemCard/GenericItemCard.tsx
+++ b/web/src/components/GenericItemCard/GenericItemCard.tsx
@@ -120,7 +120,7 @@ const GenericItemCardOptionsButton = React.forwardRef<HTMLButtonElement>(functio
 
 const GenericItemCardDate: React.FC<GenericItemCardDate> = ({ date, ...rest }) => {
   return (
-    <Text fontSize="small" as="span" color="gray-500" {...rest}>
+    <Text fontSize="small" as="span" color="navyblue-200" {...rest}>
       {date}
     </Text>
   );

--- a/web/src/components/cards/AlertCard/__snapshots__/AlertCard.test.tsx.snap
+++ b/web/src/components/cards/AlertCard/__snapshots__/AlertCard.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`AlertCard should match snapshot 1`] = `
 
 .panther-3 {
   font-size: 0.75rem;
-  color: #716f6f;
+  color: #4f627c;
 }
 
 .panther-5 {


### PR DESCRIPTION
## Background

The Color of the date on the Cards is not correct, but the correct one is not in our palette. After speaking with @dimitriszoitas we agreed to use `navyblue-200`

### Before

<img width="569" alt="Screen Shot 2020-12-03 at 6 09 44 PM" src="https://user-images.githubusercontent.com/10436045/101056005-2dcff480-3593-11eb-810c-0054c3d1c26b.png">


### After

<img width="283" alt="Screen Shot 2020-12-03 at 6 09 54 PM" src="https://user-images.githubusercontent.com/10436045/101056027-34f70280-3593-11eb-810d-f7db9d16f356.png">


## Changes

- Change color of "date" on cards to `navyblue-200`

## Testing

- `npm run test`
