### PR TITLE
Update max lambda size to 10240

### DIFF
--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -568,8 +568,10 @@ Resources:
                 - s3:GetObject
                 - s3:GetObjectVersion
               Resource:
+                - !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/cloud_security/*
                 - !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/logs/*
                 - !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/rules/*
+                - !Sub arn:${AWS::Partition}:s3:::${ProcessedData}/rule_errors/*
             - !Ref AWS::NoValue
 
   AthenaResults: # athena query results

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -60,7 +60,7 @@ Parameters:
     Type: Number
     Description: Log processor Lambda memory allocation
     MinValue: 256 # 128 is too small, risks OOM errors
-    MaxValue: 3008
+    MaxValue: 10240
   LogProcessorLambdaSQSReadBatchSize:
     Type: Number
     Description: How many SQS messsage the log processor reads per SQS read. If the log processor is timing out, reduce this number.

--- a/internal/core/custom_resources/resources/alarms_lambda.go
+++ b/internal/core/custom_resources/resources/alarms_lambda.go
@@ -40,7 +40,7 @@ const (
 type LambdaAlarmProperties struct {
 	AlarmTopicArn      string `validate:"required"`
 	FunctionName       string `validate:"required"`
-	FunctionMemoryMB   int    `json:",string" validate:"min=128,max=3008"`
+	FunctionMemoryMB   int    `json:",string" validate:"min=128,max=10240"`
 	FunctionTimeoutSec int    `json:",string" validate:"min=1"`
 
 	// These are pointers because we have to distinguish 0 from not specified

--- a/internal/core/custom_resources/resources/alarms_lambda.go
+++ b/internal/core/custom_resources/resources/alarms_lambda.go
@@ -40,7 +40,7 @@ const (
 type LambdaAlarmProperties struct {
 	AlarmTopicArn      string `validate:"required"`
 	FunctionName       string `validate:"required"`
-	FunctionMemoryMB   int    `json:",string" validate:"min=128,max=10240"`
+	FunctionMemoryMB   int    `json:",string" validate:"min=128"`
 	FunctionTimeoutSec int    `json:",string" validate:"min=1"`
 
 	// These are pointers because we have to distinguish 0 from not specified


### PR DESCRIPTION
## Background

The max size (I thought) I fixed earlier but it seems to have been put back to 3008. Lambda now allows 10240. Master stack has this correct.

## Changes

- Change max in log process CF and in the alarm generation code.

## Testing

- mage test:ci
- benchmarks using large lambdas
