### PR TITLE
Don't wrap error in internal error

### DIFF
--- a/internal/log_analysis/alerts_api/main/lambda.go
+++ b/internal/log_analysis/alerts_api/main/lambda.go
@@ -33,12 +33,7 @@ var router *genericapi.Router
 
 func lambdaHandler(ctx context.Context, input *models.LambdaInput) (interface{}, error) {
 	lambdalogger.ConfigureGlobal(ctx, nil)
-	event, err := router.Handle(input)
-	if err != nil {
-		// wrap for api, InternalError the only kind of error from this lambda
-		err = &genericapi.InternalError{Message: err.Error()}
-	}
-	return event, err
+	return router.Handle(input)
 }
 
 func main() {


### PR DESCRIPTION
## Background

It seems that the code was wrapping errors always in InternalError. This is not correct though: The error could be e.g. a input validation error

## Testing

- mage test:ci
