### PR TITLE
fix: return alertId when generating the URL

### DIFF
--- a/internal/core/alert_delivery/outputs/asana_test.go
+++ b/internal/core/alert_delivery/outputs/asana_test.go
@@ -37,6 +37,7 @@ func TestAsanaAlert(t *testing.T) {
 	createdAtTime, err := time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	require.NoError(t, err)
 	alert := &alertModels.Alert{
+		AlertID:             aws.String("alertId"),
 		AnalysisID:          "ruleId",
 		Type:                alertModels.PolicyType,
 		CreatedAt:           createdAtTime,
@@ -53,7 +54,7 @@ func TestAsanaAlert(t *testing.T) {
 		"data": map[string]interface{}{
 			"name": "Policy Failure: policy_name",
 			"notes": "policy_name failed on new resources\n" +
-				"For more details please visit: https://panther.io/policies/ruleId\nSeverity: INFO\nRunbook: \n" +
+				"For more details please visit: https://panther.io/alerts/alertId\nSeverity: INFO\nRunbook: \n" +
 				"Reference: \nDescription: description\nAlertContext: {\"key\":\"value\"}",
 			"projects": []string{"projectGid"},
 		},

--- a/internal/core/alert_delivery/outputs/custom_webhook_test.go
+++ b/internal/core/alert_delivery/outputs/custom_webhook_test.go
@@ -45,6 +45,7 @@ func TestCustomWebhookAlert(t *testing.T) {
 		t.Error(err)
 	}
 	alert := &alertModels.Alert{
+		AlertID:    aws.String("alertId"),
 		AnalysisID: "policyId",
 		Type:       alertModels.PolicyType,
 		CreatedAt:  createdAtTime,
@@ -60,7 +61,7 @@ func TestCustomWebhookAlert(t *testing.T) {
 		Name:        alert.AnalysisName,
 		Severity:    alert.Severity,
 		Type:        alert.Type,
-		Link:        "https://panther.io/policies/policyId",
+		Link:        "https://panther.io/alerts/" + aws.StringValue(alert.AlertID),
 		Title:       "Policy Failure: policyId",
 		Description: aws.String(alert.AnalysisDescription),
 		Runbook:     aws.String(alert.Runbook),

--- a/internal/core/alert_delivery/outputs/github_test.go
+++ b/internal/core/alert_delivery/outputs/github_test.go
@@ -37,6 +37,7 @@ func TestGithubAlert(t *testing.T) {
 
 	var createdAtTime, _ = time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	alert := &alertModels.Alert{
+		AlertID:             aws.String("alertId"),
 		AnalysisID:          "policyId",
 		Type:                alertModels.PolicyType,
 		CreatedAt:           createdAtTime,
@@ -50,7 +51,7 @@ func TestGithubAlert(t *testing.T) {
 	githubRequest := map[string]interface{}{
 		"title": "Policy Failure: policy_name",
 		"body": "**Description:** description\n " +
-			"[Click here to view in the Panther UI](https://panther.io/policies/policyId)\n" +
+			"[Click here to view in the Panther UI](https://panther.io/alerts/alertId)\n" +
 			" **Runbook:** \n **Severity:** INFO\n **Tags:** \n **AlertContext:** {\"key\":\"value\"}",
 	}
 

--- a/internal/core/alert_delivery/outputs/jira_test.go
+++ b/internal/core/alert_delivery/outputs/jira_test.go
@@ -46,6 +46,7 @@ func TestJiraAlert(t *testing.T) {
 
 	var createdAtTime, _ = time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	alert := &alertModels.Alert{
+		AlertID:             aws.String("alertId"),
 		AnalysisID:          "policyId",
 		Type:                alertModels.PolicyType,
 		CreatedAt:           createdAtTime,
@@ -58,7 +59,7 @@ func TestJiraAlert(t *testing.T) {
 		"fields": map[string]interface{}{
 			"summary": "Policy Failure: policyId",
 			"description": "*Description:* policyDescription\n " +
-				"[Click here to view in the Panther UI|https://panther.io/policies/policyId]\n" +
+				"[Click here to view in the Panther UI|https://panther.io/alerts/alertId]\n" +
 				" *Runbook:* \n *Severity:* INFO\n *Tags:* \n *AlertContext:* {\"key\":\"value\"}",
 			"project": map[string]*string{
 				"key": aws.String(jiraConfig.ProjectKey),

--- a/internal/core/alert_delivery/outputs/msteams.go
+++ b/internal/core/alert_delivery/outputs/msteams.go
@@ -31,7 +31,7 @@ import (
 func (client *OutputClient) MsTeams(
 	alert *alertModels.Alert, config *outputModels.MsTeamsConfig) *AlertDeliveryResponse {
 
-	link := "[Click here to view in the Panther UI](" + policyURLPrefix + alert.AnalysisID + ").\n"
+	link := "[Click here to view in the Panther UI](" + generateURL(alert) + ").\n"
 
 	// Best effort attempt to marshal Alert Context
 	marshaledContext, _ := jsoniter.MarshalToString(alert.Context)

--- a/internal/core/alert_delivery/outputs/msteams_test.go
+++ b/internal/core/alert_delivery/outputs/msteams_test.go
@@ -39,6 +39,7 @@ func TestMsTeamsAlert(t *testing.T) {
 
 	var createdAtTime, _ = time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	alert := &alertModels.Alert{
+		AlertID:      aws.String("alertId"),
 		AnalysisID:   "policyId",
 		Type:         alertModels.PolicyType,
 		CreatedAt:    createdAtTime,
@@ -61,7 +62,7 @@ func TestMsTeamsAlert(t *testing.T) {
 					map[string]string{"name": "Tags", "value": ""},
 					map[string]string{"name": "AlertContext", "value": `{"key":"value"}`},
 				},
-				"text": "[Click here to view in the Panther UI](https://panther.io/policies/policyId).\n",
+				"text": "[Click here to view in the Panther UI](https://panther.io/alerts/alertId).\n",
 			},
 		},
 		"potentialAction": []interface{}{
@@ -71,7 +72,7 @@ func TestMsTeamsAlert(t *testing.T) {
 				"targets": []interface{}{
 					map[string]string{
 						"os":  "default",
-						"uri": "https://panther.io/policies/policyId",
+						"uri": "https://panther.io/alerts/alertId",
 					},
 				},
 			},

--- a/internal/core/alert_delivery/outputs/opsgenie_test.go
+++ b/internal/core/alert_delivery/outputs/opsgenie_test.go
@@ -40,6 +40,7 @@ func TestOpsgenieAlert(t *testing.T) {
 	createdAtTime, err := time.Parse(time.RFC3339, "2019-08-03T11:40:13Z")
 	require.NoError(t, err)
 	alert := &alertModels.Alert{
+		AlertID:      aws.String("alertId"),
 		AnalysisID:   "policyId",
 		Type:         alertModels.PolicyType,
 		CreatedAt:    createdAtTime,
@@ -54,7 +55,7 @@ func TestOpsgenieAlert(t *testing.T) {
 		"message": "Policy Failure: policyName",
 		"description": strings.Join([]string{
 			"<strong>Description:</strong> ",
-			"<a href=\"https://panther.io/policies/policyId\">Click here to view in the Panther UI</a>",
+			"<a href=\"https://panther.io/alerts/alertId\">Click here to view in the Panther UI</a>",
 			" <strong>Runbook:</strong> ",
 			" <strong>Severity:</strong> CRITICAL",
 			" <strong>AlertContext:</strong> {\"key\":\"value\"}",

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -34,9 +34,8 @@ import (
 )
 
 var (
-	policyURLPrefix = os.Getenv("POLICY_URL_PREFIX")
-	appDomainURL    = os.Getenv("APP_DOMAIN_URL")
-	alertURLPrefix  = os.Getenv("ALERT_URL_PREFIX")
+	appDomainURL   = os.Getenv("APP_DOMAIN_URL")
+	alertURLPrefix = os.Getenv("ALERT_URL_PREFIX")
 )
 
 // HTTPWrapper encapsulates the Golang's http client

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -222,12 +222,5 @@ func generateURL(alert *alertModels.Alert) string {
 	if alert.IsTest {
 		return appDomainURL
 	}
-	switch alert.Type {
-	case alertModels.RuleType, alertModels.RuleErrorType:
-		return alertURLPrefix + *alert.AlertID
-	case alertModels.PolicyType:
-		return policyURLPrefix + alert.AnalysisID
-	default:
-		panic("uknown alert type" + alert.Type)
-	}
+	return alertURLPrefix + *alert.AlertID
 }

--- a/internal/core/alert_delivery/outputs/outputs_test.go
+++ b/internal/core/alert_delivery/outputs/outputs_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func init() {
-	policyURLPrefix = "https://panther.io/policies/"
 	alertURLPrefix = "https://panther.io/alerts/"
 }
 

--- a/internal/core/alert_delivery/outputs/pagerduty_test.go
+++ b/internal/core/alert_delivery/outputs/pagerduty_test.go
@@ -34,6 +34,7 @@ import (
 var (
 	createdAtTime, _ = time.Parse(time.RFC3339, "2019-05-03T11:40:13Z")
 	pagerDutyAlert   = &alertModels.Alert{
+		AlertID:      aws.String("alertId"),
 		AnalysisName: aws.String("policyName"),
 		AnalysisID:   "policyId",
 		Severity:     "INFO",
@@ -55,10 +56,11 @@ func TestSendPagerDutyAlert(t *testing.T) {
 		"payload": map[string]interface{}{
 			"custom_details": Notification{
 				ID:           "policyId",
+				AlertID:      aws.String("alertId"),
 				CreatedAt:    createdAtTime,
 				Severity:     "INFO",
 				Type:         alertModels.PolicyType,
-				Link:         "https://panther.io/policies/policyId",
+				Link:         "https://panther.io/alerts/alertId",
 				Title:        "Policy Failure: policyName",
 				Name:         aws.String("policyName"),
 				Description:  aws.String(""),

--- a/internal/core/alert_delivery/outputs/slack_test.go
+++ b/internal/core/alert_delivery/outputs/slack_test.go
@@ -37,6 +37,7 @@ func TestSlackAlert(t *testing.T) {
 
 	createdAtTime := time.Now()
 	alert := &alertModels.Alert{
+		AlertID:      aws.String("alertId"),
 		AnalysisID:   "policyId",
 		Type:         alertModels.PolicyType,
 		CreatedAt:    createdAtTime,
@@ -52,7 +53,7 @@ func TestSlackAlert(t *testing.T) {
 				"fields": []map[string]interface{}{
 					{
 						"short": false,
-						"value": "<https://panther.io/policies/policyId|Click here to view in the Panther UI>",
+						"value": "<https://panther.io/alerts/alertId|Click here to view in the Panther UI>",
 					},
 					{
 						"short": false,

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -47,6 +47,7 @@ func TestSendSns(t *testing.T) {
 
 	createdAtTime := time.Now()
 	alert := &alertModels.Alert{
+		AlertID:             aws.String("alertId"),
 		AnalysisName:        aws.String("policyName"),
 		Type:                alertModels.PolicyType,
 		AnalysisID:          "policyId",
@@ -62,13 +63,14 @@ func TestSendSns(t *testing.T) {
 
 	defaultMessage := Notification{
 		ID:          "policyId",
+		AlertID:     aws.String("alertId"),
 		Type:        alertModels.PolicyType,
 		Name:        aws.String("policyName"),
 		Description: aws.String("policyDescription"),
 		Severity:    "severity",
 		Runbook:     aws.String("runbook"),
 		CreatedAt:   createdAtTime,
-		Link:        "https://panther.io/policies/policyId",
+		Link:        "https://panther.io/alerts/alertId",
 		Title:       "Policy Failure: policyName",
 		Tags:        []string{},
 		AlertContext: map[string]interface{}{
@@ -81,7 +83,7 @@ func TestSendSns(t *testing.T) {
 
 	expectedSnsMessage := &snsMessage{
 		DefaultMessage: defaultSerializedMessage,
-		EmailMessage: "policyName failed on new resources\nFor more details please visit: https://panther.io/policies/policyId\n" +
+		EmailMessage: "policyName failed on new resources\nFor more details please visit: https://panther.io/alerts/alertId\n" +
 			"Severity: severity\nRunbook: runbook\nReference: reference\nDescription: policyDescription\nAlertContext: {\"key\":\"value\"}",
 	}
 	expectedSerializedSnsMessage, err := jsoniter.MarshalToString(expectedSnsMessage)

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -42,6 +42,7 @@ func TestSendSqs(t *testing.T) {
 		QueueURL: "https://sqs.us-west-2.amazonaws.com/123456789012/test-output",
 	}
 	alert := &alertModels.Alert{
+		AlertID:             aws.String("alertId"),
 		AnalysisName:        aws.String("policyName"),
 		Type:                alertModels.PolicyType,
 		AnalysisID:          "policyId",
@@ -55,12 +56,13 @@ func TestSendSqs(t *testing.T) {
 
 	expectedSqsMessage := &Notification{
 		ID:          alert.AnalysisID,
+		AlertID:     aws.String("alertId"),
 		Type:        alertModels.PolicyType,
 		Name:        alert.AnalysisName,
 		Description: aws.String(alert.AnalysisDescription),
 		Severity:    alert.Severity,
 		Runbook:     aws.String(alert.Runbook),
-		Link:        "https://panther.io/policies/policyId",
+		Link:        "https://panther.io/alerts/alertId",
 		Title:       "Policy Failure: policyName",
 		Tags:        []string{},
 		AlertContext: map[string]interface{}{


### PR DESCRIPTION
## Background

Previously, alerts generated by policies were including a URL that was the sending the user to the `AnalysisID` or policy details page because there was no supporting _alert_ details page for these types of alerts.

This PR ensures all alerts will have the same URL to direct the user to the respective alert details pages.

## Changes

- `return alertURLPrefix + *alert.AlertID` for all alerts regardless of the alert type

## Testing

- Manually
- mage test:go
