### PR TITLE
fix: ci image update node

### DIFF
--- a/build/images/ci/Dockerfile
+++ b/build/images/ci/Dockerfile
@@ -23,7 +23,7 @@ FROM buildpack-deps:buster-scm
 
 LABEL description="Panther CircleCI combined Go/Node/Python environment"
 
-ENV GO_VERSION=1.15.1 NODE_VERSION=12.18.3 PYTHON_VERSION=3.7.9
+ENV GO_VERSION=1.15.1 NODE_VERSION=14.15.1 PYTHON_VERSION=3.7.9
 
 
 # ****************     APT Packages     *******************


### PR DESCRIPTION
## Background

Updates the docker build image to use node `v14.15.1`

## Changes

- change the version string

## Testing

- the URL download works with the specified version
