### PR TITLE
fix: correct deep merging on alert's events

### DIFF
--- a/web/src/pages/AlertDetails/RuleAlertDetails/RuleAlertDetails.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/RuleAlertDetails.tsx
@@ -24,6 +24,7 @@ import { AlertDetailsFull } from 'Source/graphql/fragments/AlertDetailsFull.gene
 import { BorderedTab, BorderTabDivider } from 'Components/BorderedTab';
 import { extractErrorMessage } from 'Helpers/utils';
 import { DEFAULT_LARGE_PAGE_SIZE } from 'Source/constants';
+import { AlertDetails } from 'Pages/AlertDetails';
 import invert from 'lodash/invert';
 import useUrlParams from 'Hooks/useUrlParams';
 import Skeleton from '../Skeleton';
@@ -69,17 +70,24 @@ const RuleAlertDetails: React.FC<RuleAlertDetailsProps> = ({ alert, fetchMore })
           eventsExclusiveStartKey: alertDetectionInfo.eventsLastEvaluatedKey,
         },
       },
-      updateQuery: (previousResult, { fetchMoreResult }) => {
+      updateQuery: (
+        previousResult: AlertDetails,
+        { fetchMoreResult }: { fetchMoreResult: AlertDetails }
+      ): AlertDetails => {
         return {
           ...previousResult,
           ...fetchMoreResult,
           alert: {
             ...previousResult.alert,
             ...fetchMoreResult.alert,
-            events: [
-              ...(previousResult.alert.detection as AlertDetailsRuleInfo).events,
-              ...(fetchMoreResult.alert.detection as AlertDetailsRuleInfo).events,
-            ],
+            detection: {
+              ...previousResult.alert.detection,
+              ...fetchMoreResult.alert.detection,
+              events: [
+                ...(previousResult.alert.detection as AlertDetailsRuleInfo).events,
+                ...(fetchMoreResult.alert.detection as AlertDetailsRuleInfo).events,
+              ],
+            },
           },
         };
       },


### PR DESCRIPTION
## Background

When moving to policy-based alerts, the GraphQL structure changed and we introduced more "parent" objects to the alert's `events` key. Because of the fact that our GraphQL library isn't 100% strongly typed, we missed a modification that was affecting endless pagination on alert's events.

This PR fixes that

## Changes

- Fix issue where the paginated events were not being properly merged with the existing ones
- Enforce strong types on pagination params

## Testing

- `npm run test`
- Manually
