### PR TITLE
Revert to sequential publishing

### DIFF
--- a/deployments/web_server.yml
+++ b/deployments/web_server.yml
@@ -85,7 +85,7 @@ Parameters:
   PantherCommit:
     Type: String
     Description: The commit of the current deployment (e.g. `5c2a8a76`)
-    AllowedPattern: '^[0-9a-f]{8}$'
+    AllowedPattern: '^[0-9a-f]+$'
   PantherVersion:
     Type: String
     Description: The base semantic version of the current deployment (e.g. `1.3.0`)

--- a/tools/mage/deploy/frontend.go
+++ b/tools/mage/deploy/frontend.go
@@ -56,7 +56,7 @@ func deployFrontend(bootstrapOutputs map[string]string, settings *PantherConfig)
 		return err
 	}
 
-	dockerImage, err := DockerPush(bootstrapOutputs["ImageRegistryUri"], localImageID, "")
+	dockerImage, err := DockerPush(clients.ECR(), bootstrapOutputs["ImageRegistryUri"], localImageID, "")
 	if err != nil {
 		return err
 	}
@@ -99,9 +99,9 @@ func DockerBuild() (string, error) {
 }
 
 // Build a personalized docker image from source and push it to the private image repo of the user
-func DockerPush(imageRegistry, localImageID, tag string) (string, error) {
+func DockerPush(ecrClient *ecr.ECR, imageRegistry, localImageID, tag string) (string, error) {
 	log.Debug("requesting access to remote image repo")
-	response, err := clients.ECR().GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
+	response, err := ecrClient.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get ecr auth token: %v", err)
 	}

--- a/tools/mage/master/deploy.go
+++ b/tools/mage/master/deploy.go
@@ -107,7 +107,7 @@ func Deploy() error {
 	}
 	var registryURI = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", clients.AccountID(), clients.Region(), repoName)
 
-	pkg, err := pkgAssets(log, clients.Region(), bucket, registryURI, dockerImageID)
+	pkg, err := pkgAssets(log, clients.ECR(), clients.Region(), bucket, registryURI, dockerImageID)
 	if err != nil {
 		return err
 	}

--- a/tools/mage/master/publish.go
+++ b/tools/mage/master/publish.go
@@ -94,8 +94,12 @@ func Publish() error {
 	// Publish to each region.
 	//
 	// This fails if you publish multiple regions in parallel, unfortunately.
-	// However, when we implement our own packaging, each region can package its own assets in parallel.
+	// However, when we implement our own packaging, each region will package its own assets in parallel.
 	for _, region := range regions {
+		if !deploy.SupportedRegions[region] {
+			return fmt.Errorf("%s is not a supported region", region)
+		}
+
 		if err := publishToRegion(log, region, dockerImageID); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Background

The v1.14 release adds publishing support for 15 different AWS regions! We tried to publish the regions in parallel, but both @s0l0ist and I ran into issues with "Content-MD5 mismatch" or "docker credential failure"

So, we have to revert to sequential region publishing. However, to compensate, I've added the ability to specify which regions you want to publish. For release testing, for example, we don't need to publish all 15 regions, which can take quite awhile.

## Changes

- List your changes here in more detail

## Testing

- `mage master:publish`

> 17:49:15	INFO	[master:publish]	Publishing panther-community 1.14.0-RC to ca-central-1, ap-northeast-2, eu-north-1, eu-west-1, eu-west-2, us-west-1, ap-northeast-1, ap-southeast-1, ap-southeast-2, us-east-1, us-east-2, us-west-2, ap-south-1, eu-central-1, eu-west-3, sa-east-1

- `REGION=us-east-1,us-east-2,us-west-1,us-west-2 mage master:publish`

> 17:50:01	INFO	[master:publish]	Publishing panther-community 1.14.0-RC to us-east-1, us-east-2, us-west-1, us-west-2

A test publish is in progress (of the master branch with v1.14.0-RC, which I'll overwrite when it syncs to the release branch)
