### PR TITLE
Removed s3Prefix from S3LogSourceCard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,19 +54,14 @@
         "@aws-amplify/auth": "^2.1.8",
         "@aws-amplify/cache": "^2.1.8",
         "@aws-amplify/core": "^2.3.0",
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable": "^0.8.6"
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
+          "version": "^0.21.1"
         },
         "follow-redirects": {
           "version": "1.13.1",
@@ -3884,7 +3879,7 @@
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "2.6.1",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0"
       },
@@ -3933,10 +3928,7 @@
           "dev": true
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
+          "version": "2.6.1"
         }
       }
     },
@@ -6282,7 +6274,7 @@
       "integrity": "sha512-GZURr25umfYxZYZUyOlOtJRbYjAn0VfbjbnS0NBcOiF8VcjmhoEhmx8Gw4va8HeQb8j7Ra0ZltY/IeHgSHFXFw==",
       "dev": true,
       "requires": {
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "brotli-size": "0.1.0",
         "bytes": "^3.1.0",
         "ci-env": "^1.4.0",
@@ -6295,13 +6287,7 @@
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
+          "version": "^0.21.1"
         },
         "cosmiconfig": {
           "version": "5.2.1",
@@ -7473,15 +7459,12 @@
       "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.0",
+        "node-fetch": "2.6.1",
         "whatwg-fetch": "3.0.0"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
+          "version": "2.6.1"
         }
       }
     },
@@ -9513,13 +9496,11 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "ua-parser-js": "0.7.23"
       },
       "dependencies": {
         "ua-parser-js": {
-          "version": "0.7.23",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-          "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+          "version": "0.7.23"
         }
       }
     },
@@ -10256,17 +10237,11 @@
       "integrity": "sha512-VAT4NFU8hm9Ks5yNKuuczD2zMbmouAKHtxtwvmCj34Q2DpZsjgp3LLjtrKlm/YvGSzSNGmj22ccJQQei+f/vIw==",
       "dev": true,
       "requires": {
-        "axios": "0.19.0"
+        "axios": "^0.21.1"
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
+          "version": "^0.21.1"
         },
         "follow-redirects": {
           "version": "1.13.1",
@@ -10413,22 +10388,17 @@
           "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
           "dev": true,
           "requires": {
-            "node-fetch": "2.1.2",
+            "node-fetch": "2.6.1",
             "whatwg-fetch": "2.0.4"
           },
           "dependencies": {
             "node-fetch": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-              "dev": true
+              "version": "2.6.1"
             }
           }
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.1"
         },
         "whatwg-fetch": {
           "version": "2.0.4",
@@ -10454,16 +10424,13 @@
         "deprecated-decorator": "^0.1.6",
         "form-data": "^3.0.0",
         "iterall": "^1.3.0",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "2.6.1",
         "tslib": "^1.11.1",
         "uuid": "^7.0.3"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
+          "version": "2.6.1"
         },
         "uuid": {
           "version": "7.0.3",
@@ -11772,14 +11739,12 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
+        "node-fetch": "2.6.1",
         "whatwg-fetch": ">=0.10.0"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.1"
         }
       }
     },
@@ -18610,14 +18575,11 @@
             "object-assign": "^4.1.0",
             "promise": "^7.1.1",
             "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
+            "ua-parser-js": "0.7.23"
           },
           "dependencies": {
             "ua-parser-js": {
-              "version": "0.7.23",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-              "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
-              "dev": true
+              "version": "0.7.23"
             }
           }
         },
@@ -18856,14 +18818,11 @@
             "object-assign": "^4.1.0",
             "promise": "^7.1.1",
             "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
+            "ua-parser-js": "0.7.23"
           },
           "dependencies": {
             "ua-parser-js": {
-              "version": "0.7.23",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-              "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
-              "dev": true
+              "version": "0.7.23"
             }
           }
         }

--- a/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.test.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.test.tsx
@@ -30,7 +30,6 @@ describe('S3LogSourceCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(source.integrationLabel)).toBeInTheDocument();
-    expect(getByText(source.s3Prefix)).toBeInTheDocument();
     expect(getByText(source.s3Bucket)).toBeInTheDocument();
     expect(getByText(source.kmsKey)).toBeInTheDocument();
     expect(getByText(formatDatetime(source.createdAtTime, true))).toBeInTheDocument();

--- a/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.tsx
@@ -38,7 +38,6 @@ const S3LogSourceCard: React.FC<S3LogSourceCardProps> = ({ source }) => {
     <LogSourceCard logo={s3Logo} source={source}>
       <GenericItemCard.Value label="AWS Account ID" value={source.awsAccountId} />
       <GenericItemCard.Value label="S3 Bucket" value={source.s3Bucket} />
-      <GenericItemCard.Value label="S3 Prefix" value={source.s3Prefix} />
       <GenericItemCard.Value label="KMS Key" value={source.kmsKey} />
       <GenericItemCard.LineBreak />
       <GenericItemCard.Value


### PR DESCRIPTION
## Background

There was a remnant from S3 refactor in `S3LogSourceCard` related to S3Prefixes. 

We decide to remove the display of the S3 prefix from that card for the moment.

Closes #2323

## Changes

- Remove S3 prefix field from `S3LogSourceCard`
- Update test
- Update package-lock.json

## Testing

- Locally
