### PR TITLE
fix: axios issue from AWS Amplify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,19 @@
         "zen-observable": "^0.8.6"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+        },
         "graphql": {
           "version": "14.0.0",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.0.tgz",
@@ -3871,7 +3884,7 @@
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.0",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0"
       },
@@ -3920,7 +3933,10 @@
           "dev": true
         },
         "node-fetch": {
-          "version": "2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
         }
       }
     },
@@ -5507,14 +5523,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
       "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q=="
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -6286,6 +6294,15 @@
         "prettycli": "^1.4.3"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
         "cosmiconfig": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -6297,6 +6314,12 @@
             "js-yaml": "^3.13.1",
             "parse-json": "^4.0.0"
           }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+          "dev": true
         },
         "gzip-size": {
           "version": "4.1.0",
@@ -7450,12 +7473,15 @@
       "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.1",
+        "node-fetch": "2.6.0",
         "whatwg-fetch": "3.0.0"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
         }
       }
     },
@@ -7709,6 +7735,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -9486,11 +9513,13 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "0.7.23"
+        "ua-parser-js": "^0.7.18"
       },
       "dependencies": {
         "ua-parser-js": {
-          "version": "0.7.23"
+          "version": "0.7.23",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+          "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
         }
       }
     },
@@ -9837,6 +9866,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       }
@@ -10230,20 +10260,24 @@
       },
       "dependencies": {
         "axios": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
           "dev": true,
           "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
+            "follow-redirects": "^1.10.0"
           }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+          "dev": true
         },
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
     },
@@ -10379,17 +10413,22 @@
           "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
           "dev": true,
           "requires": {
-            "node-fetch": "2.6.1",
+            "node-fetch": "2.1.2",
             "whatwg-fetch": "2.0.4"
           },
           "dependencies": {
             "node-fetch": {
-              "version": "2.6.1"
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+              "dev": true
             }
           }
         },
         "node-fetch": {
-          "version": "2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "whatwg-fetch": {
           "version": "2.0.4",
@@ -10415,13 +10454,16 @@
         "deprecated-decorator": "^0.1.6",
         "form-data": "^3.0.0",
         "iterall": "^1.3.0",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.0",
         "tslib": "^1.11.1",
         "uuid": "^7.0.3"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
         },
         "uuid": {
           "version": "7.0.3",
@@ -11730,12 +11772,14 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "2.6.1",
+        "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -18566,11 +18610,14 @@
             "object-assign": "^4.1.0",
             "promise": "^7.1.1",
             "setimmediate": "^1.0.5",
-            "ua-parser-js": "0.7.23"
+            "ua-parser-js": "^0.7.18"
           },
           "dependencies": {
             "ua-parser-js": {
-              "version": "0.7.23"
+              "version": "0.7.23",
+              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+              "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+              "dev": true
             }
           }
         },
@@ -18809,11 +18856,14 @@
             "object-assign": "^4.1.0",
             "promise": "^7.1.1",
             "setimmediate": "^1.0.5",
-            "ua-parser-js": "0.7.23"
+            "ua-parser-js": "^0.7.18"
           },
           "dependencies": {
             "ua-parser-js": {
-              "version": "0.7.23"
+              "version": "0.7.23",
+              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+              "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+              "dev": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
   },
   "resolutions": {
     "node-fetch": "2.6.1",
-    "ua-parser-js": "0.7.23"
+    "ua-parser-js": "0.7.23",
+    "axios": "^0.21.1"
   },
   "scripts": {
     "preinstall": "npx npm-force-resolutions",


### PR DESCRIPTION
## Background

We use Amplify for its `Auth` package. Amplify internally uses  `axios`  which recently had a reported vulnerability. Amplify has since fixed the package, but no release has yet been cut. Even if it did,  we'd require a backport, since we are using `v2.x.x.` while Amplify is on `v3.x.x`.

Until all that happens, we manually forced Amplify to  use `v0.21.1` of axios instead of the current `v0.19.0`. Went through  axios' [changelog](https://github.com/axios/axios/blob/hotfix/0.21.1/CHANGELOG.md) and didn't see any breaking changes.

This will fix our `npm audit` issue for now and we'll upgrade to Amplify's patch version as soon as it becomes available

## Changes

- Force all axios resolutions to latest `v0.21.1`

## Testing

- `npm audit`
