### PR TITLE
Explicitly add Application:Panther tag to Athena workgroup because stack is not applying

### DIFF
--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -385,6 +385,9 @@ Resources:
     Properties:
       Name: Panther
       Description: The Panther workgroup
+      Tags: # NOTE: for some reason the tags from the stack are not being applied
+        - Key: Application
+          Value: Panther
       RecursiveDeleteOption: true
       WorkGroupConfiguration:
         EnforceWorkGroupConfiguration: false # we want client side overrides


### PR DESCRIPTION
## Background

The stack was not applying tags to the Athena Work Group. This is needed for accurate billing reporting.

## Changes

- Explicitly add Application:Panther tag to Athena workgroup

## Testing

- mage deploy, checked tags present.