### PR TITLE
Change cloudsec history table names

### DIFF
--- a/internal/compliance/snapshotlogs/compliance.go
+++ b/internal/compliance/snapshotlogs/compliance.go
@@ -23,7 +23,7 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 )
 
-const TypeCompliance = "Snapshot.ComplianceHistory"
+const TypeCompliance = "Compliance.History"
 
 var logTypeCompliance = logtypes.MustBuild(logtypes.ConfigJSON{
 	Name:         TypeCompliance,

--- a/internal/compliance/snapshotlogs/resource.go
+++ b/internal/compliance/snapshotlogs/resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
 )
 
-const TypeResource = "Snapshot.ResourceHistory"
+const TypeResource = "Resource.History"
 
 var logTypeResource = logtypes.MustBuild(logtypes.ConfigJSON{
 	Name:         TypeResource,

--- a/internal/compliance/snapshotlogs/testdata/snapshot_tests.yml
+++ b/internal/compliance/snapshotlogs/testdata/snapshot_tests.yml
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 name: compliance_history
-logType: Snapshot.ComplianceHistory
+logType: Compliance.History
 input: |
   {
     "changeType":"MODIFIED",
@@ -41,7 +41,7 @@ result: |
     "resourceType":"AWS.IAM.User",
     "status":"FAIL",
     "suppressed":false,
-    "p_log_type": "Snapshot.ComplianceHistory",
+    "p_log_type": "Compliance.History",
     "p_event_time":"2020-10-23T21:10:30.814384032Z",
     "p_any_aws_arns": ["arn:aws:iam::123456789012:user/BobJoe"],
     "p_any_aws_account_ids": ["123456789012"]
@@ -49,7 +49,7 @@ result: |
 
 ---
 name: compliance_resource
-logType: Snapshot.ResourceHistory
+logType: Resource.History
 input: |
   {
       "changeType": "CREATED",
@@ -119,7 +119,7 @@ result: |
       "Stack":"panther-log-analysis",
       "PantherEdition":"Enterprise"
       },
-    "p_log_type": "Snapshot.ResourceHistory",
+    "p_log_type": "Resource.History",
     "p_event_time":"2020-10-15T06:29:00.498108265Z",
     "p_any_aws_arns": ["arn:aws:logs:us-west-1:123456789012:log-group:/aws/apigateway/welcome"],
     "p_any_aws_tags": [

--- a/internal/log_analysis/gluetables/gluetables.go
+++ b/internal/log_analysis/gluetables/gluetables.go
@@ -128,6 +128,7 @@ func ResolveTables(ctx context.Context, resolver logtypes.Resolver, logTypes ...
 func LogTypeTableMeta(entry logtypes.Entry) *awsglue.GlueTableMetadata {
 	desc := entry.Describe()
 	schema := entry.Schema()
+	databaseName := pantherdb.DatabaseName(pantherdb.GetDataType(desc.Name))
 	tableName := pantherdb.TableName(desc.Name)
-	return awsglue.NewGlueTableMetadata(pantherdb.LogProcessingDatabase, tableName, desc.Description, awsglue.GlueTableHourly, schema)
+	return awsglue.NewGlueTableMetadata(databaseName, tableName, desc.Description, awsglue.GlueTableHourly, schema)
 }

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -503,7 +503,7 @@ func TestSendDataToCloudSecurity(t *testing.T) {
 	uploadInput := destination.mockS3Uploader.Calls[0].Arguments.Get(0).(*s3manager.UploadInput)
 
 	assert.Equal(t, aws.String("testbucket"), uploadInput.Bucket)
-	expectedPrefix := "cloud_security/snapshot_compliancehistory/year=2020/month=01/day=01/hour=00/20200101T000000Z"
+	expectedPrefix := "cloud_security/compliance_history/year=2020/month=01/day=01/hour=00/20200101T000000Z"
 
 	assert.True(t, strings.HasPrefix(*uploadInput.Key, expectedPrefix))
 


### PR DESCRIPTION

## Changes

- Change cloudsec history table names to `panther_cloudsecurity.resouce_history` and `panther_cloudsecurity.compliance_history`
- Generalize function `LogTypeTableMeta()`

## Testing

- mage test:ci
- mage deploy + Athena queries
