### PR TITLE
Upgrade web image to node14

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -21,12 +21,12 @@
 #
 # ****************     BUILD STAGE     *******************
 #
-FROM node:13.2-alpine AS build-env
+FROM node:14.15-alpine AS build-env
 
 LABEL description="The image that builds the web code and serves it through an express NodeJS server"
 
 # Update debian distro
-RUN apk update && apk add --no-cache --update nasm libtool alpine-sdk autoconf automake
+RUN apk update && apk add --no-cache --update nasm libtool alpine-sdk autoconf automake python
 
 # Move all of our logic
 RUN mkdir /code
@@ -49,7 +49,7 @@ RUN npm run build
 #
 # ****************     DEPLOYMENT & SERVE STAGE     *******************
 #
-FROM node:13.2-alpine
+FROM node:14.15-alpine
 
 # Default to exposing `8080`
 ENV SERVER_PORT=8080
@@ -79,4 +79,3 @@ CMD npm run serve
 
 # through the chosen port
 EXPOSE ${SERVER_PORT}
-


### PR DESCRIPTION
## Background

I've spent hours trying to publish the 1.14.3 release, and no matter what I try it always fails at the last step:

```
Step 17/19 : RUN npm install express express-static-gzip ejs chalk dotenv
 ---> Running in d8b2a87ddd07
npm ERR! code ECONNRESET
npm ERR! errno ECONNRESET
npm ERR! network request to https://registry.npmjs.org/escape-html failed, reason: socket hang up
npm ERR! network This is a problem related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-12-17T23_54_16_068Z-debug.log
```

I have the latest version of MacOS and Docker and have tried restarting both, no luck.

What *did* work was updating from node13 to node14 in the web image. We've already made this change in `master` (https://github.com/panther-labs/panther/pull/2258 ) and developers have been using it long enough that we can be confident the web app is still working with this change.

Besides unblocking me, the other big advantage of this change is that it fixes an SSL security vulnerability in the old image version. So it will be nice to give customers a patch release which also includes this security fix

## Changes

- Sync #2258 (specifically, the web Dockerfile) to the 1.14.3 release

## Testing

- `docker build --file deployments/Dockerfile .`
- Developers have been using this Dockerfile in `master` for awhile
- Will test 1.14.3 deployment after publication
