### PR TITLE
Change name of destination functions

### DIFF
--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -353,7 +353,7 @@ class Rule:
         return description
 
     def _get_destinations(self, event: Mapping, use_default_on_exception: bool = True) -> Optional[List[str]]:
-        if not hasattr(self._module, 'destination'):
+        if not hasattr(self._module, 'destinations'):
             return None
 
         try:

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -353,15 +353,15 @@ class Rule:
         return description
 
     def _get_destinations(self, event: Mapping, use_default_on_exception: bool = True) -> Optional[List[str]]:
-        if not hasattr(self._module, 'destination_override'):
+        if not hasattr(self._module, 'destination'):
             return None
 
         try:
-            command = getattr(self._module, 'destination_override')
+            command = getattr(self._module, 'destinations')
             destinations = self._run_command(command, event, list())
         except Exception as err:  # pylint: disable=broad-except
             if use_default_on_exception:
-                self.logger.warning('_get_destinations method raised exception. Exception: %s', err)
+                self.logger.warning('destinations method raised exception. Exception: %s', err)
                 return []
             raise
 

--- a/internal/log_analysis/rules_engine/tests/test_main.py
+++ b/internal/log_analysis/rules_engine/tests/test_main.py
@@ -105,7 +105,7 @@ class TestMainDirectAnalysis(TestCase):
                     'def reference(event):\n\treturn "generated reference"\n' \
                     'def severity(event):\n\treturn "HIGH"\n' \
                     'def runbook(event):\n\treturn "generated runbook"\n' \
-                    'def destination_override(event):\n\treturn ["destination1", "destination2"]'
+                    'def destinations(event):\n\treturn ["destination1", "destination2"]'
         payload = {'rules': [{'id': 'rule_id', 'body': rule_body}], 'events': [{'id': 'event_id', 'data': 'data'}]}
         expected_response: dict = {
             'results':
@@ -526,7 +526,7 @@ class TestMainDirectAnalysis(TestCase):
                         'id': 'rule_id',
                         'body':
                             "def rule(event):\n\treturn True\n" +
-                            "def destination_override(event):\n\traise Exception('destinations error')"
+                            "def destinations(event):\n\traise Exception('destinations error')"
                     }
                 ],
             'events': [{

--- a/internal/log_analysis/rules_engine/tests/test_main.py
+++ b/internal/log_analysis/rules_engine/tests/test_main.py
@@ -524,9 +524,7 @@ class TestMainDirectAnalysis(TestCase):
                 [
                     {
                         'id': 'rule_id',
-                        'body':
-                            "def rule(event):\n\treturn True\n" +
-                            "def destinations(event):\n\traise Exception('destinations error')"
+                        'body': "def rule(event):\n\treturn True\n" + "def destinations(event):\n\traise Exception('destinations error')"
                     }
                 ],
             'events': [{

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -288,7 +288,7 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
                     'def severity(event):\n\treturn "HIGH"\n' \
                     'def reference(event):\n\treturn "test reference"\n' \
                     'def runbook(event):\n\treturn "test runbook"\n' \
-                    'def destination_override(event):\n\treturn []'
+                    'def destinations(event):\n\treturn []'
         rule = Rule({'id': 'test_rule_with_all_generated_fields', 'body': rule_body, 'versionId': 'versionId'})
 
         expected_result = RuleResult(


### PR DESCRIPTION
## Background

Changing name from `destination_overrides` to `destinations` according to this discussion: https://github.com/panther-labs/panther/pull/2165#discussion_r534324500

It seems that this feature was not released officially in 1.14, so we get some time to fix names like this

## Changes

- Updated name of method

## Testing

- mage test:python
