### PR TITLE
Raise log processor lambda size limits since AWS has raised maximum

### DIFF
--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -122,7 +122,7 @@ Parameters:
     Type: Number
     Description: Log processor Lambda memory allocation. Increase to eliminate out-of-memory errors or reduce processing time (in exchange for higher cost)
     MinValue: 256 # 128 is too small, risks OOM errors
-    MaxValue: 3008
+    MaxValue: 10240
     Default: 2048
   LogProcessorLambdaSQSReadBatchSize:
     Type: Number

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -41,10 +41,11 @@ Infra:
   # If cost is more of a concern compared to performance, choose
   # a small memory size, however, for extremely large log volumes
   # the larger sizes may be required for adequate performance or large files.
+  # https://aws.amazon.com/lambda/pricing/
   # Processing capability can be further increased by raising the
   # Lambda concurrent execution limit from default 1000, see:
   # https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html
-  LogProcessorLambdaMemorySize: 1024 # 256 - 3008, in 64MB increments
+  LogProcessorLambdaMemorySize: 1024 # 256 - 10240, in 1MB increments
 
   # The log processor reads in batches of S3 notifications from an SQS queue.
   # In order to keep SQS API costs down we default to the largest allowed batch size. However,


### PR DESCRIPTION
## Background

AWS raised the max lambda size to 10240. This PR updates our limits for the log processor.

## Changes

- Up limits in master template and panther_config.yml

## Testing

- mage deplooy
