### PR TITLE
Change "resource no longer exists" log from Warn() to Debug()

### DIFF
--- a/internal/compliance/resources_api/handlers/delete_resources.go
+++ b/internal/compliance/resources_api/handlers/delete_resources.go
@@ -50,8 +50,8 @@ func (API) DeleteResources(input *models.DeleteResourcesInput) *events.APIGatewa
 		case http.StatusOK:
 			continue
 		case http.StatusNotFound:
-			// If the resource wasn't found, log a warning but we don't need to fail the operation.
-			zap.L().Warn("resource no longer exists", zap.Any("deleteEntry", entry))
+			// If the resource wasn't found, log but we don't need to fail the operation.
+			zap.L().Debug("resource no longer exists", zap.Any("deleteEntry", entry))
 		default:
 			return response // some other error condition
 		}


### PR DESCRIPTION
## Before

During delete  "resource no longer exists" errors were logged at warn level but this creates alarms when we get spikes of warnings above threshold.

## After

- Change "resource no longer exists" log from Warn() to Debug()

