### PR TITLE
Fixing bug that would result in crushing of the UI

### DIFF
--- a/internal/log_analysis/alerts_api/api/get_alert.go
+++ b/internal/log_analysis/alerts_api/api/get_alert.go
@@ -93,6 +93,7 @@ func (api *API) GetAlert(input *models.GetAlertInput) (result *models.GetAlertOu
 		return nil, err
 	}
 
+	// TODO: We should hit the rule cache ONLY for "old" alerts and only for alerts related to Rules or Rules errors
 	alertRule, err := api.ruleCache.Get(alertItem.RuleID, alertItem.RuleVersion)
 	if err != nil {
 		zap.L().Warn("failed to get rule with ID", zap.Any("rule id", alertItem.RuleID),

--- a/internal/log_analysis/alerts_api/utils/utils.go
+++ b/internal/log_analysis/alerts_api/utils/utils.go
@@ -62,7 +62,7 @@ func AlertItemToSummary(item *table.AlertItem, rule *models.Rule) *alertmodels.A
 	}
 
 	// Generated Fields - backwards compatibility support
-	if IsOldAlert(item) {
+	if IsOldAlert(item) && rule != nil {
 		item.Description = aws.String(rule.Description)
 		item.Reference = aws.String(rule.Reference)
 		item.Runbook = aws.String(rule.Runbook)


### PR DESCRIPTION
## Background

UI would crush trying to list policy alerts. Fixing this. 

## Changes

The code currently tries to fetch Rule information even when the user accesses/lists an alert related to a Policy. This needs to be addressed properly. In the meantime, putting a quick fix here. 

## Testing

- deployed and verified it works properly. 
