### PR TITLE
security: bump ua-parser-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9496,9 +9496,9 @@
       },
       "dependencies": {
         "ua-parser-js": {
-          "version": "0.7.22",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-          "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+          "version": "0.7.23",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+          "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
         }
       }
     },
@@ -18588,9 +18588,9 @@
           },
           "dependencies": {
             "ua-parser-js": {
-              "version": "0.7.22",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-              "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+              "version": "0.7.23",
+              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+              "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
               "dev": true
             }
           }
@@ -18834,9 +18834,9 @@
           },
           "dependencies": {
             "ua-parser-js": {
-              "version": "0.7.22",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-              "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+              "version": "0.7.23",
+              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+              "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "resolutions": {
     "node-fetch": "2.6.1",
-    "ua-parser-js": "0.7.22"
+    "ua-parser-js": "0.7.23"
   },
   "scripts": {
     "preinstall": "npx npm-force-resolutions",


### PR DESCRIPTION
## Background

Snyk re-reported a vulnerability with the patch version it recommended. This PR bumps the patch version of `ua-parser-js` once more.

## Changes

- bump to latest patch version of `ua-parser-js`

## Testing

- CI:
  - `npm audit`
  - snyk CI checks
