### PR TITLE
Happy New Year

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/.github/workflows/docker-analysis.yml
+++ b/.github/workflows/docker-analysis.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/api/lambda/alerts/models/api.go
+++ b/api/lambda/alerts/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/configmodels.go
+++ b/api/lambda/analysis/configmodels.go
@@ -2,7 +2,7 @@ package analysis
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/engine.go
+++ b/api/lambda/analysis/engine.go
@@ -2,7 +2,7 @@ package analysis
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/models/api.go
+++ b/api/lambda/analysis/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/models/data_models.go
+++ b/api/lambda/analysis/models/data_models.go
@@ -4,7 +4,7 @@ import "time"
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/models/globals.go
+++ b/api/lambda/analysis/models/globals.go
@@ -4,7 +4,7 @@ import "time"
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/models/policies.go
+++ b/api/lambda/analysis/models/policies.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/analysis/models/rules.go
+++ b/api/lambda/analysis/models/rules.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/compliance/models/api.go
+++ b/api/lambda/compliance/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/delivery/models/api.go
+++ b/api/lambda/delivery/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/logtypes/models_gen.go
+++ b/api/lambda/logtypes/models_gen.go
@@ -6,7 +6,7 @@ import "time"
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/metrics/models/api.go
+++ b/api/lambda/metrics/models/api.go
@@ -4,7 +4,7 @@ import "time"
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/organization/models/api.go
+++ b/api/lambda/organization/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/outputs/models/api.go
+++ b/api/lambda/outputs/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/remediation/models/api.go
+++ b/api/lambda/remediation/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/resources/models/api.go
+++ b/api/lambda/resources/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/source/models/integration_test.go
+++ b/api/lambda/source/models/integration_test.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/source/models/validator.go
+++ b/api/lambda/source/models/validator.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/source/models/validator_test.go
+++ b/api/lambda/source/models/validator_test.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/source/models/vars.go
+++ b/api/lambda/source/models/vars.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/users/models/api.go
+++ b/api/lambda/users/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/users/models/validator.go
+++ b/api/lambda/users/models/validator.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/api/lambda/users/models/validator_test.go
+++ b/api/lambda/users/models/validator_test.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/build/actions/pr_sync/action.yml
+++ b/build/actions/pr_sync/action.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/build/actions/pr_sync/dist/index.js
+++ b/build/actions/pr_sync/dist/index.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -163,7 +163,7 @@ module.exports = /******/ (function (modules, runtime) {
     /***/ 104: /***/ function (__unusedmodule, __unusedexports, __webpack_require__) {
       /**
        * Panther is a Cloud-Native SIEM for the Modern Security Team.
-       * Copyright (C) 2020 Panther Labs Inc
+       * Copyright (C) 2021 Panther Labs Inc
        *
        * This program is free software: you can redistribute it and/or modify
        * it under the terms of the GNU Affero General Public License as

--- a/build/actions/pr_sync/index.js
+++ b/build/actions/pr_sync/index.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/build/images/ci/Dockerfile
+++ b/build/images/ci/Dockerfile
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/build/images/deployment/Dockerfile
+++ b/build/images/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/customlogs/customlogs/infer.go
+++ b/cmd/devtools/customlogs/customlogs/infer.go
@@ -2,7 +2,7 @@ package customlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/customlogs/customlogs/infer_test.go
+++ b/cmd/devtools/customlogs/customlogs/infer_test.go
@@ -2,7 +2,7 @@ package customlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/customlogs/customlogs/test.go
+++ b/cmd/devtools/customlogs/customlogs/test.go
@@ -2,7 +2,7 @@ package customlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/customlogs/customlogs/testdata/schema_1.yml
+++ b/cmd/devtools/customlogs/customlogs/testdata/schema_1.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/customlogs/main.go
+++ b/cmd/devtools/customlogs/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/logprocessor/logprocessor/main.go
+++ b/cmd/devtools/logprocessor/logprocessor/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/devtools/pantherlog/pantherlog/main.go
+++ b/cmd/devtools/pantherlog/pantherlog/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/cost/cost/main.go
+++ b/cmd/opstools/cost/cost/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/gluerecover/gluerecover/main.go
+++ b/cmd/opstools/gluerecover/gluerecover/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/gluesync/gluesync/main.go
+++ b/cmd/opstools/gluesync/gluesync/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/opstools.go
+++ b/cmd/opstools/opstools.go
@@ -2,7 +2,7 @@ package opstools
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/requeue/integration_test.go
+++ b/cmd/opstools/requeue/integration_test.go
@@ -2,7 +2,7 @@ package requeue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/requeue/requeue.go
+++ b/cmd/opstools/requeue/requeue.go
@@ -2,7 +2,7 @@ package requeue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/requeue/requeue/main.go
+++ b/cmd/opstools/requeue/requeue/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3list/s3list.go
+++ b/cmd/opstools/s3list/s3list.go
@@ -2,7 +2,7 @@ package s3list
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3queue/integration_test.go
+++ b/cmd/opstools/s3queue/integration_test.go
@@ -2,7 +2,7 @@ package s3queue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3queue/s3queue.go
+++ b/cmd/opstools/s3queue/s3queue.go
@@ -2,7 +2,7 @@ package s3queue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3queue/s3queue/main.go
+++ b/cmd/opstools/s3queue/s3queue/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3queue/s3queue_test.go
+++ b/cmd/opstools/s3queue/s3queue_test.go
@@ -2,7 +2,7 @@ package s3queue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3sns/integration_test.go
+++ b/cmd/opstools/s3sns/integration_test.go
@@ -2,7 +2,7 @@ package s3sns
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3sns/s3sns.go
+++ b/cmd/opstools/s3sns/s3sns.go
@@ -2,7 +2,7 @@ package s3sns
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3sns/s3sns/main.go
+++ b/cmd/opstools/s3sns/s3sns/main.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/s3sns/s3sns_test.go
+++ b/cmd/opstools/s3sns/s3sns_test.go
@@ -2,7 +2,7 @@ package s3sns
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/cmd/opstools/testutils/testutils.go
+++ b/cmd/opstools/testutils/testutils.go
@@ -2,7 +2,7 @@ package testutils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/osquery-firehose.yml
+++ b/deployments/auxiliary/cloudformation/osquery-firehose.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/panther-cloudsec-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudsec-iam.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
+++ b/deployments/auxiliary/cloudformation/panther-cloudwatch-events.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/panther-deployment-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-deployment-role.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/panther-log-analysis-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-analysis-iam.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-processing-notifications.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/osquery_firehose/main.tf
+++ b/deployments/auxiliary/terraform/osquery_firehose/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/osquery_firehose/variables.tf
+++ b/deployments/auxiliary/terraform/osquery_firehose/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_cloudsec_iam/main.tf
+++ b/deployments/auxiliary/terraform/panther_cloudsec_iam/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_cloudsec_iam/outputs.tf
+++ b/deployments/auxiliary/terraform/panther_cloudsec_iam/outputs.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_cloudsec_iam/variables.tf
+++ b/deployments/auxiliary/terraform/panther_cloudsec_iam/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_cloudwatch_events/main.tf
+++ b/deployments/auxiliary/terraform/panther_cloudwatch_events/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_cloudwatch_events/panther_sns_topic_subscription.tf
+++ b/deployments/auxiliary/terraform/panther_cloudwatch_events/panther_sns_topic_subscription.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_cloudwatch_events/variables.tf
+++ b/deployments/auxiliary/terraform/panther_cloudwatch_events/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_deployment_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_deployment_role/variables.tf
+++ b/deployments/auxiliary/terraform/panther_deployment_role/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_log_analysis_iam/main.tf
+++ b/deployments/auxiliary/terraform/panther_log_analysis_iam/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_log_analysis_iam/variables.tf
+++ b/deployments/auxiliary/terraform/panther_log_analysis_iam/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_log_processing_notifications/main.tf
+++ b/deployments/auxiliary/terraform/panther_log_processing_notifications/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_log_processing_notifications/outputs.tf
+++ b/deployments/auxiliary/terraform/panther_log_processing_notifications/outputs.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_log_processing_notifications/panther_sns_topic_subscription.tf
+++ b/deployments/auxiliary/terraform/panther_log_processing_notifications/panther_sns_topic_subscription.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_log_processing_notifications/variables.tf
+++ b/deployments/auxiliary/terraform/panther_log_processing_notifications/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_stackset_iam_admin_role/main.tf
+++ b/deployments/auxiliary/terraform/panther_stackset_iam_admin_role/main.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_stackset_iam_admin_role/outputs.tf
+++ b/deployments/auxiliary/terraform/panther_stackset_iam_admin_role/outputs.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/auxiliary/terraform/panther_stackset_iam_admin_role/variables.tf
+++ b/deployments/auxiliary/terraform/panther_stackset_iam_admin_role/variables.tf
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/bootstrap.yml
+++ b/deployments/bootstrap.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -646,7 +646,7 @@ Resources:
               <br />Yours truly,
               <br />Panther - https://runpanther.io
               <br />
-              <br /><small>Copyright © 2020 Panther Labs Inc. All rights reserved.</small>
+              <br /><small>Copyright © 2021 Panther Labs Inc. All rights reserved.</small>
             - PantherHost:
                 !If [UseCustomDomain, !Ref CustomDomain, !GetAtt PublicLoadBalancer.DNSName]
       AutoVerifiedAttributes:

--- a/deployments/bootstrap_gateway.yml
+++ b/deployments/bootstrap_gateway.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/dashboards.yml
+++ b/deployments/dashboards.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/master.yml
+++ b/deployments/master.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/onboard.yml
+++ b/deployments/onboard.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/panther_config.yml
+++ b/deployments/panther_config.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/deployments/web_server.yml
+++ b/deployments/web_server.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/docs/LICENSE_HEADER_AGPL.txt
+++ b/docs/LICENSE_HEADER_AGPL.txt
@@ -1,5 +1,5 @@
 Panther is a Cloud-Native SIEM for the Modern Security Team.
-Copyright (C) 2020 Panther Labs Inc
+Copyright (C) 2021 Panther Labs Inc
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_forwarder/forwarder/forwarder.go
+++ b/internal/compliance/alert_forwarder/forwarder/forwarder.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/compliance/alert_forwarder/forwarder/forwarder_test.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_forwarder/forwarder/metrics.go
+++ b/internal/compliance/alert_forwarder/forwarder/metrics.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_forwarder/main/config.go
+++ b/internal/compliance/alert_forwarder/main/config.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_forwarder/main/lambda.go
+++ b/internal/compliance/alert_forwarder/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_processor/main/lambda.go
+++ b/internal/compliance/alert_processor/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_processor/models/api.go
+++ b/internal/compliance/alert_processor/models/api.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_processor/processor/processor.go
+++ b/internal/compliance/alert_processor/processor/processor.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/alert_processor/processor/processor_test.go
+++ b/internal/compliance/alert_processor/processor/processor_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/main/lambda.go
+++ b/internal/compliance/aws_event_processor/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/accounts.go
+++ b/internal/compliance/aws_event_processor/processor/accounts.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/accounts_test.go
+++ b/internal/compliance/aws_event_processor/processor/accounts_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/acm.go
+++ b/internal/compliance/aws_event_processor/processor/acm.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/clients.go
+++ b/internal/compliance/aws_event_processor/processor/clients.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/cloudformation.go
+++ b/internal/compliance/aws_event_processor/processor/cloudformation.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/cloudtrail.go
+++ b/internal/compliance/aws_event_processor/processor/cloudtrail.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/cloudwatch_log_group.go
+++ b/internal/compliance/aws_event_processor/processor/cloudwatch_log_group.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/config.go
+++ b/internal/compliance/aws_event_processor/processor/config.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/dynamodb.go
+++ b/internal/compliance/aws_event_processor/processor/dynamodb.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/ec2.go
+++ b/internal/compliance/aws_event_processor/processor/ec2.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/ecs.go
+++ b/internal/compliance/aws_event_processor/processor/ecs.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/elbv2.go
+++ b/internal/compliance/aws_event_processor/processor/elbv2.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/guardduty.go
+++ b/internal/compliance/aws_event_processor/processor/guardduty.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/handler.go
+++ b/internal/compliance/aws_event_processor/processor/handler.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/handler_test.go
+++ b/internal/compliance/aws_event_processor/processor/handler_test.go
@@ -3,7 +3,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/iam.go
+++ b/internal/compliance/aws_event_processor/processor/iam.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/kms.go
+++ b/internal/compliance/aws_event_processor/processor/kms.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/lambda.go
+++ b/internal/compliance/aws_event_processor/processor/lambda.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/lambda_test.go
+++ b/internal/compliance/aws_event_processor/processor/lambda_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/mocks_test.go
+++ b/internal/compliance/aws_event_processor/processor/mocks_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/process.go
+++ b/internal/compliance/aws_event_processor/processor/process.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/process_test.go
+++ b/internal/compliance/aws_event_processor/processor/process_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/rds.go
+++ b/internal/compliance/aws_event_processor/processor/rds.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/redshift.go
+++ b/internal/compliance/aws_event_processor/processor/redshift.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/s3.go
+++ b/internal/compliance/aws_event_processor/processor/s3.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/sns_confirmation.go
+++ b/internal/compliance/aws_event_processor/processor/sns_confirmation.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/sns_confirmation_test.go
+++ b/internal/compliance/aws_event_processor/processor/sns_confirmation_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/waf-regional.go
+++ b/internal/compliance/aws_event_processor/processor/waf-regional.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/aws_event_processor/processor/waf.go
+++ b/internal/compliance/aws_event_processor/processor/waf.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/awsglue/awsglue.go
+++ b/internal/compliance/awsglue/awsglue.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/delete_status.go
+++ b/internal/compliance/compliance_api/handlers/delete_status.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/describe_org.go
+++ b/internal/compliance/compliance_api/handlers/describe_org.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/describe_policy.go
+++ b/internal/compliance/compliance_api/handlers/describe_policy.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/describe_resource.go
+++ b/internal/compliance/compliance_api/handlers/describe_resource.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/dynamo.go
+++ b/internal/compliance/compliance_api/handlers/dynamo.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/env.go
+++ b/internal/compliance/compliance_api/handlers/env.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/get_org_overview.go
+++ b/internal/compliance/compliance_api/handlers/get_org_overview.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/get_status.go
+++ b/internal/compliance/compliance_api/handlers/get_status.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/paging.go
+++ b/internal/compliance/compliance_api/handlers/paging.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/set_status.go
+++ b/internal/compliance/compliance_api/handlers/set_status.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/update_metadata.go
+++ b/internal/compliance/compliance_api/handlers/update_metadata.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/handlers/util.go
+++ b/internal/compliance/compliance_api/handlers/util.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/main/integration_test.go
+++ b/internal/compliance/compliance_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/main/lambda.go
+++ b/internal/compliance/compliance_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/compliance_api/main/lambda_test.go
+++ b/internal/compliance/compliance_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/compliance.go
+++ b/internal/compliance/datalake_forwarder/forwarder/compliance.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/diff/comparisons.go
+++ b/internal/compliance/datalake_forwarder/forwarder/diff/comparisons.go
@@ -2,7 +2,7 @@ package diff
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/diff/comparisons_test.go
+++ b/internal/compliance/datalake_forwarder/forwarder/diff/comparisons_test.go
@@ -2,7 +2,7 @@ package diff
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/events/events.go
+++ b/internal/compliance/datalake_forwarder/forwarder/events/events.go
@@ -2,7 +2,7 @@ package events
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/forward.go
+++ b/internal/compliance/datalake_forwarder/forwarder/forward.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/forward_test.go
+++ b/internal/compliance/datalake_forwarder/forwarder/forward_test.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/resources.go
+++ b/internal/compliance/datalake_forwarder/forwarder/resources.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/source_api.go
+++ b/internal/compliance/datalake_forwarder/forwarder/source_api.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/forwarder/source_api_test.go
+++ b/internal/compliance/datalake_forwarder/forwarder/source_api_test.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/datalake_forwarder/main/handler.go
+++ b/internal/compliance/datalake_forwarder/main/handler.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/__init__.py
+++ b/internal/compliance/policy_engine/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/src/__init__.py
+++ b/internal/compliance/policy_engine/src/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/src/engine.py
+++ b/internal/compliance/policy_engine/src/engine.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/src/main.py
+++ b/internal/compliance/policy_engine/src/main.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/src/policy.py
+++ b/internal/compliance/policy_engine/src/policy.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/tests/__init__.py
+++ b/internal/compliance/policy_engine/tests/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/tests/integration.py
+++ b/internal/compliance/policy_engine/tests/integration.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/tests/test_engine.py
+++ b/internal/compliance/policy_engine/tests/test_engine.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/tests/test_main.py
+++ b/internal/compliance/policy_engine/tests/test_main.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/policy_engine/tests/test_policy.py
+++ b/internal/compliance/policy_engine/tests/test_policy.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/handlers/apihandlers.go
+++ b/internal/compliance/remediation_api/handlers/apihandlers.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/handlers/apihandlers_test.go
+++ b/internal/compliance/remediation_api/handlers/apihandlers_test.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/handlers/get.go
+++ b/internal/compliance/remediation_api/handlers/get.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/handlers/get_test.go
+++ b/internal/compliance/remediation_api/handlers/get_test.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/handlers/post.go
+++ b/internal/compliance/remediation_api/handlers/post.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/handlers/post_test.go
+++ b/internal/compliance/remediation_api/handlers/post_test.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/main/lambda.go
+++ b/internal/compliance/remediation_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/main/lambda_test.go
+++ b/internal/compliance/remediation_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/remediation/invoke.go
+++ b/internal/compliance/remediation_api/remediation/invoke.go
@@ -2,7 +2,7 @@ package remediation
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/remediation/invoke_test.go
+++ b/internal/compliance/remediation_api/remediation/invoke_test.go
@@ -2,7 +2,7 @@ package remediation
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_api/remediation/remediation.go
+++ b/internal/compliance/remediation_api/remediation/remediation.go
@@ -2,7 +2,7 @@ package remediation
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/__init__.py
+++ b/internal/compliance/remediation_aws/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/__init__.py
+++ b/internal/compliance/remediation_aws/src/app/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/common/__init__.py
+++ b/internal/compliance/remediation_aws/src/app/common/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/common/exceptions.py
+++ b/internal/compliance/remediation_aws/src/app/common/exceptions.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/common/logging.py
+++ b/internal/compliance/remediation_aws/src/app/common/logging.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/main.py
+++ b/internal/compliance/remediation_aws/src/app/main.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/__init__.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_cloudtrail_create_trail.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_cloudtrail_create_trail.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_cloudtrail_enable_log_validation.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_cloudtrail_enable_log_validation.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_ddb_encrypt_table.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_ddb_encrypt_table.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_enable_vpc_flow_logs_to_s3.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_enable_vpc_flow_logs_to_s3.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_set_ami_private.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_set_ami_private.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_stop_instance.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_stop_instance.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_terminate_instance.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_ec2_terminate_instance.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_guardduty_create_detector.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_guardduty_create_detector.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_iam_delete_inactive_user_keys.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_iam_delete_inactive_user_keys.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_iam_update_account_password_policy.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_iam_update_account_password_policy.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_kms_enable_key_rotation.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_kms_enable_key_rotation.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_rds_disable_instance_public_access.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_rds_disable_instance_public_access.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_rds_disable_snapshot_public_access.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_rds_disable_snapshot_public_access.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_rds_enable_auto_minor_version_upgrade.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_rds_enable_auto_minor_version_upgrade.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_s3_block_bucket_public_access.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_s3_block_bucket_public_access.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_s3_block_bucket_public_acl.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_s3_block_bucket_public_acl.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_s3_enable_bucket_encryption.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_s3_enable_bucket_encryption.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_s3_enable_bucket_logging.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_s3_enable_bucket_logging.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/aws_s3_enable_bucket_versioning.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/aws_s3_enable_bucket_versioning.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/remediation.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/remediation.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
+++ b/internal/compliance/remediation_aws/src/app/remediations/remediation_base.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/__init__.py
+++ b/internal/compliance/remediation_aws/tests/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/__init__.py
+++ b/internal/compliance/remediation_aws/tests/remediations/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_cloudtrail_create_trail.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_cloudtrail_create_trail.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_cloudtrail_enable_log_validation.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_cloudtrail_enable_log_validation.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_ddb_encrypt_table.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_ddb_encrypt_table.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_ec2_enable_vpc_flow_logs_to_s3.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_ec2_enable_vpc_flow_logs_to_s3.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_ec2_stop_instance.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_ec2_stop_instance.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_ec2_terminate_instance.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_ec2_terminate_instance.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_guardduty_create_detector.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_guardduty_create_detector.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_iam_update_account_password_policy.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_iam_update_account_password_policy.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_kms_enable_key_rotation.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_kms_enable_key_rotation.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_rds_disable_instance_public_access.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_rds_disable_instance_public_access.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_rds_disable_snapshot_public_access.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_rds_disable_snapshot_public_access.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_rds_enable_auto_minor_version_upgrade.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_rds_enable_auto_minor_version_upgrade.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_block_bucket_public_access.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_block_bucket_public_access.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_block_bucket_public_acl.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_block_bucket_public_acl.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_enable_bucket_encryption.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_enable_bucket_encryption.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_enable_bucket_logging.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_enable_bucket_logging.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_enable_bucket_versioning.py
+++ b/internal/compliance/remediation_aws/tests/remediations/test_aws_s3_enable_bucket_versioning.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/remediation_processor/main/lambda.go
+++ b/internal/compliance/remediation_processor/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/main/lambda.go
+++ b/internal/compliance/resource_processor/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/models/lookup.go
+++ b/internal/compliance/resource_processor/models/lookup.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/processor/analysis_api.go
+++ b/internal/compliance/resource_processor/processor/analysis_api.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/processor/clients.go
+++ b/internal/compliance/resource_processor/processor/clients.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/processor/handler.go
+++ b/internal/compliance/resource_processor/processor/handler.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/processor/handler_test.go
+++ b/internal/compliance/resource_processor/processor/handler_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resource_processor/processor/resources_api.go
+++ b/internal/compliance/resource_processor/processor/resources_api.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/add_resources.go
+++ b/internal/compliance/resources_api/handlers/add_resources.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/clients.go
+++ b/internal/compliance/resources_api/handlers/clients.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/compliance.go
+++ b/internal/compliance/resources_api/handlers/compliance.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/delete_resources.go
+++ b/internal/compliance/resources_api/handlers/delete_resources.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/dynamo.go
+++ b/internal/compliance/resources_api/handlers/dynamo.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/get_resource.go
+++ b/internal/compliance/resources_api/handlers/get_resource.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/handlers/list_resources.go
+++ b/internal/compliance/resources_api/handlers/list_resources.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/main/integration_test.go
+++ b/internal/compliance/resources_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/main/lambda.go
+++ b/internal/compliance/resources_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/resources_api/main/lambda_test.go
+++ b/internal/compliance/resources_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/main/handler.go
+++ b/internal/compliance/snapshot_poller/main/handler.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/acm_certificate.go
+++ b/internal/compliance/snapshot_poller/models/aws/acm_certificate.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/cloudformation_stack.go
+++ b/internal/compliance/snapshot_poller/models/aws/cloudformation_stack.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/cloudtrail.go
+++ b/internal/compliance/snapshot_poller/models/aws/cloudtrail.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/cloudwatchlogs_log_group.go
+++ b/internal/compliance/snapshot_poller/models/aws/cloudwatchlogs_log_group.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/configservice.go
+++ b/internal/compliance/snapshot_poller/models/aws/configservice.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/dynamodb_table.go
+++ b/internal/compliance/snapshot_poller/models/aws/dynamodb_table.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ec2_ami.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_ami.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ec2_instance.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_instance.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ec2_network_acl.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_network_acl.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ec2_security_group.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_security_group.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ec2_volume.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_volume.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ec2_vpc.go
+++ b/internal/compliance/snapshot_poller/models/aws/ec2_vpc.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/models/aws/ecs_cluster.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/eks_cluster.go
+++ b/internal/compliance/snapshot_poller/models/aws/eks_cluster.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/elbv2_application_load_balancer.go
+++ b/internal/compliance/snapshot_poller/models/aws/elbv2_application_load_balancer.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/guardduty_detector.go
+++ b/internal/compliance/snapshot_poller/models/aws/guardduty_detector.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/iam_group.go
+++ b/internal/compliance/snapshot_poller/models/aws/iam_group.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/iam_policy.go
+++ b/internal/compliance/snapshot_poller/models/aws/iam_policy.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/iam_role.go
+++ b/internal/compliance/snapshot_poller/models/aws/iam_role.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/iam_user.go
+++ b/internal/compliance/snapshot_poller/models/aws/iam_user.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/kms_key.go
+++ b/internal/compliance/snapshot_poller/models/aws/kms_key.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/lambda_function.go
+++ b/internal/compliance/snapshot_poller/models/aws/lambda_function.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/password_policy.go
+++ b/internal/compliance/snapshot_poller/models/aws/password_policy.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/rds_instance.go
+++ b/internal/compliance/snapshot_poller/models/aws/rds_instance.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/redshift_cluster.go
+++ b/internal/compliance/snapshot_poller/models/aws/redshift_cluster.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/s3_bucket.go
+++ b/internal/compliance/snapshot_poller/models/aws/s3_bucket.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/types.go
+++ b/internal/compliance/snapshot_poller/models/aws/types.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/aws/waf_web_acl.go
+++ b/internal/compliance/snapshot_poller/models/aws/waf_web_acl.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/models/poller/poller.go
+++ b/internal/compliance/snapshot_poller/models/poller/poller.go
@@ -2,7 +2,7 @@ package poller
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/acm_certificate.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/acm_certificate.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/acm_certificate_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/acm_certificate_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/acm.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/acm.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/applicationautoscaling.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/applicationautoscaling.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/assume_role.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/assume_role.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/cloudformation.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/cloudformation.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/cloudtrail.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/cloudtrail.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/cloudwatchlogs.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/cloudwatchlogs.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/configservice.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/configservice.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/dynamodb.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/dynamodb.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/ec2.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/ec2.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/ecs.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/ecs.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/eks.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/eks.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/guardduty.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/guardduty.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/iam.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/iam.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/kms.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/kms.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/lambda.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/lambda.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/rds.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/rds.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/redshift.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/redshift.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/s3.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/s3.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/sts.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/sts.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/utils.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/utils.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/waf.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/waf.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/wafregional.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/wafregional.go
@@ -2,7 +2,7 @@ package awstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/clients.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/clients.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/cloudformation_stack.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudformation_stack.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/cloudformation_stack_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudformation_stack_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/cloudtrail.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudtrail.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/cloudtrail_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudtrail_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/cloudwatchlogs_log_group.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudwatchlogs_log_group.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/cloudwatchlogs_log_group_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudwatchlogs_log_group_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/configservice.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/configservice.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/configservice_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/configservice_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/dynamodb_table.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/dynamodb_table.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/dynamodb_table_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/dynamodb_table_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_ami.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_ami.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_ami_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_ami_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_instance.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_instance.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_instance_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_instance_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_network_acl.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_network_acl.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_network_acl_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_network_acl_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_security_group.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_security_group.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_security_group_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_security_group_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_volume.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_volume.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_volume_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_volume_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ec2_vpc_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/ecs_cluster_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/eks_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/eks_cluster.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/eks_cluster_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/eks_cluster_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/guardduty_detector.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/guardduty_detector.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/guardduty_detector_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/guardduty_detector_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_group.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_group.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_group_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_group_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_policy.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_policy.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_policy_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_policy_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_role.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_role.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_role_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_role_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_user.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/iam_user_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/iam_user_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/kms_key.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/kms_key.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/kms_key_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/kms_key_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/lambda_function.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/lambda_function.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/lambda_function_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/lambda_function_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/password_policy.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/password_policy.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/password_policy_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/password_policy_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/poll.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/poll_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/poll_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/rds_instance.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/rds_instance.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/rds_instance_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/rds_instance_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/redshift_cluster.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/redshift_cluster.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/redshift_cluster_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/redshift_cluster_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/s3_bucket.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/s3_bucket.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/s3_bucket_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/s3_bucket_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/utils_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/utils_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/waf_web_acl.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/waf_web_acl.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/aws/waf_web_acl_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/waf_web_acl_test.go
@@ -2,7 +2,7 @@ package aws
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/clients.go
+++ b/internal/compliance/snapshot_poller/pollers/clients.go
@@ -2,7 +2,7 @@ package pollers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/lambda.go
+++ b/internal/compliance/snapshot_poller/pollers/lambda.go
@@ -2,7 +2,7 @@ package pollers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/lambda_test.go
+++ b/internal/compliance/snapshot_poller/pollers/lambda_test.go
@@ -2,7 +2,7 @@ package pollers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/utils/logging.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/logging.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/utils/requeue.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/requeue.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/utils/resource_id.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/resource_id.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/utils/tags.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/tags.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/utils/tags_test.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/tags_test.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_poller/pollers/utils/time.go
+++ b/internal/compliance/snapshot_poller/pollers/utils/time.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_scheduler/main/handler.go
+++ b/internal/compliance/snapshot_scheduler/main/handler.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_scheduler/scheduler/schedule.go
+++ b/internal/compliance/snapshot_scheduler/scheduler/schedule.go
@@ -2,7 +2,7 @@ package scheduler
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshot_scheduler/scheduler/schedule_test.go
+++ b/internal/compliance/snapshot_scheduler/scheduler/schedule_test.go
@@ -2,7 +2,7 @@ package scheduler
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshotlogs/compliance.go
+++ b/internal/compliance/snapshotlogs/compliance.go
@@ -2,7 +2,7 @@ package snapshotlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshotlogs/resource.go
+++ b/internal/compliance/snapshotlogs/resource.go
@@ -2,7 +2,7 @@ package snapshotlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshotlogs/snapshotlogs_test.go
+++ b/internal/compliance/snapshotlogs/snapshotlogs_test.go
@@ -2,7 +2,7 @@ package snapshotlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshotlogs/snapshots.go
+++ b/internal/compliance/snapshotlogs/snapshots.go
@@ -2,7 +2,7 @@ package snapshotlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/compliance/snapshotlogs/testdata/snapshot_tests.yml
+++ b/internal/compliance/snapshotlogs/testdata/snapshot_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/api.go
+++ b/internal/core/alert_delivery/api/api.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/api_test.go
+++ b/internal/core/alert_delivery/api/api_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/cache.go
+++ b/internal/core/alert_delivery/api/cache.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/cache_test.go
+++ b/internal/core/alert_delivery/api/cache_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/deliver_alert.go
+++ b/internal/core/alert_delivery/api/deliver_alert.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/deliver_alert_test.go
+++ b/internal/core/alert_delivery/api/deliver_alert_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/dispatch_alerts.go
+++ b/internal/core/alert_delivery/api/dispatch_alerts.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/dispatch_alerts_test.go
+++ b/internal/core/alert_delivery/api/dispatch_alerts_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/outputs.go
+++ b/internal/core/alert_delivery/api/outputs.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/outputs_test.go
+++ b/internal/core/alert_delivery/api/outputs_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/retry.go
+++ b/internal/core/alert_delivery/api/retry.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/retry_test.go
+++ b/internal/core/alert_delivery/api/retry_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/send.go
+++ b/internal/core/alert_delivery/api/send.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/send_test.go
+++ b/internal/core/alert_delivery/api/send_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/send_test_alert.go
+++ b/internal/core/alert_delivery/api/send_test_alert.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/update_delivery.go
+++ b/internal/core/alert_delivery/api/update_delivery.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/api/update_delivery_test.go
+++ b/internal/core/alert_delivery/api/update_delivery_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/main/lambda.go
+++ b/internal/core/alert_delivery/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/asana.go
+++ b/internal/core/alert_delivery/outputs/asana.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/asana_test.go
+++ b/internal/core/alert_delivery/outputs/asana_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/custom_webhook.go
+++ b/internal/core/alert_delivery/outputs/custom_webhook.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/custom_webhook_test.go
+++ b/internal/core/alert_delivery/outputs/custom_webhook_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/errors.go
+++ b/internal/core/alert_delivery/outputs/errors.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/errors_test.go
+++ b/internal/core/alert_delivery/outputs/errors_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/github.go
+++ b/internal/core/alert_delivery/outputs/github.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/github_test.go
+++ b/internal/core/alert_delivery/outputs/github_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/jira.go
+++ b/internal/core/alert_delivery/outputs/jira.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/jira_test.go
+++ b/internal/core/alert_delivery/outputs/jira_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/msteams.go
+++ b/internal/core/alert_delivery/outputs/msteams.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/msteams_test.go
+++ b/internal/core/alert_delivery/outputs/msteams_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/opsgenie.go
+++ b/internal/core/alert_delivery/outputs/opsgenie.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/opsgenie_test.go
+++ b/internal/core/alert_delivery/outputs/opsgenie_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/outputs.go
+++ b/internal/core/alert_delivery/outputs/outputs.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/outputs_test.go
+++ b/internal/core/alert_delivery/outputs/outputs_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/pagerduty.go
+++ b/internal/core/alert_delivery/outputs/pagerduty.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/pagerduty_test.go
+++ b/internal/core/alert_delivery/outputs/pagerduty_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/post.go
+++ b/internal/core/alert_delivery/outputs/post.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/post_test.go
+++ b/internal/core/alert_delivery/outputs/post_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/slack.go
+++ b/internal/core/alert_delivery/outputs/slack.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/slack_test.go
+++ b/internal/core/alert_delivery/outputs/slack_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/sns.go
+++ b/internal/core/alert_delivery/outputs/sns.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/sns_test.go
+++ b/internal/core/alert_delivery/outputs/sns_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/sqs.go
+++ b/internal/core/alert_delivery/outputs/sqs.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/sqs_test.go
+++ b/internal/core/alert_delivery/outputs/sqs_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/utils.go
+++ b/internal/core/alert_delivery/outputs/utils.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/alert_delivery/outputs/utils_test.go
+++ b/internal/core/alert_delivery/outputs/utils_test.go
@@ -2,7 +2,7 @@ package outputs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/analysis/doc.go
+++ b/internal/core/analysis_api/analysis/doc.go
@@ -3,7 +3,7 @@ package analysis
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/analysis/policy_engine.go
+++ b/internal/core/analysis_api/analysis/policy_engine.go
@@ -2,7 +2,7 @@ package analysis
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/analysis/rule_engine.go
+++ b/internal/core/analysis_api/analysis/rule_engine.go
@@ -2,7 +2,7 @@ package analysis
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/analysis/rule_engine_test.go
+++ b/internal/core/analysis_api/analysis/rule_engine_test.go
@@ -2,7 +2,7 @@ package analysis
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/bulk_upload.go
+++ b/internal/core/analysis_api/handlers/bulk_upload.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/clients.go
+++ b/internal/core/analysis_api/handlers/clients.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/compliance.go
+++ b/internal/core/analysis_api/handlers/compliance.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/create_update_datamodel.go
+++ b/internal/core/analysis_api/handlers/create_update_datamodel.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/create_update_global.go
+++ b/internal/core/analysis_api/handlers/create_update_global.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/create_update_policy.go
+++ b/internal/core/analysis_api/handlers/create_update_policy.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/create_update_rule.go
+++ b/internal/core/analysis_api/handlers/create_update_rule.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/delete.go
+++ b/internal/core/analysis_api/handlers/delete.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/dynamo.go
+++ b/internal/core/analysis_api/handlers/dynamo.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/get.go
+++ b/internal/core/analysis_api/handlers/get.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/list.go
+++ b/internal/core/analysis_api/handlers/list.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/list_data_models.go
+++ b/internal/core/analysis_api/handlers/list_data_models.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/list_globals.go
+++ b/internal/core/analysis_api/handlers/list_globals.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/list_policies.go
+++ b/internal/core/analysis_api/handlers/list_policies.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/list_rules.go
+++ b/internal/core/analysis_api/handlers/list_rules.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/list_test.go
+++ b/internal/core/analysis_api/handlers/list_test.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/s3.go
+++ b/internal/core/analysis_api/handlers/s3.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/sqs.go
+++ b/internal/core/analysis_api/handlers/sqs.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/suppress.go
+++ b/internal/core/analysis_api/handlers/suppress.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/test_python.go
+++ b/internal/core/analysis_api/handlers/test_python.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/util.go
+++ b/internal/core/analysis_api/handlers/util.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/handlers/util_test.go
+++ b/internal/core/analysis_api/handlers/util_test.go
@@ -2,7 +2,7 @@ package handlers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/lambda.go
+++ b/internal/core/analysis_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/lambda_test.go
+++ b/internal/core/analysis_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/policy_always_true.py
+++ b/internal/core/analysis_api/main/test_analyses/policy_always_true.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/policy_always_true.yml
+++ b/internal/core/analysis_api/main/test_analyses/policy_always_true.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/policy_aws_cloudtrail_log_validation_enabled.py
+++ b/internal/core/analysis_api/main/test_analyses/policy_aws_cloudtrail_log_validation_enabled.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/policy_aws_cloudtrail_log_validation_enabled.yml
+++ b/internal/core/analysis_api/main/test_analyses/policy_aws_cloudtrail_log_validation_enabled.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/rule_always_true.py
+++ b/internal/core/analysis_api/main/test_analyses/rule_always_true.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/rule_always_true.yml
+++ b/internal/core/analysis_api/main/test_analyses/rule_always_true.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/analysis_api/main/test_analyses/sample_data_model.yml
+++ b/internal/core/analysis_api/main/test_analyses/sample_data_model.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/main/lambda.go
+++ b/internal/core/custom_resources/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms.go
+++ b/internal/core/custom_resources/resources/alarms.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_api_gateway.go
+++ b/internal/core/custom_resources/resources/alarms_api_gateway.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_appsync.go
+++ b/internal/core/custom_resources/resources/alarms_appsync.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_dynamo.go
+++ b/internal/core/custom_resources/resources/alarms_dynamo.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_elb.go
+++ b/internal/core/custom_resources/resources/alarms_elb.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_lambda.go
+++ b/internal/core/custom_resources/resources/alarms_lambda.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_sfn.go
+++ b/internal/core/custom_resources/resources/alarms_sfn.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_sns.go
+++ b/internal/core/custom_resources/resources/alarms_sns.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/alarms_sqs.go
+++ b/internal/core/custom_resources/resources/alarms_sqs.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/analysis_set.go
+++ b/internal/core/custom_resources/resources/analysis_set.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/certificate.go
+++ b/internal/core/custom_resources/resources/certificate.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/clients.go
+++ b/internal/core/custom_resources/resources/clients.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/cognito_user_pool_mfa.go
+++ b/internal/core/custom_resources/resources/cognito_user_pool_mfa.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/glue_tables.go
+++ b/internal/core/custom_resources/resources/glue_tables.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/guardduty_destination.go
+++ b/internal/core/custom_resources/resources/guardduty_destination.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/lambda_metric_filters.go
+++ b/internal/core/custom_resources/resources/lambda_metric_filters.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/layer_attachment.go
+++ b/internal/core/custom_resources/resources/layer_attachment.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/map.go
+++ b/internal/core/custom_resources/resources/map.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/panther_settings.go
+++ b/internal/core/custom_resources/resources/panther_settings.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/panther_teardown.go
+++ b/internal/core/custom_resources/resources/panther_teardown.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/panther_user.go
+++ b/internal/core/custom_resources/resources/panther_user.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/parser.go
+++ b/internal/core/custom_resources/resources/parser.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/s3_bucket_notification.go
+++ b/internal/core/custom_resources/resources/s3_bucket_notification.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/custom_resources/resources/self_registration.go
+++ b/internal/core/custom_resources/resources/self_registration.go
@@ -2,7 +2,7 @@ package resources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/layer_manager/main/integration_test.go
+++ b/internal/core/layer_manager/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/layer_manager/main/lambda.go
+++ b/internal/core/layer_manager/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/layer_manager/manager/clients.go
+++ b/internal/core/layer_manager/manager/clients.go
@@ -2,7 +2,7 @@ package manager
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/layer_manager/manager/handle.go
+++ b/internal/core/layer_manager/manager/handle.go
@@ -2,7 +2,7 @@ package manager
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/api.go
+++ b/internal/core/logtypesapi/api.go
@@ -2,7 +2,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/api_test.go
+++ b/internal/core/logtypesapi/api_test.go
@@ -2,7 +2,7 @@ package logtypesapi_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/available.go
+++ b/internal/core/logtypesapi/available.go
@@ -2,7 +2,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/available_test.go
+++ b/internal/core/logtypesapi/available_test.go
@@ -2,7 +2,7 @@ package logtypesapi_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/customlogs.go
+++ b/internal/core/logtypesapi/customlogs.go
@@ -2,7 +2,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/customlogs_test.go
+++ b/internal/core/logtypesapi/customlogs_test.go
@@ -2,7 +2,7 @@ package logtypesapi_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/dynamodb.go
+++ b/internal/core/logtypesapi/dynamodb.go
@@ -2,7 +2,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/inmem.go
+++ b/internal/core/logtypesapi/inmem.go
@@ -2,7 +2,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/lambdaclient_gen.go
+++ b/internal/core/logtypesapi/lambdaclient_gen.go
@@ -3,7 +3,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/main/lambda.go
+++ b/internal/core/logtypesapi/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/resolver.go
+++ b/internal/core/logtypesapi/resolver.go
@@ -2,7 +2,7 @@ package logtypesapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/transact/transact.go
+++ b/internal/core/logtypesapi/transact/transact.go
@@ -3,7 +3,7 @@ package transact
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/logtypesapi/transact/transact_test.go
+++ b/internal/core/logtypesapi/transact/transact_test.go
@@ -2,7 +2,7 @@ package transact
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/alert_metrics.go
+++ b/internal/core/metrics_api/api/alert_metrics.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/get_metrics.go
+++ b/internal/core/metrics_api/api/get_metrics.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/get_metrics_test.go
+++ b/internal/core/metrics_api/api/get_metrics_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/helpers.go
+++ b/internal/core/metrics_api/api/helpers.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/helpers_test.go
+++ b/internal/core/metrics_api/api/helpers_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/log_processor_metrics.go
+++ b/internal/core/metrics_api/api/log_processor_metrics.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/api/vars.go
+++ b/internal/core/metrics_api/api/vars.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/main/integration_test.go
+++ b/internal/core/metrics_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/metrics_api/main/lambda.go
+++ b/internal/core/metrics_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/api/api.go
+++ b/internal/core/organization_api/api/api.go
@@ -3,7 +3,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/api/get_settings.go
+++ b/internal/core/organization_api/api/get_settings.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/api/update_settings.go
+++ b/internal/core/organization_api/api/update_settings.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/main/integration_test.go
+++ b/internal/core/organization_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/main/lambda.go
+++ b/internal/core/organization_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/main/lambda_test.go
+++ b/internal/core/organization_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/table/get.go
+++ b/internal/core/organization_api/table/get.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/table/get_test.go
+++ b/internal/core/organization_api/table/get_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/table/table.go
+++ b/internal/core/organization_api/table/table.go
@@ -3,7 +3,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/table/table_test.go
+++ b/internal/core/organization_api/table/table_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/table/update.go
+++ b/internal/core/organization_api/table/update.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/organization_api/table/update_test.go
+++ b/internal/core/organization_api/table/update_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/add_output.go
+++ b/internal/core/outputs_api/api/add_output.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/add_output_test.go
+++ b/internal/core/outputs_api/api/add_output_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/api.go
+++ b/internal/core/outputs_api/api/api.go
@@ -3,7 +3,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/api_test.go
+++ b/internal/core/outputs_api/api/api_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/delete_output.go
+++ b/internal/core/outputs_api/api/delete_output.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/delete_output_test.go
+++ b/internal/core/outputs_api/api/delete_output_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/get_output.go
+++ b/internal/core/outputs_api/api/get_output.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/get_output_test.go
+++ b/internal/core/outputs_api/api/get_output_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/get_outputs.go
+++ b/internal/core/outputs_api/api/get_outputs.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/get_outputs_test.go
+++ b/internal/core/outputs_api/api/get_outputs_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/get_outputs_unredacted.go
+++ b/internal/core/outputs_api/api/get_outputs_unredacted.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/update_output.go
+++ b/internal/core/outputs_api/api/update_output.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/update_output_test.go
+++ b/internal/core/outputs_api/api/update_output_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/api/utils.go
+++ b/internal/core/outputs_api/api/utils.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/main/integration_test.go
+++ b/internal/core/outputs_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/main/lambda.go
+++ b/internal/core/outputs_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/main/lambda_test.go
+++ b/internal/core/outputs_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/delete.go
+++ b/internal/core/outputs_api/table/delete.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/delete_test.go
+++ b/internal/core/outputs_api/table/delete_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/put.go
+++ b/internal/core/outputs_api/table/put.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/put_test.go
+++ b/internal/core/outputs_api/table/put_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/query.go
+++ b/internal/core/outputs_api/table/query.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/query_test.go
+++ b/internal/core/outputs_api/table/query_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/table.go
+++ b/internal/core/outputs_api/table/table.go
@@ -3,7 +3,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/table_test.go
+++ b/internal/core/outputs_api/table/table_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/update.go
+++ b/internal/core/outputs_api/table/update.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/table/update_test.go
+++ b/internal/core/outputs_api/table/update_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/validator/validator.go
+++ b/internal/core/outputs_api/validator/validator.go
@@ -2,7 +2,7 @@ package validator
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/outputs_api/validator/validator_test.go
+++ b/internal/core/outputs_api/validator/validator_test.go
@@ -2,7 +2,7 @@ package validator
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/delete_integration.go
+++ b/internal/core/source_api/api/delete_integration.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/delete_integration_test.go
+++ b/internal/core/source_api/api/delete_integration_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/get_integration_template.go
+++ b/internal/core/source_api/api/get_integration_template.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/get_integration_template_test.go
+++ b/internal/core/source_api/api/get_integration_template_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/lambda_utils.go
+++ b/internal/core/source_api/api/lambda_utils.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/list_integrations.go
+++ b/internal/core/source_api/api/list_integrations.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/list_integrations_test.go
+++ b/internal/core/source_api/api/list_integrations_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/list_logtypes.go
+++ b/internal/core/source_api/api/list_logtypes.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/list_logtypes_test.go
+++ b/internal/core/source_api/api/list_logtypes_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/put_integration_test.go
+++ b/internal/core/source_api/api/put_integration_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/sqs_utils.go
+++ b/internal/core/source_api/api/sqs_utils.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/testdata/panther-cloudsec-iam-updated.yml
+++ b/internal/core/source_api/api/testdata/panther-cloudsec-iam-updated.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/testdata/panther-log-analysis-iam-updated.yml
+++ b/internal/core/source_api/api/testdata/panther-log-analysis-iam-updated.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/update_integration_test.go
+++ b/internal/core/source_api/api/update_integration_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/update_status.go
+++ b/internal/core/source_api/api/update_status.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/vars.go
+++ b/internal/core/source_api/api/vars.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/api/vars_test.go
+++ b/internal/core/source_api/api/vars_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/apifunctions/apifunctions.go
+++ b/internal/core/source_api/apifunctions/apifunctions.go
@@ -2,7 +2,7 @@ package apifunctions
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/ddb.go
+++ b/internal/core/source_api/ddb/ddb.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/delete_item.go
+++ b/internal/core/source_api/ddb/delete_item.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/get_item.go
+++ b/internal/core/source_api/ddb/get_item.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/modelstest/mocks.go
+++ b/internal/core/source_api/ddb/modelstest/mocks.go
@@ -2,7 +2,7 @@ package modelstest
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/put_item.go
+++ b/internal/core/source_api/ddb/put_item.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/scan.go
+++ b/internal/core/source_api/ddb/scan.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/ddb/update.go
+++ b/internal/core/source_api/ddb/update.go
@@ -2,7 +2,7 @@ package ddb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/main/handler.go
+++ b/internal/core/source_api/main/handler.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/main/handler_test.go
+++ b/internal/core/source_api/main/handler_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/source_api/main/integration_test.go
+++ b/internal/core/source_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/api.go
+++ b/internal/core/users_api/api/api.go
@@ -3,7 +3,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/cognito_trigger.go
+++ b/internal/core/users_api/api/cognito_trigger.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -45,7 +45,7 @@ const passwordResetTemplate = `
 <br />Yours truly,
 <br />Panther - https://runpanther.io
 <br />
-<br /><small>Copyright © 2020 Panther Labs Inc. All rights reserved.</small>
+<br /><small>Copyright © 2021 Panther Labs Inc. All rights reserved.</small>
 `
 
 func CognitoTrigger(header events.CognitoEventUserPoolsHeader, input json.RawMessage) (interface{}, error) {

--- a/internal/core/users_api/api/get_user.go
+++ b/internal/core/users_api/api/get_user.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/get_user_test.go
+++ b/internal/core/users_api/api/get_user_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/invite_user.go
+++ b/internal/core/users_api/api/invite_user.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/invite_user_test.go
+++ b/internal/core/users_api/api/invite_user_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/list_users.go
+++ b/internal/core/users_api/api/list_users.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/list_users_test.go
+++ b/internal/core/users_api/api/list_users_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/remove_user.go
+++ b/internal/core/users_api/api/remove_user.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/remove_user_test.go
+++ b/internal/core/users_api/api/remove_user_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/reset_user_password.go
+++ b/internal/core/users_api/api/reset_user_password.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/reset_user_password_test.go
+++ b/internal/core/users_api/api/reset_user_password_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/update_user.go
+++ b/internal/core/users_api/api/update_user.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/api/update_user_test.go
+++ b/internal/core/users_api/api/update_user_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/create_user.go
+++ b/internal/core/users_api/cognito/create_user.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/create_user_test.go
+++ b/internal/core/users_api/cognito/create_user_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/delete_user.go
+++ b/internal/core/users_api/cognito/delete_user.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/delete_user_test.go
+++ b/internal/core/users_api/cognito/delete_user_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/get_user.go
+++ b/internal/core/users_api/cognito/get_user.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/get_user_test.go
+++ b/internal/core/users_api/cognito/get_user_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/list_users.go
+++ b/internal/core/users_api/cognito/list_users.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/list_users_test.go
+++ b/internal/core/users_api/cognito/list_users_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/mock_cognito_client.go
+++ b/internal/core/users_api/cognito/mock_cognito_client.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/mock_gateway.go
+++ b/internal/core/users_api/cognito/mock_gateway.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/reset_user_password.go
+++ b/internal/core/users_api/cognito/reset_user_password.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/reset_user_password_test.go
+++ b/internal/core/users_api/cognito/reset_user_password_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/update_user.go
+++ b/internal/core/users_api/cognito/update_user.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/update_user_test.go
+++ b/internal/core/users_api/cognito/update_user_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/users_gateway.go
+++ b/internal/core/users_api/cognito/users_gateway.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/cognito/users_gateway_test.go
+++ b/internal/core/users_api/cognito/users_gateway_test.go
@@ -2,7 +2,7 @@ package cognito
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/main/integration_test.go
+++ b/internal/core/users_api/main/integration_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/main/lambda.go
+++ b/internal/core/users_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/core/users_api/main/lambda_test.go
+++ b/internal/core/users_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/cost/panther.go
+++ b/internal/cost/panther.go
@@ -2,7 +2,7 @@ package cost
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/__init__.py
+++ b/internal/log_analysis/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/forwarder_test.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/forwarder/metrics.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/metrics.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/forwarder/rule_cache.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/rule_cache.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/forwarder/rule_cache_test.go
+++ b/internal/log_analysis/alert_forwarder/forwarder/rule_cache_test.go
@@ -14,7 +14,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/main/config.go
+++ b/internal/log_analysis/alert_forwarder/main/config.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alert_forwarder/main/lambda.go
+++ b/internal/log_analysis/alert_forwarder/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/api.go
+++ b/internal/log_analysis/alerts_api/api/api.go
@@ -3,7 +3,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/api_test.go
+++ b/internal/log_analysis/alerts_api/api/api_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/get_alert.go
+++ b/internal/log_analysis/alerts_api/api/get_alert.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/get_alert_test.go
+++ b/internal/log_analysis/alerts_api/api/get_alert_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/list_alerts.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/list_alerts_test.go
+++ b/internal/log_analysis/alerts_api/api/list_alerts_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/s3_search.go
+++ b/internal/log_analysis/alerts_api/api/s3_search.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/s3select_query.go
+++ b/internal/log_analysis/alerts_api/api/s3select_query.go
@@ -14,7 +14,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/update_alert_delivery.go
+++ b/internal/log_analysis/alerts_api/api/update_alert_delivery.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/update_alert_delivery_test.go
+++ b/internal/log_analysis/alerts_api/api/update_alert_delivery_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/update_alert_status.go
+++ b/internal/log_analysis/alerts_api/api/update_alert_status.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/update_alert_status_test.go
+++ b/internal/log_analysis/alerts_api/api/update_alert_status_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/api/utils_test.go
+++ b/internal/log_analysis/alerts_api/api/utils_test.go
@@ -2,7 +2,7 @@ package api
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/main/lambda.go
+++ b/internal/log_analysis/alerts_api/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/main/lambda_test.go
+++ b/internal/log_analysis/alerts_api/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/models/models.go
+++ b/internal/log_analysis/alerts_api/models/models.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/models/models_test.go
+++ b/internal/log_analysis/alerts_api/models/models_test.go
@@ -2,7 +2,7 @@ package models
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/table/get_alert.go
+++ b/internal/log_analysis/alerts_api/table/get_alert.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/table/get_alert_test.go
+++ b/internal/log_analysis/alerts_api/table/get_alert_test.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/table/list.go
+++ b/internal/log_analysis/alerts_api/table/list.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/table/table.go
+++ b/internal/log_analysis/alerts_api/table/table.go
@@ -3,7 +3,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/table/update_alert.go
+++ b/internal/log_analysis/alerts_api/table/update_alert.go
@@ -2,7 +2,7 @@ package table
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/utils/utils.go
+++ b/internal/log_analysis/alerts_api/utils/utils.go
@@ -3,7 +3,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/alerts_api/utils/utils_test.go
+++ b/internal/log_analysis/alerts_api/utils/utils_test.go
@@ -2,7 +2,7 @@ package utils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/athenaviews/athenaviews.go
+++ b/internal/log_analysis/athenaviews/athenaviews.go
@@ -2,7 +2,7 @@ package athenaviews
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/athenaviews/athenaviews_test.go
+++ b/internal/log_analysis/athenaviews/athenaviews_test.go
@@ -2,7 +2,7 @@ package athenaviews
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/awsglue.go
+++ b/internal/log_analysis/awsglue/awsglue.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/awsglue_test.go
+++ b/internal/log_analysis/awsglue/awsglue_test.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glue_timebin.go
+++ b/internal/log_analysis/awsglue/glue_timebin.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glue_timebin_test.go
+++ b/internal/log_analysis/awsglue/glue_timebin_test.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glueschema/columns.go
+++ b/internal/log_analysis/awsglue/glueschema/columns.go
@@ -2,7 +2,7 @@ package glueschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glueschema/columns_test.go
+++ b/internal/log_analysis/awsglue/glueschema/columns_test.go
@@ -2,7 +2,7 @@ package glueschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glueschema/glueschema.go
+++ b/internal/log_analysis/awsglue/glueschema/glueschema.go
@@ -2,7 +2,7 @@ package glueschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glueschema/glueschema_test.go
+++ b/internal/log_analysis/awsglue/glueschema/glueschema_test.go
@@ -2,7 +2,7 @@ package glueschema_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/glueschema/mappings.go
+++ b/internal/log_analysis/awsglue/glueschema/mappings.go
@@ -2,7 +2,7 @@ package glueschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/gluetimestamp/gluetimestamp.go
+++ b/internal/log_analysis/awsglue/gluetimestamp/gluetimestamp.go
@@ -3,7 +3,7 @@ package gluetimestamp
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/integration_test.go
+++ b/internal/log_analysis/awsglue/integration_test.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/partition.go
+++ b/internal/log_analysis/awsglue/partition.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/partition_test.go
+++ b/internal/log_analysis/awsglue/partition_test.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/schema.go
+++ b/internal/log_analysis/awsglue/schema.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/table_metadata.go
+++ b/internal/log_analysis/awsglue/table_metadata.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/table_metadata_test.go
+++ b/internal/log_analysis/awsglue/table_metadata_test.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/awsglue/wrappers.go
+++ b/internal/log_analysis/awsglue/wrappers.go
@@ -2,7 +2,7 @@ package awsglue
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/client.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/client.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/create_tables.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/create_tables.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/create_tables_test.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/create_tables_test.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/handler.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/handler.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/handler_test.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/handler_test.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/s3.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/s3.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/sync_database.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/sync_database.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/sync_database_partitions.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/sync_database_partitions.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/sync_table_partitions.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/sync_table_partitions.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/datacatalog/update_table.go
+++ b/internal/log_analysis/datacatalog_updater/datacatalog/update_table.go
@@ -2,7 +2,7 @@ package datacatalog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/datacatalog_updater/main/lambda.go
+++ b/internal/log_analysis/datacatalog_updater/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/gluetables/gluetables.go
+++ b/internal/log_analysis/gluetables/gluetables.go
@@ -2,7 +2,7 @@ package gluetables
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/gluetasks/recover.go
+++ b/internal/log_analysis/gluetasks/recover.go
@@ -2,7 +2,7 @@ package gluetasks
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/gluetasks/sync.go
+++ b/internal/log_analysis/gluetasks/sync.go
@@ -2,7 +2,7 @@ package gluetasks
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/classification/classifier.go
+++ b/internal/log_analysis/log_processor/classification/classifier.go
@@ -2,7 +2,7 @@ package classification
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/classification/classifier_test.go
+++ b/internal/log_analysis/log_processor/classification/classifier_test.go
@@ -2,7 +2,7 @@ package classification
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/classification/parser_queue.go
+++ b/internal/log_analysis/log_processor/classification/parser_queue.go
@@ -2,7 +2,7 @@ package classification
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/common/common.go
+++ b/internal/log_analysis/log_processor/common/common.go
@@ -2,7 +2,7 @@ package common
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/common/json.go
+++ b/internal/log_analysis/log_processor/common/json.go
@@ -2,7 +2,7 @@ package common
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/common/metrics.go
+++ b/internal/log_analysis/log_processor/common/metrics.go
@@ -2,7 +2,7 @@ package common
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/common/oplog.go
+++ b/internal/log_analysis/log_processor/common/oplog.go
@@ -2,7 +2,7 @@ package common
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/customlogs/customlogs.go
+++ b/internal/log_analysis/log_processor/customlogs/customlogs.go
@@ -3,7 +3,7 @@ package customlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/customlogs/customlogs_test.go
+++ b/internal/log_analysis/log_processor/customlogs/customlogs_test.go
@@ -2,7 +2,7 @@ package customlogs_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -19,7 +19,7 @@ package customlogs_test
  */
 
 /**
-* Copyright (C) 2020 Panther Labs Inc
+* Copyright (C) 2021 Panther Labs Inc
 https://github.com/panther-labs/panther-enterprise/pull/1505*
 * Panther Enterprise is licensed under the terms of a commercial license available from
 * Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/customlogs/customparser/customparser.go
+++ b/internal/log_analysis/log_processor/customlogs/customparser/customparser.go
@@ -3,7 +3,7 @@ package customparser
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/customlogs/updates.go
+++ b/internal/log_analysis/log_processor/customlogs/updates.go
@@ -2,7 +2,7 @@ package customlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/customlogs/updates_test.go
+++ b/internal/log_analysis/log_processor/customlogs/updates_test.go
@@ -2,7 +2,7 @@ package customlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/destinations/destinations.go
+++ b/internal/log_analysis/log_processor/destinations/destinations.go
@@ -2,7 +2,7 @@ package destinations
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -2,7 +2,7 @@ package destinations
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/destinations/s3_test.go
+++ b/internal/log_analysis/log_processor/destinations/s3_test.go
@@ -2,7 +2,7 @@ package destinations
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/bindata.go
+++ b/internal/log_analysis/log_processor/logschema/bindata.go
@@ -5,7 +5,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/diff.go
+++ b/internal/log_analysis/log_processor/logschema/diff.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/infer.go
+++ b/internal/log_analysis/log_processor/logschema/infer.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/logschema.go
+++ b/internal/log_analysis/log_processor/logschema/logschema.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/logschema_test.go
+++ b/internal/log_analysis/log_processor/logschema/logschema_test.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/merge.go
+++ b/internal/log_analysis/log_processor/logschema/merge.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/merge_test.go
+++ b/internal/log_analysis/log_processor/logschema/merge_test.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/reflect.go
+++ b/internal/log_analysis/log_processor/logschema/reflect.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/reflect_test.go
+++ b/internal/log_analysis/log_processor/logschema/reflect_test.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/refs.go
+++ b/internal/log_analysis/log_processor/logschema/refs.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/refs_test.go
+++ b/internal/log_analysis/log_processor/logschema/refs_test.go
@@ -2,7 +2,7 @@ package logschema
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logschema/testdata/apache_common_log_fastmatch_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/apache_common_log_fastmatch_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logschema/testdata/apache_common_log_regex_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/apache_common_log_regex_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logschema/testdata/cloudtrail_insight_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/cloudtrail_insight_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logschema/testdata/gitlab_api_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/gitlab_api_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logschema/testdata/osquery_status_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/osquery_status_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logschema/testdata/sample_api_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/sample_api_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logschema/testdata/vpcflow_schema.yml
+++ b/internal/log_analysis/log_processor/logschema/testdata/vpcflow_schema.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # Panther Enterprise is licensed under the terms of a commercial license available from
 # Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.

--- a/internal/log_analysis/log_processor/logtypes/entry.go
+++ b/internal/log_analysis/log_processor/logtypes/entry.go
@@ -2,7 +2,7 @@ package logtypes
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logtypes/group.go
+++ b/internal/log_analysis/log_processor/logtypes/group.go
@@ -2,7 +2,7 @@ package logtypes
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logtypes/logtesting/logtesting.go
+++ b/internal/log_analysis/log_processor/logtypes/logtesting/logtesting.go
@@ -2,7 +2,7 @@ package logtesting
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logtypes/resolver.go
+++ b/internal/log_analysis/log_processor/logtypes/resolver.go
@@ -2,7 +2,7 @@ package logtypes
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/logtypes/resolver_test.go
+++ b/internal/log_analysis/log_processor/logtypes/resolver_test.go
@@ -2,7 +2,7 @@ package logtypes
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/main/lambda.go
+++ b/internal/log_analysis/log_processor/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/main/lambda_test.go
+++ b/internal/log_analysis/log_processor/main/lambda_test.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/encoders.go
+++ b/internal/log_analysis/log_processor/pantherlog/encoders.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/extract.go
+++ b/internal/log_analysis/log_processor/pantherlog/extract.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/jsoniter.go
+++ b/internal/log_analysis/log_processor/pantherlog/jsoniter.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/jsoniter_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/jsoniter_test.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/meta.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/meta_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/meta_test.go
@@ -2,7 +2,7 @@ package pantherlog_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/nocopy.go
+++ b/internal/log_analysis/log_processor/pantherlog/nocopy.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/boolean.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/boolean.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/boolean_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/boolean_test.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/float32.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/float32.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/float32_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/float32_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/float64.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/float64.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/float64_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/float64_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int16.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int16.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int16_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int16_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int32.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int32.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int32_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int32_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int64.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int64.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int64_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int64_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int8.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int8.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/int8_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/int8_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/null.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/null.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/null_benchmark_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/null_benchmark_test.go
@@ -2,7 +2,7 @@ package null_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/null_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/null_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/string.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/string.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/string_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/string_test.go
@@ -2,7 +2,7 @@ package null_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint16.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint16.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint16_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint16_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint32.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint32.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint32_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint32_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint64.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint64.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint64_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint64_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint8.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint8.go
@@ -3,7 +3,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/null/uint8_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/null/uint8_test.go
@@ -2,7 +2,7 @@ package null
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/omitempty/omitempty.go
+++ b/internal/log_analysis/log_processor/pantherlog/omitempty/omitempty.go
@@ -2,7 +2,7 @@ package omitempty
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/omitempty/omitempty_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/omitempty/omitempty_test.go
@@ -2,7 +2,7 @@ package omitempty
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/pantherlog.go
+++ b/internal/log_analysis/log_processor/pantherlog/pantherlog.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/parsers.go
+++ b/internal/log_analysis/log_processor/pantherlog/parsers.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/renamefields/renamefields.go
+++ b/internal/log_analysis/log_processor/pantherlog/renamefields/renamefields.go
@@ -2,7 +2,7 @@ package renamefields
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/renamefields/renamefields_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/renamefields/renamefields_test.go
@@ -2,7 +2,7 @@ package renamefields
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/result.go
+++ b/internal/log_analysis/log_processor/pantherlog/result.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/result_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/result_test.go
@@ -2,7 +2,7 @@ package pantherlog_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/rowid/rowid.go
+++ b/internal/log_analysis/log_processor/pantherlog/rowid/rowid.go
@@ -2,7 +2,7 @@ package rowid
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/rowid/rowid_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/rowid/rowid_test.go
@@ -2,7 +2,7 @@ package rowid
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/scanners.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/scanners_aws.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners_aws.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/scanners_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/scanners_test.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/extension.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/extension.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/extension_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/extension_test.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/registry.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/registry.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/registry_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/registry_test.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/tcodec_test.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/tcodec/unix.go
+++ b/internal/log_analysis/log_processor/pantherlog/tcodec/unix.go
@@ -2,7 +2,7 @@ package tcodec
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/values.go
+++ b/internal/log_analysis/log_processor/pantherlog/values.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/pantherlog/values_test.go
+++ b/internal/log_analysis/log_processor/pantherlog/values_test.go
@@ -2,7 +2,7 @@ package pantherlog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/adapter.go
+++ b/internal/log_analysis/log_processor/parsers/adapter.go
@@ -4,7 +4,7 @@ import "github.com/panther-labs/panther/internal/log_analysis/log_processor/pant
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/apachelogs/access_combined.go
+++ b/internal/log_analysis/log_processor/parsers/apachelogs/access_combined.go
@@ -2,7 +2,7 @@ package apachelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/apachelogs/access_combined_test.go
+++ b/internal/log_analysis/log_processor/parsers/apachelogs/access_combined_test.go
@@ -2,7 +2,7 @@ package apachelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/apachelogs/access_common.go
+++ b/internal/log_analysis/log_processor/parsers/apachelogs/access_common.go
@@ -2,7 +2,7 @@ package apachelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/apachelogs/access_common_test.go
+++ b/internal/log_analysis/log_processor/parsers/apachelogs/access_common_test.go
@@ -2,7 +2,7 @@ package apachelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/apachelogs/apachelogs.go
+++ b/internal/log_analysis/log_processor/parsers/apachelogs/apachelogs.go
@@ -3,7 +3,7 @@ package apachelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/alb.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/alb.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/alb_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/alb_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/aurora_mysql_audit_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
@@ -3,7 +3,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_digest.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_digest.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_insights.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_insights.go
@@ -9,7 +9,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudtrail_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudwatch_events.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudwatch_events.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/cloudwatch_events_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/cloudwatch_events_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/extractor.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/extractor.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/extractor_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/extractor_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/guardduty.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/guardduty.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/guardduty_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/guardduty_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/indicators.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/indicators_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/indicators_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/pantherlog.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/pantherlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/pantherlog_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/s3_server_access_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/testdata/cloudtrail_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/awslogs/testdata/cloudtrail_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/testdata/vpc_dns_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/awslogs/testdata/vpc_dns_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_dns.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_dns.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_dns_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_dns_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/vpc_flow_test.go
@@ -2,7 +2,7 @@ package awslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/boxlogs/boxlogs.go
+++ b/internal/log_analysis/log_processor/parsers/boxlogs/boxlogs.go
@@ -2,7 +2,7 @@ package boxlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/boxlogs/events.go
+++ b/internal/log_analysis/log_processor/parsers/boxlogs/events.go
@@ -2,7 +2,7 @@ package boxlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/cloudflarelogs.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/cloudflarelogs.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/cloudflarelogs_test.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/cloudflarelogs_test.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/firewall.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/firewall.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/http_request.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/http_request.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/spectrum.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/spectrum.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/tcodec.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/tcodec.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/tcodec_test.go
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/tcodec_test.go
@@ -2,7 +2,7 @@ package cloudflarelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/cloudflarelogs/testdata/cloudflare_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/cloudflarelogs/testdata/cloudflare_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs_test.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs_test.go
@@ -2,7 +2,7 @@ package crowdstrikelogs_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/dns_request.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/dns_request.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/dns_request_test.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/dns_request_test.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/network.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/network.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/network_test.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/network_test.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/process_rollup.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/process_rollup.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/process_rollup_test.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/process_rollup_test.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/unknown.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/unknown.go
@@ -2,7 +2,7 @@ package crowdstrikelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/csv_utils.go
+++ b/internal/log_analysis/log_processor/parsers/csv_utils.go
@@ -2,7 +2,7 @@ package parsers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/csvstream/csvstream.go
+++ b/internal/log_analysis/log_processor/parsers/csvstream/csvstream.go
@@ -2,7 +2,7 @@ package csvstream
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/csvstream/csvstream_test.go
+++ b/internal/log_analysis/log_processor/parsers/csvstream/csvstream_test.go
@@ -2,7 +2,7 @@ package csvstream
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/administrator.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/administrator.go
@@ -2,7 +2,7 @@ package duologs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/authentication.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/authentication.go
@@ -2,7 +2,7 @@ package duologs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/duologs.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/duologs.go
@@ -2,7 +2,7 @@ package duologs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/duologs_test.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/duologs_test.go
@@ -2,7 +2,7 @@ package duologs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/offline_enrollment.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/offline_enrollment.go
@@ -2,7 +2,7 @@ package duologs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/telephony.go
+++ b/internal/log_analysis/log_processor/parsers/duologs/telephony.go
@@ -2,7 +2,7 @@ package duologs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/duologs/testdata/duologs_test.yml
+++ b/internal/log_analysis/log_processor/parsers/duologs/testdata/duologs_test.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fastlylogs/access.go
+++ b/internal/log_analysis/log_processor/parsers/fastlylogs/access.go
@@ -2,7 +2,7 @@ package fastlylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fastlylogs/access_test.go
+++ b/internal/log_analysis/log_processor/parsers/fastlylogs/access_test.go
@@ -2,7 +2,7 @@ package fastlylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/fluentdsyslogs.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/fluentdsyslogs.go
@@ -2,7 +2,7 @@ package fluentdsyslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164.go
@@ -2,7 +2,7 @@ package fluentdsyslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc3164_test.go
@@ -2,7 +2,7 @@ package fluentdsyslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424.go
@@ -2,7 +2,7 @@ package fluentdsyslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424_test.go
+++ b/internal/log_analysis/log_processor/parsers/fluentdsyslogs/rfc5424_test.go
@@ -2,7 +2,7 @@ package fluentdsyslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gcplogs/auditlog.go
+++ b/internal/log_analysis/log_processor/parsers/gcplogs/auditlog.go
@@ -2,7 +2,7 @@ package gcplogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gcplogs/auditlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/gcplogs/auditlog_test.go
@@ -2,7 +2,7 @@ package gcplogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gcplogs/gcplogs.go
+++ b/internal/log_analysis/log_processor/parsers/gcplogs/gcplogs.go
@@ -3,7 +3,7 @@ package gcplogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/api.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/api.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/audit.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/audit.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/exceptions.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/exceptions.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/git.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/git.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/gitlablogs.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/gitlablogs.go
@@ -10,7 +10,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/gitlablogs_test.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/gitlablogs_test.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/integrations.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/integrations.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/rails.go
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/rails.go
@@ -2,7 +2,7 @@ package gitlablogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/api_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/api_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/audit_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/audit_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/exceptions_test.yml
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/exceptions_test.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/git_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/git_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/integrations_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/integrations_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/production_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gitlablogs/testdata/production_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gravitationallogs/audit.go
+++ b/internal/log_analysis/log_processor/parsers/gravitationallogs/audit.go
@@ -2,7 +2,7 @@ package gravitationallogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gravitationallogs/audit_test.go
+++ b/internal/log_analysis/log_processor/parsers/gravitationallogs/audit_test.go
@@ -2,7 +2,7 @@ package gravitationallogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gravitationallogs/gravitationallogs.go
+++ b/internal/log_analysis/log_processor/parsers/gravitationallogs/gravitationallogs.go
@@ -2,7 +2,7 @@ package gravitationallogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gravitationallogs/testdata/audit_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gravitationallogs/testdata/audit_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gsuitelogs/gsuitelogs.go
+++ b/internal/log_analysis/log_processor/parsers/gsuitelogs/gsuitelogs.go
@@ -2,7 +2,7 @@ package gsuitelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gsuitelogs/reports.go
+++ b/internal/log_analysis/log_processor/parsers/gsuitelogs/reports.go
@@ -2,7 +2,7 @@ package gsuitelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gsuitelogs/reports_test.go
+++ b/internal/log_analysis/log_processor/parsers/gsuitelogs/reports_test.go
@@ -2,7 +2,7 @@ package gsuitelogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/gsuitelogs/testdata/reports_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/gsuitelogs/testdata/reports_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/access.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/access.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/access_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/access_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/audit.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/audit.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/audit_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/audit_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/firewall.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/firewall.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/firewall_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/firewall_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/juniperlogs.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/juniperlogs.go
@@ -3,7 +3,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/juniperlogs_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/juniperlogs_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/mws.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/mws.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/mws_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/mws_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/postgres.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/postgres.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/postgres_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/postgres_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/security.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/security.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/juniperlogs/security_test.go
+++ b/internal/log_analysis/log_processor/parsers/juniperlogs/security_test.go
@@ -2,7 +2,7 @@ package juniperlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/laceworklogs/lacework.go
+++ b/internal/log_analysis/log_processor/parsers/laceworklogs/lacework.go
@@ -2,7 +2,7 @@ package laceworklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/laceworklogs/lacework_test.go
+++ b/internal/log_analysis/log_processor/parsers/laceworklogs/lacework_test.go
@@ -2,7 +2,7 @@ package laceworklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/laceworklogs/laceworklogs.go
+++ b/internal/log_analysis/log_processor/parsers/laceworklogs/laceworklogs.go
@@ -2,7 +2,7 @@ package laceworklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/nginxlogs/access.go
+++ b/internal/log_analysis/log_processor/parsers/nginxlogs/access.go
@@ -2,7 +2,7 @@ package nginxlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/nginxlogs/access_test.go
+++ b/internal/log_analysis/log_processor/parsers/nginxlogs/access_test.go
@@ -2,7 +2,7 @@ package nginxlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/nginxlogs/nginxlogs.go
+++ b/internal/log_analysis/log_processor/parsers/nginxlogs/nginxlogs.go
@@ -3,7 +3,7 @@ package nginxlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/numerics/numerics.go
+++ b/internal/log_analysis/log_processor/parsers/numerics/numerics.go
@@ -2,7 +2,7 @@ package numerics
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/numerics/numerics_test.go
+++ b/internal/log_analysis/log_processor/parsers/numerics/numerics_test.go
@@ -2,7 +2,7 @@ package numerics
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/oktalogs/oktalogs.go
+++ b/internal/log_analysis/log_processor/parsers/oktalogs/oktalogs.go
@@ -2,7 +2,7 @@ package oktalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/oktalogs/systemlog.go
+++ b/internal/log_analysis/log_processor/parsers/oktalogs/systemlog.go
@@ -2,7 +2,7 @@ package oktalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/oktalogs/systemlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/oktalogs/systemlog_test.go
@@ -2,7 +2,7 @@ package oktalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/oneloginlogs/onelogin.go
+++ b/internal/log_analysis/log_processor/parsers/oneloginlogs/onelogin.go
@@ -2,7 +2,7 @@ package oneloginlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/oneloginlogs/onelogin_test.go
+++ b/internal/log_analysis/log_processor/parsers/oneloginlogs/onelogin_test.go
@@ -2,7 +2,7 @@ package oneloginlogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/oneloginlogs/testdata/onelogin_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/oneloginlogs/testdata/onelogin_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/batch.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/batch.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/batch_test.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/batch_test.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/differential.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/differential.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/differential_test.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/differential_test.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/osquerylogs.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/osquerylogs.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/snapshot.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/snapshot.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/snapshot_test.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/snapshot_test.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/status.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/status.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osquerylogs/status_test.go
+++ b/internal/log_analysis/log_processor/parsers/osquerylogs/status_test.go
@@ -2,7 +2,7 @@ package osquerylogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo.go
+++ b/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo.go
@@ -2,7 +2,7 @@ package osseclogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo_test.go
+++ b/internal/log_analysis/log_processor/parsers/osseclogs/eventinfo_test.go
@@ -2,7 +2,7 @@ package osseclogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/osseclogs/osseclogs.go
+++ b/internal/log_analysis/log_processor/parsers/osseclogs/osseclogs.go
@@ -2,7 +2,7 @@ package osseclogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/pantherlog.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog.go
@@ -2,7 +2,7 @@ package parsers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/pantherlog_test.go
+++ b/internal/log_analysis/log_processor/parsers/pantherlog_test.go
@@ -2,7 +2,7 @@ package parsers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/parsers.go
+++ b/internal/log_analysis/log_processor/parsers/parsers.go
@@ -2,7 +2,7 @@ package parsers
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/slacklogs/accesslogs.go
+++ b/internal/log_analysis/log_processor/parsers/slacklogs/accesslogs.go
@@ -2,7 +2,7 @@ package slacklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/slacklogs/auditlogs.go
+++ b/internal/log_analysis/log_processor/parsers/slacklogs/auditlogs.go
@@ -2,7 +2,7 @@ package slacklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/slacklogs/slacklogs.go
+++ b/internal/log_analysis/log_processor/parsers/slacklogs/slacklogs.go
@@ -2,7 +2,7 @@ package slacklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/slacklogs/slacklogs_test.go
+++ b/internal/log_analysis/log_processor/parsers/slacklogs/slacklogs_test.go
@@ -2,7 +2,7 @@ package slacklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/slacklogs/testdata/slacklogs_test.yml
+++ b/internal/log_analysis/log_processor/parsers/slacklogs/testdata/slacklogs_test.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sophoslogs/central.go
+++ b/internal/log_analysis/log_processor/parsers/sophoslogs/central.go
@@ -2,7 +2,7 @@ package sophoslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sophoslogs/central_test.go
+++ b/internal/log_analysis/log_processor/parsers/sophoslogs/central_test.go
@@ -2,7 +2,7 @@ package sophoslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sophoslogs/sophos.go
+++ b/internal/log_analysis/log_processor/parsers/sophoslogs/sophos.go
@@ -2,7 +2,7 @@ package sophoslogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sophoslogs/testdata/central_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/sophoslogs/testdata/central_tests.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/suricatalogs/anomaly.go
+++ b/internal/log_analysis/log_processor/parsers/suricatalogs/anomaly.go
@@ -2,7 +2,7 @@ package suricatalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/suricatalogs/anomaly_test.go
+++ b/internal/log_analysis/log_processor/parsers/suricatalogs/anomaly_test.go
@@ -2,7 +2,7 @@ package suricatalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/suricatalogs/dns.go
+++ b/internal/log_analysis/log_processor/parsers/suricatalogs/dns.go
@@ -2,7 +2,7 @@ package suricatalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/suricatalogs/dns_test.go
+++ b/internal/log_analysis/log_processor/parsers/suricatalogs/dns_test.go
@@ -2,7 +2,7 @@ package suricatalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/suricatalogs/suricatalogs.go
+++ b/internal/log_analysis/log_processor/parsers/suricatalogs/suricatalogs.go
@@ -2,7 +2,7 @@ package suricatalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164.go
@@ -2,7 +2,7 @@ package sysloglogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc3164_test.go
@@ -2,7 +2,7 @@ package sysloglogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424.go
@@ -2,7 +2,7 @@ package sysloglogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424_test.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/rfc5424_test.go
@@ -2,7 +2,7 @@ package sysloglogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/sysloglogs/syslogs.go
+++ b/internal/log_analysis/log_processor/parsers/sysloglogs/syslogs.go
@@ -3,7 +3,7 @@ package sysloglogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/testutil/testutil.go
+++ b/internal/log_analysis/log_processor/parsers/testutil/testutil.go
@@ -2,7 +2,7 @@ package testutil
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/timestamp/timestamp.go
+++ b/internal/log_analysis/log_processor/parsers/timestamp/timestamp.go
@@ -2,7 +2,7 @@ package timestamp
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/timestamp/timestamp_test.go
+++ b/internal/log_analysis/log_processor/parsers/timestamp/timestamp_test.go
@@ -2,7 +2,7 @@ package timestamp
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/dns.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/dns.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/dns_test.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/dns_test.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/firewall.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/firewall.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/firewall_test.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/firewall_test.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/ip.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/ip.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/ip_test.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/ip_test.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/proxy.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/proxy.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/proxy_test.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/proxy_test.go
@@ -2,7 +2,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/umbrellalogs/umbrellalogs.go
+++ b/internal/log_analysis/log_processor/parsers/umbrellalogs/umbrellalogs.go
@@ -3,7 +3,7 @@ package umbrellalogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/zeeklogs/dns.go
+++ b/internal/log_analysis/log_processor/parsers/zeeklogs/dns.go
@@ -2,7 +2,7 @@ package zeeklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/zeeklogs/dns_test.go
+++ b/internal/log_analysis/log_processor/parsers/zeeklogs/dns_test.go
@@ -2,7 +2,7 @@ package zeeklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/parsers/zeeklogs/zeeklogs.go
+++ b/internal/log_analysis/log_processor/parsers/zeeklogs/zeeklogs.go
@@ -2,7 +2,7 @@ package zeeklogs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/preprocessors/csv.go
+++ b/internal/log_analysis/log_processor/preprocessors/csv.go
@@ -2,7 +2,7 @@ package preprocessors
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/preprocessors/fastmatch.go
+++ b/internal/log_analysis/log_processor/preprocessors/fastmatch.go
@@ -2,7 +2,7 @@ package preprocessors
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/preprocessors/preprocessors.go
+++ b/internal/log_analysis/log_processor/preprocessors/preprocessors.go
@@ -3,7 +3,7 @@ package preprocessors
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/preprocessors/regexmatch.go
+++ b/internal/log_analysis/log_processor/preprocessors/regexmatch.go
@@ -2,7 +2,7 @@ package preprocessors
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/preprocessors/text.go
+++ b/internal/log_analysis/log_processor/preprocessors/text.go
@@ -2,7 +2,7 @@ package preprocessors
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/preprocessors/text_test.go
+++ b/internal/log_analysis/log_processor/preprocessors/text_test.go
@@ -2,7 +2,7 @@ package preprocessors
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/logstream/jsonarray.go
+++ b/internal/log_analysis/log_processor/processor/logstream/jsonarray.go
@@ -2,7 +2,7 @@ package logstream
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/logstream/jsonarray_test.go
+++ b/internal/log_analysis/log_processor/processor/logstream/jsonarray_test.go
@@ -2,7 +2,7 @@ package logstream
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/logstream/linestream.go
+++ b/internal/log_analysis/log_processor/processor/logstream/linestream.go
@@ -2,7 +2,7 @@ package logstream
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/logstream/linestream_test.go
+++ b/internal/log_analysis/log_processor/processor/logstream/linestream_test.go
@@ -2,7 +2,7 @@ package logstream
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/processor.go
+++ b/internal/log_analysis/log_processor/processor/processor.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/processor_test.go
+++ b/internal/log_analysis/log_processor/processor/processor_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/rescale.go
+++ b/internal/log_analysis/log_processor/processor/rescale.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/rescale_test.go
+++ b/internal/log_analysis/log_processor/processor/rescale_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/stream.go
+++ b/internal/log_analysis/log_processor/processor/stream.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/processor/stream_test.go
+++ b/internal/log_analysis/log_processor/processor/stream_test.go
@@ -2,7 +2,7 @@ package processor
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/registry/generate_init.go
+++ b/internal/log_analysis/log_processor/registry/generate_init.go
@@ -4,7 +4,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/registry/init.go
+++ b/internal/log_analysis/log_processor/registry/init.go
@@ -3,7 +3,7 @@ package registry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/registry/init_test.go
+++ b/internal/log_analysis/log_processor/registry/init_test.go
@@ -2,7 +2,7 @@ package registry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/registry/internal/generate.go
+++ b/internal/log_analysis/log_processor/registry/internal/generate.go
@@ -2,7 +2,7 @@ package internal
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/registry/registry.go
+++ b/internal/log_analysis/log_processor/registry/registry.go
@@ -2,7 +2,7 @@ package registry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/s3pipe/s3pipe.go
+++ b/internal/log_analysis/log_processor/s3pipe/s3pipe.go
@@ -2,7 +2,7 @@ package s3pipe
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/s3pipe/s3pipe_test.go
+++ b/internal/log_analysis/log_processor/s3pipe/s3pipe_test.go
@@ -2,7 +2,7 @@ package s3pipe
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/message_forwarder_reader.go
+++ b/internal/log_analysis/log_processor/sources/message_forwarder_reader.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/message_forwarder_reader_test.go
+++ b/internal/log_analysis/log_processor/sources/message_forwarder_reader_test.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/s3_client_cache.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/sources.go
+++ b/internal/log_analysis/log_processor/sources/sources.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/sources_test.go
+++ b/internal/log_analysis/log_processor/sources/sources_test.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/sqs.go
+++ b/internal/log_analysis/log_processor/sources/sqs.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/log_processor/sources/sqs_test.go
+++ b/internal/log_analysis/log_processor/sources/sqs_test.go
@@ -2,7 +2,7 @@ package sources
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/message_forwarder/cache/cache.go
+++ b/internal/log_analysis/message_forwarder/cache/cache.go
@@ -2,7 +2,7 @@ package cache
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/message_forwarder/cache/cache_test.go
+++ b/internal/log_analysis/message_forwarder/cache/cache_test.go
@@ -2,7 +2,7 @@ package cache
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/message_forwarder/config/config.go
+++ b/internal/log_analysis/message_forwarder/config/config.go
@@ -2,7 +2,7 @@ package config
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
+++ b/internal/log_analysis/message_forwarder/forwarder/forwarder_test.go
@@ -2,7 +2,7 @@ package forwarder
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/message_forwarder/main/lambda.go
+++ b/internal/log_analysis/message_forwarder/main/lambda.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/notify/s3.go
+++ b/internal/log_analysis/notify/s3.go
@@ -2,7 +2,7 @@ package notify
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/notify/sns.go
+++ b/internal/log_analysis/notify/sns.go
@@ -2,7 +2,7 @@ package notify
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/pantherdb/pantherdb.go
+++ b/internal/log_analysis/pantherdb/pantherdb.go
@@ -2,7 +2,7 @@ package pantherdb
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/__init__.py
+++ b/internal/log_analysis/rules_engine/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/__init__.py
+++ b/internal/log_analysis/rules_engine/src/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/alert_merger.py
+++ b/internal/log_analysis/rules_engine/src/alert_merger.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/analysis_api.py
+++ b/internal/log_analysis/rules_engine/src/analysis_api.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/aws_clients.py
+++ b/internal/log_analysis/rules_engine/src/aws_clients.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/data_model.py
+++ b/internal/log_analysis/rules_engine/src/data_model.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/engine.py
+++ b/internal/log_analysis/rules_engine/src/engine.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/enriched_event.py
+++ b/internal/log_analysis/rules_engine/src/enriched_event.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/logging.py
+++ b/internal/log_analysis/rules_engine/src/logging.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/main.py
+++ b/internal/log_analysis/rules_engine/src/main.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/output.py
+++ b/internal/log_analysis/rules_engine/src/output.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/src/util.py
+++ b/internal/log_analysis/rules_engine/src/util.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/__init__.py
+++ b/internal/log_analysis/rules_engine/tests/__init__.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/test_data_model.py
+++ b/internal/log_analysis/rules_engine/tests/test_data_model.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/test_engine.py
+++ b/internal/log_analysis/rules_engine/tests/test_engine.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/test_enriched_event.py
+++ b/internal/log_analysis/rules_engine/tests/test_enriched_event.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/test_main.py
+++ b/internal/log_analysis/rules_engine/tests/test_main.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/test_output.py
+++ b/internal/log_analysis/rules_engine/tests/test_output.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/magefile.go
+++ b/magefile.go
@@ -4,7 +4,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsathena/integration_test.go
+++ b/pkg/awsathena/integration_test.go
@@ -2,7 +2,7 @@ package awsathena
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsathena/query.go
+++ b/pkg/awsathena/query.go
@@ -2,7 +2,7 @@ package awsathena
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/dynamodbbatch/batch_get_item.go
+++ b/pkg/awsbatch/dynamodbbatch/batch_get_item.go
@@ -2,7 +2,7 @@ package dynamodbbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/dynamodbbatch/batch_get_item_test.go
+++ b/pkg/awsbatch/dynamodbbatch/batch_get_item_test.go
@@ -2,7 +2,7 @@ package dynamodbbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/dynamodbbatch/batch_write_item.go
+++ b/pkg/awsbatch/dynamodbbatch/batch_write_item.go
@@ -2,7 +2,7 @@ package dynamodbbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/dynamodbbatch/batch_write_item_test.go
+++ b/pkg/awsbatch/dynamodbbatch/batch_write_item_test.go
@@ -2,7 +2,7 @@ package dynamodbbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/dynamodbbatch/item_size.go
+++ b/pkg/awsbatch/dynamodbbatch/item_size.go
@@ -2,7 +2,7 @@ package dynamodbbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/dynamodbbatch/item_size_test.go
+++ b/pkg/awsbatch/dynamodbbatch/item_size_test.go
@@ -2,7 +2,7 @@ package dynamodbbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/firehosebatch/firehosebatch.go
+++ b/pkg/awsbatch/firehosebatch/firehosebatch.go
@@ -2,7 +2,7 @@ package firehosebatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/firehosebatch/firehosebatch_test.go
+++ b/pkg/awsbatch/firehosebatch/firehosebatch_test.go
@@ -2,7 +2,7 @@ package firehosebatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/kinesisbatch/put_records.go
+++ b/pkg/awsbatch/kinesisbatch/put_records.go
@@ -2,7 +2,7 @@ package kinesisbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/kinesisbatch/put_records_test.go
+++ b/pkg/awsbatch/kinesisbatch/put_records_test.go
@@ -2,7 +2,7 @@ package kinesisbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/s3batch/delete_objects.go
+++ b/pkg/awsbatch/s3batch/delete_objects.go
@@ -2,7 +2,7 @@ package s3batch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/s3batch/delete_objects_test.go
+++ b/pkg/awsbatch/s3batch/delete_objects_test.go
@@ -2,7 +2,7 @@ package s3batch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/sqsbatch/delete_message_batch.go
+++ b/pkg/awsbatch/sqsbatch/delete_message_batch.go
@@ -2,7 +2,7 @@ package sqsbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/sqsbatch/delete_message_batch_test.go
+++ b/pkg/awsbatch/sqsbatch/delete_message_batch_test.go
@@ -2,7 +2,7 @@ package sqsbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/sqsbatch/send_message_batch.go
+++ b/pkg/awsbatch/sqsbatch/send_message_batch.go
@@ -2,7 +2,7 @@ package sqsbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsbatch/sqsbatch/send_message_batch_test.go
+++ b/pkg/awsbatch/sqsbatch/send_message_batch_test.go
@@ -2,7 +2,7 @@ package sqsbatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awscfn/awscfn.go
+++ b/pkg/awscfn/awscfn.go
@@ -3,7 +3,7 @@ package awscfn
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awscostexplorer/cost.go
+++ b/pkg/awscostexplorer/cost.go
@@ -2,7 +2,7 @@ package awscostexplorer
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsretry/access_denied_retryer.go
+++ b/pkg/awsretry/access_denied_retryer.go
@@ -2,7 +2,7 @@ package awsretry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsretry/access_denied_retryer_test.go
+++ b/pkg/awsretry/access_denied_retryer_test.go
@@ -2,7 +2,7 @@ package awsretry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsretry/connection_retryer.go
+++ b/pkg/awsretry/connection_retryer.go
@@ -2,7 +2,7 @@ package awsretry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsretry/connection_retryer_test.go
+++ b/pkg/awsretry/connection_retryer_test.go
@@ -2,7 +2,7 @@ package awsretry
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awssqs/permissions.go
+++ b/pkg/awssqs/permissions.go
@@ -2,7 +2,7 @@ package awssqs
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -2,7 +2,7 @@ package awsutils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -6,7 +6,7 @@ import "time"
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/encryption/decrypt.go
+++ b/pkg/encryption/decrypt.go
@@ -2,7 +2,7 @@ package encryption
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/encryption/decrypt_test.go
+++ b/pkg/encryption/decrypt_test.go
@@ -2,7 +2,7 @@ package encryption
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/encryption/encrypt.go
+++ b/pkg/encryption/encrypt.go
@@ -2,7 +2,7 @@ package encryption
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/encryption/encrypt_test.go
+++ b/pkg/encryption/encrypt_test.go
@@ -2,7 +2,7 @@ package encryption
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/encryption/key.go
+++ b/pkg/encryption/key.go
@@ -3,7 +3,7 @@ package encryption
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/encryption/key_test.go
+++ b/pkg/encryption/key_test.go
@@ -2,7 +2,7 @@ package encryption
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/extract/extractor.go
+++ b/pkg/extract/extractor.go
@@ -2,7 +2,7 @@ package extract
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/extract/extractor_test.go
+++ b/pkg/extract/extractor_test.go
@@ -2,7 +2,7 @@ package extract
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/gatewayapi/invoke.go
+++ b/pkg/gatewayapi/invoke.go
@@ -2,7 +2,7 @@ package gatewayapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/gatewayapi/mock.go
+++ b/pkg/gatewayapi/mock.go
@@ -2,7 +2,7 @@ package gatewayapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/gatewayapi/router.go
+++ b/pkg/gatewayapi/router.go
@@ -2,7 +2,7 @@ package gatewayapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/errors.go
+++ b/pkg/genericapi/errors.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/errors_test.go
+++ b/pkg/genericapi/errors_test.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/invoke.go
+++ b/pkg/genericapi/invoke.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/invoke_test.go
+++ b/pkg/genericapi/invoke_test.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/redact.go
+++ b/pkg/genericapi/redact.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/redact_test.go
+++ b/pkg/genericapi/redact_test.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/replace_nils.go
+++ b/pkg/genericapi/replace_nils.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/replace_nils_test.go
+++ b/pkg/genericapi/replace_nils_test.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/router.go
+++ b/pkg/genericapi/router.go
@@ -3,7 +3,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/router_test.go
+++ b/pkg/genericapi/router_test.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/verify.go
+++ b/pkg/genericapi/verify.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/genericapi/verify_test.go
+++ b/pkg/genericapi/verify_test.go
@@ -2,7 +2,7 @@ package genericapi
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/lambdalogger/lambdalogger.go
+++ b/pkg/lambdalogger/lambdalogger.go
@@ -2,7 +2,7 @@ package lambdalogger
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/lambdalogger/logger.go
+++ b/pkg/lambdalogger/logger.go
@@ -3,7 +3,7 @@ package lambdalogger
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/lambdalogger/logger_test.go
+++ b/pkg/lambdalogger/logger_test.go
@@ -2,7 +2,7 @@ package lambdalogger
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/metrics/logger.go
+++ b/pkg/metrics/logger.go
@@ -2,7 +2,7 @@ package metrics
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/oplog/oplog.go
+++ b/pkg/oplog/oplog.go
@@ -25,7 +25,7 @@ package oplog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/oplog/oplog_test.go
+++ b/pkg/oplog/oplog_test.go
@@ -2,7 +2,7 @@ package oplog
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/priorityq/priorityq.go
+++ b/pkg/priorityq/priorityq.go
@@ -2,7 +2,7 @@ package priorityq
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/priorityq/priorityq_test.go
+++ b/pkg/priorityq/priorityq_test.go
@@ -2,7 +2,7 @@ package priorityq
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -5,7 +5,7 @@ package prompt
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/shutil/archive.go
+++ b/pkg/shutil/archive.go
@@ -2,7 +2,7 @@ package shutil
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/stringset/stringset.go
+++ b/pkg/stringset/stringset.go
@@ -2,7 +2,7 @@ package stringset
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/stringset/stringset_test.go
+++ b/pkg/stringset/stringset_test.go
@@ -2,7 +2,7 @@ package stringset
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -2,7 +2,7 @@ package testutils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/testutils/clear.go
+++ b/pkg/testutils/clear.go
@@ -2,7 +2,7 @@ package testutils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/testutils/gatewayapi.go
+++ b/pkg/testutils/gatewayapi.go
@@ -8,7 +8,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/testutils/integration.go
+++ b/pkg/testutils/integration.go
@@ -2,7 +2,7 @@ package testutils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/testutils/metrics.go
+++ b/pkg/testutils/metrics.go
@@ -2,7 +2,7 @@ package testutils
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/unbox/unbox.go
+++ b/pkg/unbox/unbox.go
@@ -5,7 +5,7 @@ import "time"
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/apigen/apigen.go
+++ b/pkg/x/apigen/apigen.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/apigen/internal/methods.go
+++ b/pkg/x/apigen/internal/methods.go
@@ -2,7 +2,7 @@ package internal
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/apigen/internal/models.go
+++ b/pkg/x/apigen/internal/models.go
@@ -2,7 +2,7 @@ package internal
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/apigen/templates.go
+++ b/pkg/x/apigen/templates.go
@@ -2,7 +2,7 @@ package main
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/fastmatch/fastmatch.go
+++ b/pkg/x/fastmatch/fastmatch.go
@@ -2,7 +2,7 @@ package fastmatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/fastmatch/fastmatch_benchmark_test.go
+++ b/pkg/x/fastmatch/fastmatch_benchmark_test.go
@@ -2,7 +2,7 @@ package fastmatch_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/fastmatch/fastmatch_test.go
+++ b/pkg/x/fastmatch/fastmatch_test.go
@@ -2,7 +2,7 @@ package fastmatch
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/gork/builtin.go
+++ b/pkg/x/gork/builtin.go
@@ -2,7 +2,7 @@ package gork
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/gork/builtin_test.go
+++ b/pkg/x/gork/builtin_test.go
@@ -2,7 +2,7 @@ package gork
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/gork/gork.go
+++ b/pkg/x/gork/gork.go
@@ -2,7 +2,7 @@ package gork
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/gork/gork_benchmark_test.go
+++ b/pkg/x/gork/gork_benchmark_test.go
@@ -2,7 +2,7 @@ package gork_test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/gork/gork_test.go
+++ b/pkg/x/gork/gork_test.go
@@ -2,7 +2,7 @@ package gork
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/lambdamux/lambadmux.go
+++ b/pkg/x/lambdamux/lambadmux.go
@@ -2,7 +2,7 @@ package lambdamux
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/lambdamux/middleware.go
+++ b/pkg/x/lambdamux/middleware.go
@@ -2,7 +2,7 @@ package lambdamux
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/lambdamux/mux.go
+++ b/pkg/x/lambdamux/mux.go
@@ -2,7 +2,7 @@ package lambdamux
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/lambdamux/mux_test.go
+++ b/pkg/x/lambdamux/mux_test.go
@@ -2,7 +2,7 @@ package lambdamux
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/lambdamux/route.go
+++ b/pkg/x/lambdamux/route.go
@@ -2,7 +2,7 @@ package lambdamux
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pkg/x/lambdamux/route_test.go
+++ b/pkg/x/lambdamux/route_test.go
@@ -2,7 +2,7 @@ package lambdamux
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/cfnstacks/cfnstacks.go
+++ b/tools/cfnstacks/cfnstacks.go
@@ -13,7 +13,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/build/lambda.go
+++ b/tools/mage/build/lambda.go
@@ -2,7 +2,7 @@ package build
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/build/layer.go
+++ b/tools/mage/build/layer.go
@@ -2,7 +2,7 @@ package build
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/build/tools.go
+++ b/tools/mage/build/tools.go
@@ -2,7 +2,7 @@ package build
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/clean/clean.go
+++ b/tools/mage/clean/clean.go
@@ -2,7 +2,7 @@ package clean
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/clients/aws.go
+++ b/tools/mage/clients/aws.go
@@ -3,7 +3,7 @@ package clients
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/deploy/config.go
+++ b/tools/mage/deploy/config.go
@@ -2,7 +2,7 @@ package deploy
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/deploy/deploy.go
+++ b/tools/mage/deploy/deploy.go
@@ -2,7 +2,7 @@ package deploy
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/deploy/deploy_template.go
+++ b/tools/mage/deploy/deploy_template.go
@@ -2,7 +2,7 @@ package deploy
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/deploy/frontend.go
+++ b/tools/mage/deploy/frontend.go
@@ -2,7 +2,7 @@ package deploy
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/doc/cfndoc.go
+++ b/tools/mage/doc/cfndoc.go
@@ -2,7 +2,7 @@ package doc
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/doc/cfndoc_test.go
+++ b/tools/mage/doc/cfndoc_test.go
@@ -2,7 +2,7 @@ package doc
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/doc/doc.go
+++ b/tools/mage/doc/doc.go
@@ -2,7 +2,7 @@ package doc
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/doc/doc_test.go
+++ b/tools/mage/doc/doc_test.go
@@ -2,7 +2,7 @@ package doc
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/gen/dashboards/dashboards.go
+++ b/tools/mage/gen/dashboards/dashboards.go
@@ -2,7 +2,7 @@ package dashboards
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/gen/dashboards/dashboards_test.go
+++ b/tools/mage/gen/dashboards/dashboards_test.go
@@ -2,7 +2,7 @@ package dashboards
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/gen/dashboards/log_processing.go
+++ b/tools/mage/gen/dashboards/log_processing.go
@@ -2,7 +2,7 @@ package dashboards
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/gen/gen.go
+++ b/tools/mage/gen/gen.go
@@ -2,7 +2,7 @@ package gen
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/logger/logger.go
+++ b/tools/mage/logger/logger.go
@@ -2,7 +2,7 @@ package logger
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/master/build.go
+++ b/tools/mage/master/build.go
@@ -2,7 +2,7 @@ package master
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/master/deploy.go
+++ b/tools/mage/master/deploy.go
@@ -2,7 +2,7 @@ package master
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/master/publish.go
+++ b/tools/mage/master/publish.go
@@ -2,7 +2,7 @@ package master
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/setup/setup.go
+++ b/tools/mage/setup/setup.go
@@ -2,7 +2,7 @@ package setup
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/srcfmt/fmt.go
+++ b/tools/mage/srcfmt/fmt.go
@@ -2,7 +2,7 @@ package srcfmt
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/srcfmt/fmt_license.go
+++ b/tools/mage/srcfmt/fmt_license.go
@@ -2,7 +2,7 @@ package srcfmt
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/teardown/cfn.go
+++ b/tools/mage/teardown/cfn.go
@@ -2,7 +2,7 @@ package teardown
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/teardown/s3.go
+++ b/tools/mage/teardown/s3.go
@@ -2,7 +2,7 @@ package teardown
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/teardown/teardown.go
+++ b/tools/mage/teardown/teardown.go
@@ -2,7 +2,7 @@ package teardown
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/test/cfn.go
+++ b/tools/mage/test/cfn.go
@@ -2,7 +2,7 @@ package test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/test/ci.go
+++ b/tools/mage/test/ci.go
@@ -2,7 +2,7 @@ package test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/test/go.go
+++ b/tools/mage/test/go.go
@@ -2,7 +2,7 @@ package test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/test/integration.go
+++ b/tools/mage/test/integration.go
@@ -2,7 +2,7 @@ package test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/test/python.go
+++ b/tools/mage/test/python.go
@@ -2,7 +2,7 @@ package test
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/test/web.go
+++ b/tools/mage/test/web.go
@@ -7,7 +7,7 @@ import (
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/util/cfnparse.go
+++ b/tools/mage/util/cfnparse.go
@@ -2,7 +2,7 @@ package util
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/util/files.go
+++ b/tools/mage/util/files.go
@@ -2,7 +2,7 @@ package util
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/util/run.go
+++ b/tools/mage/util/run.go
@@ -2,7 +2,7 @@ package util
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/util/s3.go
+++ b/tools/mage/util/s3.go
@@ -2,7 +2,7 @@ package util
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/util/task.go
+++ b/tools/mage/util/task.go
@@ -2,7 +2,7 @@ package util
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/mage/util/version.go
+++ b/tools/mage/util/version.go
@@ -2,7 +2,7 @@ package util
 
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/__mocks__/@reach/dialog.tsx
+++ b/web/__tests__/__mocks__/@reach/dialog.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/__mocks__/file.ts
+++ b/web/__tests__/__mocks__/file.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/__mocks__/react-spring.ts
+++ b/web/__tests__/__mocks__/react-spring.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/example.test.tsx
+++ b/web/__tests__/example.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/jest.config.js
+++ b/web/__tests__/jest.config.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/setupEnv.ts
+++ b/web/__tests__/setupEnv.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/setupPantherConfig.ts
+++ b/web/__tests__/setupPantherConfig.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/setupTests.ts
+++ b/web/__tests__/setupTests.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/utils/auth.ts
+++ b/web/__tests__/utils/auth.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/utils/helpers.ts
+++ b/web/__tests__/utils/helpers.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/utils/index.ts
+++ b/web/__tests__/utils/index.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/utils/queries.ts
+++ b/web/__tests__/utils/queries.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/__tests__/utils/render.tsx
+++ b/web/__tests__/utils/render.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/codegen.yml
+++ b/web/codegen.yml
@@ -1,5 +1,5 @@
 # Panther is a Cloud-Native SIEM for the Modern Security Team.
-# Copyright (C) 2020 Panther Labs Inc
+# Copyright (C) 2021 Panther Labs Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/web/codegen/addLicenseHeaderPlugin.js
+++ b/web/codegen/addLicenseHeaderPlugin.js
@@ -1,7 +1,6 @@
-'use strict';
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -16,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+'use strict';
 var __awaiter =
   (this && this.__awaiter) ||
   function (thisArg, _arguments, P, generator) {

--- a/web/codegen/addLicenseHeaderPlugin.ts
+++ b/web/codegen/addLicenseHeaderPlugin.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/codegen/buildGraphqlResourcesPlugin.js
+++ b/web/codegen/buildGraphqlResourcesPlugin.js
@@ -1,7 +1,6 @@
-'use strict';
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -16,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+'use strict';
 var __importDefault =
   (this && this.__importDefault) ||
   function (mod) {

--- a/web/codegen/buildGraphqlResourcesPlugin.ts
+++ b/web/codegen/buildGraphqlResourcesPlugin.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/codegen/mockGraphqlOperationsPlugin.js
+++ b/web/codegen/mockGraphqlOperationsPlugin.js
@@ -1,8 +1,6 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,6 +15,9 @@ Object.defineProperty(exports, '__esModule', { value: true });
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
 const graphql_1 = require('graphql');
 const visitor_plugin_common_1 = require('@graphql-codegen/visitor-plugin-common');
 /**

--- a/web/codegen/mockGraphqlOperationsPlugin.ts
+++ b/web/codegen/mockGraphqlOperationsPlugin.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/lint-staged.config.js
+++ b/web/lint-staged.config.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/scripts/build.js
+++ b/web/scripts/build.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/scripts/serve.js
+++ b/web/scripts/serve.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/scripts/start.js
+++ b/web/scripts/start.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/scripts/utils.js
+++ b/web/scripts/utils.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/authLink.ts
+++ b/web/src/apollo/authLink.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/cleanParamsLink.ts
+++ b/web/src/apollo/cleanParamsLink.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/createApolloClient.ts
+++ b/web/src/apollo/createApolloClient.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/createErrorLink.ts
+++ b/web/src/apollo/createErrorLink.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/httpLink.ts
+++ b/web/src/apollo/httpLink.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/index.ts
+++ b/web/src/apollo/index.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/apollo/typePolicies.ts
+++ b/web/src/apollo/typePolicies.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/AuthPageContainer/AuthPageContainer.tsx
+++ b/web/src/components/AuthPageContainer/AuthPageContainer.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/AuthPageContainer/index.tsx
+++ b/web/src/components/AuthPageContainer/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BorderedTab/BorderTabDivider.tsx
+++ b/web/src/components/BorderedTab/BorderTabDivider.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BorderedTab/BorderedTab.test.tsx
+++ b/web/src/components/BorderedTab/BorderedTab.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BorderedTab/BorderedTab.tsx
+++ b/web/src/components/BorderedTab/BorderedTab.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BorderedTab/index.tsx
+++ b/web/src/components/BorderedTab/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/web/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Breadcrumbs/index.tsx
+++ b/web/src/components/Breadcrumbs/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BulletedValue/BulletedValue.test.tsx
+++ b/web/src/components/BulletedValue/BulletedValue.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BulletedValue/BulletedValue.tsx
+++ b/web/src/components/BulletedValue/BulletedValue.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BulletedValue/index.tsx
+++ b/web/src/components/BulletedValue/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BulletedValueList/BulletedValueList.test.tsx
+++ b/web/src/components/BulletedValueList/BulletedValueList.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BulletedValueList/BulletedValueList.tsx
+++ b/web/src/components/BulletedValueList/BulletedValueList.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/BulletedValueList/index.tsx
+++ b/web/src/components/BulletedValueList/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Editor/Editor.tsx
+++ b/web/src/components/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Editor/__mocks__/Editor.tsx
+++ b/web/src/components/Editor/__mocks__/Editor.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Editor/__mocks__/index.tsx
+++ b/web/src/components/Editor/__mocks__/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Editor/index.tsx
+++ b/web/src/components/Editor/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Editor/theme.ts
+++ b/web/src/components/Editor/theme.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/ErrorBoundary/index.tsx
+++ b/web/src/components/ErrorBoundary/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/FieldPolicyChecker/FieldPolicyCheck.tsx
+++ b/web/src/components/FieldPolicyChecker/FieldPolicyCheck.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/FieldPolicyChecker/FieldPolicyChecker.test.tsx
+++ b/web/src/components/FieldPolicyChecker/FieldPolicyChecker.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/FieldPolicyChecker/FieldPolicyChecker.tsx
+++ b/web/src/components/FieldPolicyChecker/FieldPolicyChecker.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/FieldPolicyChecker/index.tsx
+++ b/web/src/components/FieldPolicyChecker/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Footer/index.tsx
+++ b/web/src/components/Footer/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/GenericItemCard/GenericItemCard.test.tsx
+++ b/web/src/components/GenericItemCard/GenericItemCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/GenericItemCard/GenericItemCard.tsx
+++ b/web/src/components/GenericItemCard/GenericItemCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/GenericItemCard/index.tsx
+++ b/web/src/components/GenericItemCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/GuardedRoute/GuardedRoute.tsx
+++ b/web/src/components/GuardedRoute/GuardedRoute.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/GuardedRoute/index.tsx
+++ b/web/src/components/GuardedRoute/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Header/index.tsx
+++ b/web/src/components/Header/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/JsonViewer/JsonViewer.test.tsx
+++ b/web/src/components/JsonViewer/JsonViewer.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/JsonViewer/JsonViewer.tsx
+++ b/web/src/components/JsonViewer/JsonViewer.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/JsonViewer/index.tsx
+++ b/web/src/components/JsonViewer/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Layout/index.tsx
+++ b/web/src/components/Layout/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/LimitItemDisplay/LimitItemDisplay.test.tsx
+++ b/web/src/components/LimitItemDisplay/LimitItemDisplay.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/LimitItemDisplay/LimitItemDisplay.tsx
+++ b/web/src/components/LimitItemDisplay/LimitItemDisplay.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/LimitItemDisplay/index.tsx
+++ b/web/src/components/LimitItemDisplay/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Linkify/Linkify.tsx
+++ b/web/src/components/Linkify/Linkify.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Linkify/index.tsx
+++ b/web/src/components/Linkify/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/NavGroup/NavGroup.test.tsx
+++ b/web/src/components/Navigation/NavGroup/NavGroup.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/NavGroup/NavGroup.tsx
+++ b/web/src/components/Navigation/NavGroup/NavGroup.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/NavGroup/index.tsx
+++ b/web/src/components/Navigation/NavGroup/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/NavLink/NavLink.test.tsx
+++ b/web/src/components/Navigation/NavLink/NavLink.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/NavLink/NavLink.tsx
+++ b/web/src/components/Navigation/NavLink/NavLink.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/NavLink/index.tsx
+++ b/web/src/components/Navigation/NavLink/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/Navigation.test.tsx
+++ b/web/src/components/Navigation/Navigation.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/ProfileInfo/ProfileInfo.test.tsx
+++ b/web/src/components/Navigation/ProfileInfo/ProfileInfo.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/ProfileInfo/ProfileInfo.tsx
+++ b/web/src/components/Navigation/ProfileInfo/ProfileInfo.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/ProfileInfo/index.tsx
+++ b/web/src/components/Navigation/ProfileInfo/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/SecondaryNavigations/ComplianceNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/ComplianceNavigation.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/SecondaryNavigations/LogAnalysisNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/LogAnalysisNavigation.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/SecondaryNavigations/SettingsNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/SettingsNavigation.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/SecondaryNavigations/index.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Navigation/index.ts
+++ b/web/src/components/Navigation/index.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NoDataFound/NoDataFound.test.tsx
+++ b/web/src/components/NoDataFound/NoDataFound.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NoDataFound/NoDataFound.tsx
+++ b/web/src/components/NoDataFound/NoDataFound.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NoDataFound/index.tsx
+++ b/web/src/components/NoDataFound/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NoResultsFound/NoResultsFound.test.tsx
+++ b/web/src/components/NoResultsFound/NoResultsFound.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NoResultsFound/NoResultsFound.tsx
+++ b/web/src/components/NoResultsFound/NoResultsFound.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NoResultsFound/index.tsx
+++ b/web/src/components/NoResultsFound/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NotificationJewel/NotificationJewel.tsx
+++ b/web/src/components/NotificationJewel/NotificationJewel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/NotificationJewel/index.tsx
+++ b/web/src/components/NotificationJewel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Panel/Panel.tsx
+++ b/web/src/components/Panel/Panel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Panel/PanelPlaceholder.tsx
+++ b/web/src/components/Panel/PanelPlaceholder.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Panel/index.tsx
+++ b/web/src/components/Panel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/RelatedDestinations/RelatedDestinations.test.tsx
+++ b/web/src/components/RelatedDestinations/RelatedDestinations.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/RelatedDestinations/RelatedDestinations.tsx
+++ b/web/src/components/RelatedDestinations/RelatedDestinations.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/RelatedDestinations/index.tsx
+++ b/web/src/components/RelatedDestinations/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/TablePlaceholder/TablePlaceholder.tsx
+++ b/web/src/components/TablePlaceholder/TablePlaceholder.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/TablePlaceholder/index.tsx
+++ b/web/src/components/TablePlaceholder/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Wizard/Wizard.test.tsx
+++ b/web/src/components/Wizard/Wizard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Wizard/Wizard.tsx
+++ b/web/src/components/Wizard/Wizard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Wizard/WizardContext.tsx
+++ b/web/src/components/Wizard/WizardContext.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Wizard/WizardPanel.tsx
+++ b/web/src/components/Wizard/WizardPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/Wizard/index.tsx
+++ b/web/src/components/Wizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/AlertStatusBadge/AlertStatusBadge.tsx
+++ b/web/src/components/badges/AlertStatusBadge/AlertStatusBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/AlertStatusBadge/index.tsx
+++ b/web/src/components/badges/AlertStatusBadge/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/SeverityBadge/SeverityBadge.tsx
+++ b/web/src/components/badges/SeverityBadge/SeverityBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/SeverityBadge/index.tsx
+++ b/web/src/components/badges/SeverityBadge/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/SourceHealthBadge/SourceHealthBadge.test.tsx
+++ b/web/src/components/badges/SourceHealthBadge/SourceHealthBadge.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/SourceHealthBadge/SourceHealthBadge.tsx
+++ b/web/src/components/badges/SourceHealthBadge/SourceHealthBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/SourceHealthBadge/index.tsx
+++ b/web/src/components/badges/SourceHealthBadge/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/StatusBadge/StatusBadge.tsx
+++ b/web/src/components/badges/StatusBadge/StatusBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/badges/StatusBadge/index.tsx
+++ b/web/src/components/badges/StatusBadge/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/buttons/LinkButton/LinkButton.tsx
+++ b/web/src/components/buttons/LinkButton/LinkButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/buttons/LinkButton/index.tsx
+++ b/web/src/components/buttons/LinkButton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/buttons/SubmitButton/SubmitButton.tsx
+++ b/web/src/components/buttons/SubmitButton/SubmitButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/buttons/SubmitButton/index.tsx
+++ b/web/src/components/buttons/SubmitButton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/buttons/TextButton/TextButton.tsx
+++ b/web/src/components/buttons/TextButton/TextButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/buttons/TextButton/index.tsx
+++ b/web/src/components/buttons/TextButton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/AlertCard.tsx
+++ b/web/src/components/cards/AlertCard/AlertCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/PolicyAlertCard/PolicyAlertCard.test.tsx
+++ b/web/src/components/cards/AlertCard/PolicyAlertCard/PolicyAlertCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/PolicyAlertCard/PolicyAlertCard.tsx
+++ b/web/src/components/cards/AlertCard/PolicyAlertCard/PolicyAlertCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/PolicyAlertCard/index.tsx
+++ b/web/src/components/cards/AlertCard/PolicyAlertCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/RuleAlertCard/RuleAlertCard.test.tsx
+++ b/web/src/components/cards/AlertCard/RuleAlertCard/RuleAlertCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/RuleAlertCard/RuleAlertCard.tsx
+++ b/web/src/components/cards/AlertCard/RuleAlertCard/RuleAlertCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/RuleAlertCard/index.tsx
+++ b/web/src/components/cards/AlertCard/RuleAlertCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/AlertCard/index.tsx
+++ b/web/src/components/cards/AlertCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/RuleCard/RuleCard.test.tsx
+++ b/web/src/components/cards/RuleCard/RuleCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/RuleCard/RuleCard.tsx
+++ b/web/src/components/cards/RuleCard/RuleCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/RuleCard/RuleCardOptions/RuleCardOptions.tsx
+++ b/web/src/components/cards/RuleCard/RuleCardOptions/RuleCardOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/RuleCard/RuleCardOptions/index.tsx
+++ b/web/src/components/cards/RuleCard/RuleCardOptions/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/cards/RuleCard/index.tsx
+++ b/web/src/components/cards/RuleCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/BarChart/BarChart.tsx
+++ b/web/src/components/charts/BarChart/BarChart.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/BarChart/index.tsx
+++ b/web/src/components/charts/BarChart/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/BarChart/useBarChartSpacing.tsx
+++ b/web/src/components/charts/BarChart/useBarChartSpacing.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ChartSummary/ChartSummary.tsx
+++ b/web/src/components/charts/ChartSummary/ChartSummary.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ChartSummary/index.tsx
+++ b/web/src/components/charts/ChartSummary/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ResetButton/ResetButton.tsx
+++ b/web/src/components/charts/ResetButton/ResetButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ResetButton/index.tsx
+++ b/web/src/components/charts/ResetButton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ScaleControls/ScaleButton.tsx
+++ b/web/src/components/charts/ScaleControls/ScaleButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ScaleControls/ScaleControls.tsx
+++ b/web/src/components/charts/ScaleControls/ScaleControls.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/ScaleControls/index.tsx
+++ b/web/src/components/charts/ScaleControls/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/TimeSeriesChart/ChartTooltip.tsx
+++ b/web/src/components/charts/TimeSeriesChart/ChartTooltip.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart/TimeSeriesChart.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/TimeSeriesChart/index.tsx
+++ b/web/src/components/charts/TimeSeriesChart/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/charts/TimeSeriesChart/useChartOptions.tsx
+++ b/web/src/components/charts/TimeSeriesChart/useChartOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/dropdowns/UpdateAlertDropdown/UpdateAlertDropdown.tsx
+++ b/web/src/components/dropdowns/UpdateAlertDropdown/UpdateAlertDropdown.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/dropdowns/UpdateAlertDropdown/index.tsx
+++ b/web/src/components/dropdowns/UpdateAlertDropdown/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Checkbox/Checkbox.tsx
+++ b/web/src/components/fields/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Checkbox/index.tsx
+++ b/web/src/components/fields/Checkbox/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/ComboBox/ComboBox.tsx
+++ b/web/src/components/fields/ComboBox/ComboBox.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/ComboBox/index.tsx
+++ b/web/src/components/fields/ComboBox/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/DateRangeInput/DateRangeInput.test.tsx
+++ b/web/src/components/fields/DateRangeInput/DateRangeInput.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/DateRangeInput/DateRangeInput.tsx
+++ b/web/src/components/fields/DateRangeInput/DateRangeInput.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/DateRangeInput/index.tsx
+++ b/web/src/components/fields/DateRangeInput/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Editor/Editor.tsx
+++ b/web/src/components/fields/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Editor/index.tsx
+++ b/web/src/components/fields/Editor/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/MultiComboBox/MultiComboBox.tsx
+++ b/web/src/components/fields/MultiComboBox/MultiComboBox.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/MultiComboBox/index.tsx
+++ b/web/src/components/fields/MultiComboBox/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/NumberInput/NumberInput.tsx
+++ b/web/src/components/fields/NumberInput/NumberInput.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/NumberInput/index.tsx
+++ b/web/src/components/fields/NumberInput/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Radio/Radio.tsx
+++ b/web/src/components/fields/Radio/Radio.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Radio/index.tsx
+++ b/web/src/components/fields/Radio/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/SensitiveTextInput/SensitiveTextInput.test.tsx
+++ b/web/src/components/fields/SensitiveTextInput/SensitiveTextInput.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/SensitiveTextInput/SensitiveTextInput.tsx
+++ b/web/src/components/fields/SensitiveTextInput/SensitiveTextInput.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/SensitiveTextInput/index.tsx
+++ b/web/src/components/fields/SensitiveTextInput/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Switch/Switch.tsx
+++ b/web/src/components/fields/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/Switch/index.tsx
+++ b/web/src/components/fields/Switch/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/TextArea/TextArea.tsx
+++ b/web/src/components/fields/TextArea/TextArea.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/TextArea/index.tsx
+++ b/web/src/components/fields/TextArea/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/TextInput/TextInput.tsx
+++ b/web/src/components/fields/TextInput/TextInput.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/fields/TextInput/index.tsx
+++ b/web/src/components/fields/TextInput/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/AnalyticsConsentForm/AnalyticsConsentForm.tsx
+++ b/web/src/components/forms/AnalyticsConsentForm/AnalyticsConsentForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/AnalyticsConsentForm/AnalyticsConsentSection.tsx
+++ b/web/src/components/forms/AnalyticsConsentForm/AnalyticsConsentSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/AnalyticsConsentForm/index.tsx
+++ b/web/src/components/forms/AnalyticsConsentForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/AsanaDestinationForm/AsanaDestinationForm.test.tsx
+++ b/web/src/components/forms/AsanaDestinationForm/AsanaDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/AsanaDestinationForm/AsanaDestinationForm.tsx
+++ b/web/src/components/forms/AsanaDestinationForm/AsanaDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/AsanaDestinationForm/index.tsx
+++ b/web/src/components/forms/AsanaDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
+++ b/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseDestinationForm/index.tsx
+++ b/web/src/components/forms/BaseDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/BaseRuleFormCoreSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/BaseRuleFormCoreSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/index.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormEditorSection/BaseRuleFormEditorSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormEditorSection/BaseRuleFormEditorSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormEditorSection/index.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormEditorSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/BaseRuleFormTestSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/BaseRuleFormTestSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/index.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormTestSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/index.tsx
+++ b/web/src/components/forms/BaseRuleForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/BaseRuleForm/useListAvailableDestinations.tsx
+++ b/web/src/components/forms/BaseRuleForm/useListAvailableDestinations.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ChangePasswordForm/ChangePasswordForm.test.tsx
+++ b/web/src/components/forms/ChangePasswordForm/ChangePasswordForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/web/src/components/forms/ChangePasswordForm/ChangePasswordForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ChangePasswordForm/index.tsx
+++ b/web/src/components/forms/ChangePasswordForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CompanyInformationForm/CompanyInformationForm.tsx
+++ b/web/src/components/forms/CompanyInformationForm/CompanyInformationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CompanyInformationForm/index.tsx
+++ b/web/src/components/forms/CompanyInformationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomLogForm/CustomLogForm.test.tsx
+++ b/web/src/components/forms/CustomLogForm/CustomLogForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomLogForm/CustomLogForm.tsx
+++ b/web/src/components/forms/CustomLogForm/CustomLogForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomLogForm/ValidateButton/ValidateButton.tsx
+++ b/web/src/components/forms/CustomLogForm/ValidateButton/ValidateButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomLogForm/ValidateButton/index.tsx
+++ b/web/src/components/forms/CustomLogForm/ValidateButton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomLogForm/index.tsx
+++ b/web/src/components/forms/CustomLogForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomWebhookDestinationForm/CustomWebhookDestinationForm.test.tsx
+++ b/web/src/components/forms/CustomWebhookDestinationForm/CustomWebhookDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomWebhookDestinationForm/CustomWebhookDestinationForm.tsx
+++ b/web/src/components/forms/CustomWebhookDestinationForm/CustomWebhookDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/CustomWebhookDestinationForm/index.tsx
+++ b/web/src/components/forms/CustomWebhookDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/DataModelForm/DataModelForm.test.tsx
+++ b/web/src/components/forms/DataModelForm/DataModelForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/DataModelForm/DataModelForm.tsx
+++ b/web/src/components/forms/DataModelForm/DataModelForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/DataModelForm/index.tsx
+++ b/web/src/components/forms/DataModelForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/DestinationFormSwitcher/DestinationFormSwitcher.tsx
+++ b/web/src/components/forms/DestinationFormSwitcher/DestinationFormSwitcher.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/DestinationFormSwitcher/index.tsx
+++ b/web/src/components/forms/DestinationFormSwitcher/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/EditProfileForm/EditProfileForm.tsx
+++ b/web/src/components/forms/EditProfileForm/EditProfileForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/EditProfileForm/index.tsx
+++ b/web/src/components/forms/EditProfileForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ForgotPasswordConfirmForm/ForgotPasswordConfirmForm.test.tsx
+++ b/web/src/components/forms/ForgotPasswordConfirmForm/ForgotPasswordConfirmForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ForgotPasswordConfirmForm/ForgotPasswordConfirmForm.tsx
+++ b/web/src/components/forms/ForgotPasswordConfirmForm/ForgotPasswordConfirmForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ForgotPasswordConfirmForm/index.tsx
+++ b/web/src/components/forms/ForgotPasswordConfirmForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.test.tsx
+++ b/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/ForgotPasswordForm/index.tsx
+++ b/web/src/components/forms/ForgotPasswordForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/GithubDestinationForm/GithubDestinationForm.test.tsx
+++ b/web/src/components/forms/GithubDestinationForm/GithubDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/GithubDestinationForm/GithubDestinationForm.tsx
+++ b/web/src/components/forms/GithubDestinationForm/GithubDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/GithubDestinationForm/index.tsx
+++ b/web/src/components/forms/GithubDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/GlobalPythonModuleForm/GlobalPythonModuleForm.tsx
+++ b/web/src/components/forms/GlobalPythonModuleForm/GlobalPythonModuleForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/GlobalPythonModuleForm/index.tsx
+++ b/web/src/components/forms/GlobalPythonModuleForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/JiraDestinationForm/JiraDestinationForm.test.tsx
+++ b/web/src/components/forms/JiraDestinationForm/JiraDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/JiraDestinationForm/JiraDestinationForm.tsx
+++ b/web/src/components/forms/JiraDestinationForm/JiraDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/JiraDestinationForm/index.tsx
+++ b/web/src/components/forms/JiraDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/MfaForm/MfaForm.tsx
+++ b/web/src/components/forms/MfaForm/MfaForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/MfaForm/index.tsx
+++ b/web/src/components/forms/MfaForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.test.tsx
+++ b/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.tsx
+++ b/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/MicrosoftTeamsDestinationForm/index.tsx
+++ b/web/src/components/forms/MicrosoftTeamsDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/OpsgenieDestinationForm/OpsGenieDestinationForm.test.tsx
+++ b/web/src/components/forms/OpsgenieDestinationForm/OpsGenieDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/OpsgenieDestinationForm/OpsgenieDestinationForm.tsx
+++ b/web/src/components/forms/OpsgenieDestinationForm/OpsgenieDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/OpsgenieDestinationForm/index.tsx
+++ b/web/src/components/forms/OpsgenieDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PagerdutyDestinationForm/PagerdutyDestinationForm.test.tsx
+++ b/web/src/components/forms/PagerdutyDestinationForm/PagerdutyDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PagerdutyDestinationForm/PagerdutyDestinationForm.tsx
+++ b/web/src/components/forms/PagerdutyDestinationForm/PagerdutyDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PagerdutyDestinationForm/index.tsx
+++ b/web/src/components/forms/PagerdutyDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyForm.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/PolicyFormAutoRemediationFields.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/PolicyFormAutoRemediationFields.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/PolicyFormAutoRemediationSection.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/PolicyFormAutoRemediationSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/graphql/listRemediations.generated.ts
+++ b/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/graphql/listRemediations.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/index.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormAutoRemediationSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestResult/PolicyFormTestResult.test.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestResult/PolicyFormTestResult.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestResult/PolicyFormTestResult.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestResult/PolicyFormTestResult.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestResult/index.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestResult/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestSection/PolicyFormTestSection.test.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestSection/PolicyFormTestSection.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestSection/PolicyFormTestSection.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestSection/PolicyFormTestSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestSection/graphql/testPolicy.generated.ts
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestSection/graphql/testPolicy.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/PolicyFormTestSection/index.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormTestSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/PolicyForm/index.tsx
+++ b/web/src/components/forms/PolicyForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleForm.tsx
+++ b/web/src/components/forms/RuleForm/RuleForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestResult/RuleFormTestResult.test.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestResult/RuleFormTestResult.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestResult/RuleFormTestResult.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestResult/RuleFormTestResult.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestResult/index.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestResult/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestSection/RuleFormTestSection.test.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestSection/RuleFormTestSection.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestSection/RuleFormTestSection.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestSection/RuleFormTestSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestSection/graphql/testRule.generated.ts
+++ b/web/src/components/forms/RuleForm/RuleFormTestSection/graphql/testRule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/RuleFormTestSection/index.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormTestSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/RuleForm/index.tsx
+++ b/web/src/components/forms/RuleForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SetPasswordForm/SetPasswordForm.test.tsx
+++ b/web/src/components/forms/SetPasswordForm/SetPasswordForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SetPasswordForm/SetPasswordForm.tsx
+++ b/web/src/components/forms/SetPasswordForm/SetPasswordForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SetPasswordForm/index.tsx
+++ b/web/src/components/forms/SetPasswordForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SigninForm/SigninForm.tsx
+++ b/web/src/components/forms/SigninForm/SigninForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SigninForm/index.tsx
+++ b/web/src/components/forms/SigninForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.test.tsx
+++ b/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.tsx
+++ b/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SlackDestinationForm/index.tsx
+++ b/web/src/components/forms/SlackDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SnsDestinationForm/SnsDestinationForm.test.tsx
+++ b/web/src/components/forms/SnsDestinationForm/SnsDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SnsDestinationForm/SnsDestinationForm.tsx
+++ b/web/src/components/forms/SnsDestinationForm/SnsDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SnsDestinationForm/index.tsx
+++ b/web/src/components/forms/SnsDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SqsDestinationForm/SqsDestinationForm.test.tsx
+++ b/web/src/components/forms/SqsDestinationForm/SqsDestinationForm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SqsDestinationForm/SqsDestinationForm.tsx
+++ b/web/src/components/forms/SqsDestinationForm/SqsDestinationForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/SqsDestinationForm/index.tsx
+++ b/web/src/components/forms/SqsDestinationForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/TotpForm/TotpForm.tsx
+++ b/web/src/components/forms/TotpForm/TotpForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/TotpForm/index.tsx
+++ b/web/src/components/forms/TotpForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/UserForm/UserForm.tsx
+++ b/web/src/components/forms/UserForm/UserForm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/forms/UserForm/index.tsx
+++ b/web/src/components/forms/UserForm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/AnalyticsConsentModal/AnalyticsConsentModal.tsx
+++ b/web/src/components/modals/AnalyticsConsentModal/AnalyticsConsentModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/AnalyticsConsentModal/graphql/updateGeneralSettingsConsents.generated.ts
+++ b/web/src/components/modals/AnalyticsConsentModal/graphql/updateGeneralSettingsConsents.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/AnalyticsConsentModal/index.tsx
+++ b/web/src/components/modals/AnalyticsConsentModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ConfirmModal/ConfirmModal.tsx
+++ b/web/src/components/modals/ConfirmModal/ConfirmModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ConfirmModal/index.tsx
+++ b/web/src/components/modals/ConfirmModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteComplianceSourceModal/DeleteComplianceSourceModal.tsx
+++ b/web/src/components/modals/DeleteComplianceSourceModal/DeleteComplianceSourceModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteComplianceSourceModal/graphql/deleteComplianceSource.generated.ts
+++ b/web/src/components/modals/DeleteComplianceSourceModal/graphql/deleteComplianceSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteComplianceSourceModal/index.tsx
+++ b/web/src/components/modals/DeleteComplianceSourceModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteCustomLogModal/DeleteCustomLogModal.tsx
+++ b/web/src/components/modals/DeleteCustomLogModal/DeleteCustomLogModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteCustomLogModal/graphql/deleteCustomLog.generated.ts
+++ b/web/src/components/modals/DeleteCustomLogModal/graphql/deleteCustomLog.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteCustomLogModal/index.tsx
+++ b/web/src/components/modals/DeleteCustomLogModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteDestinationModal/DeleteDestinationModal.tsx
+++ b/web/src/components/modals/DeleteDestinationModal/DeleteDestinationModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteDestinationModal/graphql/deleteOutput.generated.ts
+++ b/web/src/components/modals/DeleteDestinationModal/graphql/deleteOutput.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteDestinationModal/index.tsx
+++ b/web/src/components/modals/DeleteDestinationModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteGlobalPythonModuleModal/DeleteGlobalPythonModuleModal.tsx
+++ b/web/src/components/modals/DeleteGlobalPythonModuleModal/DeleteGlobalPythonModuleModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteGlobalPythonModuleModal/graphql/deleteGlobalPythonModule.generated.ts
+++ b/web/src/components/modals/DeleteGlobalPythonModuleModal/graphql/deleteGlobalPythonModule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteGlobalPythonModuleModal/index.tsx
+++ b/web/src/components/modals/DeleteGlobalPythonModuleModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteLogSourceModal/DeleteLogSourceModal.tsx
+++ b/web/src/components/modals/DeleteLogSourceModal/DeleteLogSourceModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteLogSourceModal/graphql/deleteLogSource.generated.ts
+++ b/web/src/components/modals/DeleteLogSourceModal/graphql/deleteLogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteLogSourceModal/index.tsx
+++ b/web/src/components/modals/DeleteLogSourceModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
+++ b/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeletePolicyModal/graphql/deletePolicy.generated.ts
+++ b/web/src/components/modals/DeletePolicyModal/graphql/deletePolicy.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeletePolicyModal/index.tsx
+++ b/web/src/components/modals/DeletePolicyModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
+++ b/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteRuleModal/graphql/deleteRule.generated.ts
+++ b/web/src/components/modals/DeleteRuleModal/graphql/deleteRule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteRuleModal/index.tsx
+++ b/web/src/components/modals/DeleteRuleModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteTestModal/DeleteTestModal.tsx
+++ b/web/src/components/modals/DeleteTestModal/DeleteTestModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteTestModal/index.tsx
+++ b/web/src/components/modals/DeleteTestModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteUserModal/DeleteUserModal.tsx
+++ b/web/src/components/modals/DeleteUserModal/DeleteUserModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteUserModal/graphql/deleteUser.generated.ts
+++ b/web/src/components/modals/DeleteUserModal/graphql/deleteUser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/DeleteUserModal/index.tsx
+++ b/web/src/components/modals/DeleteUserModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/NetworkErrorModal/NetworkErrorModal.tsx
+++ b/web/src/components/modals/NetworkErrorModal/NetworkErrorModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/NetworkErrorModal/index.tsx
+++ b/web/src/components/modals/NetworkErrorModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/OptimisticConfirmModal/OptimisticConfirmModal.tsx
+++ b/web/src/components/modals/OptimisticConfirmModal/OptimisticConfirmModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/OptimisticConfirmModal/index.tsx
+++ b/web/src/components/modals/OptimisticConfirmModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ProfileSettingsModal/ProfileSettingsModal.test.tsx
+++ b/web/src/components/modals/ProfileSettingsModal/ProfileSettingsModal.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ProfileSettingsModal/ProfileSettingsModal.tsx
+++ b/web/src/components/modals/ProfileSettingsModal/ProfileSettingsModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ProfileSettingsModal/index.tsx
+++ b/web/src/components/modals/ProfileSettingsModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ResetUserPasswordModal/ResetUserPasswordModal.tsx
+++ b/web/src/components/modals/ResetUserPasswordModal/ResetUserPasswordModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ResetUserPasswordModal/graphql/resetUserPassword.generated.ts
+++ b/web/src/components/modals/ResetUserPasswordModal/graphql/resetUserPassword.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/modals/ResetUserPasswordModal/index.tsx
+++ b/web/src/components/modals/ResetUserPasswordModal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/sidesheets/EditUserSidesheet/EditUserSidesheet.tsx
+++ b/web/src/components/sidesheets/EditUserSidesheet/EditUserSidesheet.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/sidesheets/EditUserSidesheet/graphql/editUser.generated.ts
+++ b/web/src/components/sidesheets/EditUserSidesheet/graphql/editUser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/sidesheets/EditUserSidesheet/index.tsx
+++ b/web/src/components/sidesheets/EditUserSidesheet/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/sidesheets/UserInvitationSidesheet/UserInvitationSidesheet.tsx
+++ b/web/src/components/sidesheets/UserInvitationSidesheet/UserInvitationSidesheet.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/sidesheets/UserInvitationSidesheet/graphql/inviteUser.generated.ts
+++ b/web/src/components/sidesheets/UserInvitationSidesheet/graphql/inviteUser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/sidesheets/UserInvitationSidesheet/index.tsx
+++ b/web/src/components/sidesheets/UserInvitationSidesheet/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/ApiErrorFallback/ApiErrorFallback.tsx
+++ b/web/src/components/utils/ApiErrorFallback/ApiErrorFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/ApiErrorFallback/index.tsx
+++ b/web/src/components/utils/ApiErrorFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/AuthContext/AuthContext.tsx
+++ b/web/src/components/utils/AuthContext/AuthContext.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/AuthContext/index.tsx
+++ b/web/src/components/utils/AuthContext/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Autosave/Autosave.tsx
+++ b/web/src/components/utils/Autosave/Autosave.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Autosave/index.tsx
+++ b/web/src/components/utils/Autosave/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/FadeInTrail/FadeInTrail.tsx
+++ b/web/src/components/utils/FadeInTrail/FadeInTrail.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/FadeInTrail/index.tsx
+++ b/web/src/components/utils/FadeInTrail/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/FormSessionRestoration/FormSessionRestoration.test.tsx
+++ b/web/src/components/utils/FormSessionRestoration/FormSessionRestoration.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/FormSessionRestoration/FormSessionRestoration.tsx
+++ b/web/src/components/utils/FormSessionRestoration/FormSessionRestoration.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/FormSessionRestoration/index.tsx
+++ b/web/src/components/utils/FormSessionRestoration/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/GenerateFiltersGroup/GenerateFiltersGroup.tsx
+++ b/web/src/components/utils/GenerateFiltersGroup/GenerateFiltersGroup.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/GenerateFiltersGroup/index.tsx
+++ b/web/src/components/utils/GenerateFiltersGroup/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Modal/ModalContext.tsx
+++ b/web/src/components/utils/Modal/ModalContext.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Modal/ModalManager.tsx
+++ b/web/src/components/utils/Modal/ModalManager.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Modal/index.tsx
+++ b/web/src/components/utils/Modal/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/PromptController/PromptController.tsx
+++ b/web/src/components/utils/PromptController/PromptController.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/PromptController/graphql/getGeneralSettingsConsents.generated.ts
+++ b/web/src/components/utils/PromptController/graphql/getGeneralSettingsConsents.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/PromptController/index.tsx
+++ b/web/src/components/utils/PromptController/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/SelectContext/SelectAllCheckbox.tsx
+++ b/web/src/components/utils/SelectContext/SelectAllCheckbox.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/SelectContext/SelectCheckbox.tsx
+++ b/web/src/components/utils/SelectContext/SelectCheckbox.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/SelectContext/SelectContext.test.tsx
+++ b/web/src/components/utils/SelectContext/SelectContext.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/SelectContext/SelectContext.tsx
+++ b/web/src/components/utils/SelectContext/SelectContext.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/SelectContext/index.tsx
+++ b/web/src/components/utils/SelectContext/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Sidesheet/SidesheetContext.tsx
+++ b/web/src/components/utils/Sidesheet/SidesheetContext.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Sidesheet/SidesheetManager.tsx
+++ b/web/src/components/utils/Sidesheet/SidesheetManager.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/Sidesheet/index.tsx
+++ b/web/src/components/utils/Sidesheet/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/TableControls/TableControlsComplianceFilter.tsx
+++ b/web/src/components/utils/TableControls/TableControlsComplianceFilter.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/TableControls/TableControlsPagination.tsx
+++ b/web/src/components/utils/TableControls/TableControlsPagination.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/TableControls/index.tsx
+++ b/web/src/components/utils/TableControls/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/UIProviders/UIProviders.tsx
+++ b/web/src/components/utils/UIProviders/UIProviders.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/utils/UIProviders/index.tsx
+++ b/web/src/components/utils/UIProviders/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/BulkUploaderWizard.test.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/BulkUploaderWizard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/BulkUploaderWizard.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/BulkUploaderWizard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/SuccessfulUploadPanel/Rows.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/SuccessfulUploadPanel/Rows.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/SuccessfulUploadPanel/SuccessfulUploadPanel.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/SuccessfulUploadPanel/SuccessfulUploadPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/SuccessfulUploadPanel/index.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/SuccessfulUploadPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/UploadPanel/Error.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/UploadPanel/Error.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/UploadPanel/Processing.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/UploadPanel/Processing.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/UploadPanel/Upload.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/UploadPanel/Upload.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/UploadPanel/UploadPanel.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/UploadPanel/UploadPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/UploadPanel/graphql/uploadPolicies.generated.ts
+++ b/web/src/components/wizards/BulkUploaderWizard/UploadPanel/graphql/uploadPolicies.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/UploadPanel/index.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/UploadPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/BulkUploaderWizard/index.tsx
+++ b/web/src/components/wizards/BulkUploaderWizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/ComplianceSourceWizard.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/ComplianceSourceWizard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/SourceConfigurationPanel/SourceConfigurationPanel.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/SourceConfigurationPanel/SourceConfigurationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/SourceConfigurationPanel/index.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/SourceConfigurationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/graphql/getComplianceCfnTemplate.generated.ts
+++ b/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/graphql/getComplianceCfnTemplate.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/index.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/StackDeploymentPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/ValidationPanel/index.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/ValidationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/ComplianceSourceWizard/index.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/ChooseDestinationPanel.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/ChooseDestinationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/DestinationCard/DestinationCard.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/DestinationCard/DestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/DestinationCard/index.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/DestinationCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/index.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ChooseDestinationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/graphql/addDestination.generated.ts
+++ b/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/graphql/addDestination.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/index.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/CreateDestinationWizard.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/CreateDestinationWizard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/CreateDestinationWizard/index.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
+++ b/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/Skeleton.tsx
+++ b/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/graphql/getDestinationDetails.generated.ts
+++ b/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/graphql/getDestinationDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/graphql/updateDestination.generated.ts
+++ b/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/graphql/updateDestination.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/index.tsx
+++ b/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/EditDestination.tsx
+++ b/web/src/components/wizards/EditDestinationWizard/EditDestination.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/EditDestinationWizard/index.tsx
+++ b/web/src/components/wizards/EditDestinationWizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/S3LogSourceWizard.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/S3LogSourceWizard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/S3SourceConfigurationPanel/S3SourceConfigurationPanel.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/S3SourceConfigurationPanel/S3SourceConfigurationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/S3SourceConfigurationPanel/index.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/S3SourceConfigurationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/StackDeployment.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/graphql/getLogCfnTemplate.generated.ts
+++ b/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/graphql/getLogCfnTemplate.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/index.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/StackDeploymentPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/ValidationPanel/index.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/ValidationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/S3LogSourceWizard/index.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/SqsSourceConfigurationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/index.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceConfigurationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/SqsSourceWizard/SqsSourceWizard.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/SqsSourceWizard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/SqsSourceWizard/ValidationPanel/index.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/ValidationPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/SqsSourceWizard/index.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/common/DestinationTestPanel/DestinationTestPanel.test.tsx
+++ b/web/src/components/wizards/common/DestinationTestPanel/DestinationTestPanel.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/common/DestinationTestPanel/DestinationTestPanel.tsx
+++ b/web/src/components/wizards/common/DestinationTestPanel/DestinationTestPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/components/wizards/common/DestinationTestPanel/index.tsx
+++ b/web/src/components/wizards/common/DestinationTestPanel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/AlertDetailsFull.generated.ts
+++ b/web/src/graphql/fragments/AlertDetailsFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/AlertSummaryFull.generated.ts
+++ b/web/src/graphql/fragments/AlertSummaryFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/ComplianceIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/ComplianceIntegrationDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/CustomLogFull.generated.ts
+++ b/web/src/graphql/fragments/CustomLogFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/CustomLogTeaser.generated.ts
+++ b/web/src/graphql/fragments/CustomLogTeaser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/DataModelFull.generated.ts
+++ b/web/src/graphql/fragments/DataModelFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/DeliveryResponseFull.generated.js
+++ b/web/src/graphql/fragments/DeliveryResponseFull.generated.js
@@ -1,7 +1,6 @@
-'use strict';
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -16,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+'use strict';
 var __makeTemplateObject =
   (this && this.__makeTemplateObject) ||
   function (cooked, raw) {

--- a/web/src/graphql/fragments/DeliveryResponseFull.generated.ts
+++ b/web/src/graphql/fragments/DeliveryResponseFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/DestinationFull.generated.ts
+++ b/web/src/graphql/fragments/DestinationFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/GeneralSettingsFull.generated.ts
+++ b/web/src/graphql/fragments/GeneralSettingsFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/GlobalPythonModuleFull.generated.ts
+++ b/web/src/graphql/fragments/GlobalPythonModuleFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/GlobalPythonModuleTeaser.generated.ts
+++ b/web/src/graphql/fragments/GlobalPythonModuleTeaser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/IntegrationItemHealthDetails.generated.ts
+++ b/web/src/graphql/fragments/IntegrationItemHealthDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/PolicyBasic.generated.ts
+++ b/web/src/graphql/fragments/PolicyBasic.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/PolicyDetailsExtra.generated.ts
+++ b/web/src/graphql/fragments/PolicyDetailsExtra.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/PolicyDetailsMain.generated.ts
+++ b/web/src/graphql/fragments/PolicyDetailsMain.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/PolicyTeaser.generated.ts
+++ b/web/src/graphql/fragments/PolicyTeaser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/RuleBasic.generated.ts
+++ b/web/src/graphql/fragments/RuleBasic.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/RuleFull.generated.ts
+++ b/web/src/graphql/fragments/RuleFull.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/SqsLogSourceIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/SqsLogSourceIntegrationDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/TestFunctionResult.generated.ts
+++ b/web/src/graphql/fragments/TestFunctionResult.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/fragments/UserDetails.generated.ts
+++ b/web/src/graphql/fragments/UserDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/queries/index.tsx
+++ b/web/src/graphql/queries/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/queries/listAvailableLogTypes.generated.ts
+++ b/web/src/graphql/queries/listAvailableLogTypes.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/queries/listComplianceSourceNames.generated.ts
+++ b/web/src/graphql/queries/listComplianceSourceNames.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/queries/listDestinations.generated.ts
+++ b/web/src/graphql/queries/listDestinations.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/queries/sendTestAlert.generated.ts
+++ b/web/src/graphql/queries/sendTestAlert.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/graphql/queries/updateAlertStatus.generated.ts
+++ b/web/src/graphql/queries/updateAlertStatus.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/__tests__/analytics.test.tsx
+++ b/web/src/helpers/__tests__/analytics.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/__tests__/errors.test.tsx
+++ b/web/src/helpers/__tests__/errors.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/analytics.ts
+++ b/web/src/helpers/analytics.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/colors.ts
+++ b/web/src/helpers/colors.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/compose.ts
+++ b/web/src/helpers/compose.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/connection.ts
+++ b/web/src/helpers/connection.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/errors.ts
+++ b/web/src/helpers/errors.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/fireworks.ts
+++ b/web/src/helpers/fireworks.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/storage.ts
+++ b/web/src/helpers/storage.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/history.ts
+++ b/web/src/history.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hoc/withSEO.tsx
+++ b/web/src/hoc/withSEO.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/__tests__/useAlertDestinations.test.tsx
+++ b/web/src/hooks/__tests__/useAlertDestinations.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/__tests__/useDetectionDestinations.test.tsx
+++ b/web/src/hooks/__tests__/useDetectionDestinations.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/__tests__/useForceUpdate.test.tsx
+++ b/web/src/hooks/__tests__/useForceUpdate.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/__tests__/useTrackPageView.test.tsx
+++ b/web/src/hooks/__tests__/useTrackPageView.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/graphql/remediateResource.generated.ts
+++ b/web/src/hooks/graphql/remediateResource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/graphql/suppressPolicy.generated.ts
+++ b/web/src/hooks/graphql/suppressPolicy.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useAlertDestinations.tsx
+++ b/web/src/hooks/useAlertDestinations.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useAlertDestinationsDeliverySuccess.tsx
+++ b/web/src/hooks/useAlertDestinationsDeliverySuccess.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useDetectionDestinations.tsx
+++ b/web/src/hooks/useDetectionDestinations.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useFastField.tsx
+++ b/web/src/hooks/useFastField.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useForceUpdate.tsx
+++ b/web/src/hooks/useForceUpdate.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useFormSessionRestoration.tsx
+++ b/web/src/hooks/useFormSessionRestoration.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useHover.test.tsx
+++ b/web/src/hooks/useHover.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useHover.tsx
+++ b/web/src/hooks/useHover.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useInfiniteScroll.tsx
+++ b/web/src/hooks/useInfiniteScroll.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useModal.tsx
+++ b/web/src/hooks/useModal.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/usePolicySuppression.tsx
+++ b/web/src/hooks/usePolicySuppression.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useRequestParamsWithPagination.tsx
+++ b/web/src/hooks/useRequestParamsWithPagination.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useRequestParamsWithoutPagination.tsx
+++ b/web/src/hooks/useRequestParamsWithoutPagination.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useResourceRemediation.tsx
+++ b/web/src/hooks/useResourceRemediation.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useRouter.tsx
+++ b/web/src/hooks/useRouter.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useSidesheet.tsx
+++ b/web/src/hooks/useSidesheet.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useTrackPageView.tsx
+++ b/web/src/hooks/useTrackPageView.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/hooks/useUrlParams.tsx
+++ b/web/src/hooks/useUrlParams.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/overrides.d.ts
+++ b/web/src/overrides.d.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/403/403.tsx
+++ b/web/src/pages/403/403.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/403/index.tsx
+++ b/web/src/pages/403/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/404/404.tsx
+++ b/web/src/pages/404/404.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/404/index.tsx
+++ b/web/src/pages/404/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/500/500.tsx
+++ b/web/src/pages/500/500.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/500/index.tsx
+++ b/web/src/pages/500/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/AlertDetails.test.tsx
+++ b/web/src/pages/AlertDetails/AlertDetails.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/AlertDetails.tsx
+++ b/web/src/pages/AlertDetails/AlertDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/AlertDetailsBanner.test.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/AlertDetailsBanner.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/index.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsInfo/index.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsInfo/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/PolicyAlertDetails.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/PolicyAlertDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/graphql/policyTeaser.generated.ts
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/graphql/policyTeaser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/index.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/AlertDetailsBanner.test.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/AlertDetailsBanner.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/index.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsEvents/AlertDetailsEvents.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsEvents/AlertDetailsEvents.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsEvents/index.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsEvents/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/index.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/RuleAlertDetails.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/RuleAlertDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/graphql/ruleTeaser.generated.ts
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/graphql/ruleTeaser.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/RuleAlertDetails/index.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/Skeleton/Skeleton.tsx
+++ b/web/src/pages/AlertDetails/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/Skeleton/index.tsx
+++ b/web/src/pages/AlertDetails/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliverySection.test.tsx
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliverySection.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliverySection.tsx
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliverySection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliveryTable/AlertDeliveryTable.test.tsx
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliveryTable/AlertDeliveryTable.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliveryTable/AlertDeliveryTable.tsx
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliveryTable/AlertDeliveryTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliveryTable/index.tsx
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/AlertDeliveryTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/graphql/retryAlertDelivery.generated.ts
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/graphql/retryAlertDelivery.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/common/AlertDeliverySection/index.tsx
+++ b/web/src/pages/AlertDetails/common/AlertDeliverySection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/graphql/alertDetails.generated.ts
+++ b/web/src/pages/AlertDetails/graphql/alertDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/AlertDetails/index.tsx
+++ b/web/src/pages/AlertDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/BulkUploader/BulkUploader.tsx
+++ b/web/src/pages/BulkUploader/BulkUploader.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/BulkUploader/index.tsx
+++ b/web/src/pages/BulkUploader/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/ComplianceOverview.tsx
+++ b/web/src/pages/ComplianceOverview/ComplianceOverview.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ComplianceOverview/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ComplianceOverview/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/PoliciesBySeverityChart/PoliciesBySeverityChart.tsx
+++ b/web/src/pages/ComplianceOverview/PoliciesBySeverityChart/PoliciesBySeverityChart.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/PoliciesBySeverityChart/index.tsx
+++ b/web/src/pages/ComplianceOverview/PoliciesBySeverityChart/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/PoliciesByStatusChart/PoliciesByStatusChart.tsx
+++ b/web/src/pages/ComplianceOverview/PoliciesByStatusChart/PoliciesByStatusChart.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/PoliciesByStatusChart/index.tsx
+++ b/web/src/pages/ComplianceOverview/PoliciesByStatusChart/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/PoliciesOverviewChart/PoliciesOverviewChart.tsx
+++ b/web/src/pages/ComplianceOverview/PoliciesOverviewChart/PoliciesOverviewChart.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/PoliciesOverviewChart/index.tsx
+++ b/web/src/pages/ComplianceOverview/PoliciesOverviewChart/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/ResourcesByStatusChart/ResourcesByStatusChart.tsx
+++ b/web/src/pages/ComplianceOverview/ResourcesByStatusChart/ResourcesByStatusChart.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/ResourcesByStatusChart/index.tsx
+++ b/web/src/pages/ComplianceOverview/ResourcesByStatusChart/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ComplianceOverview/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/Skeleton/index.tsx
+++ b/web/src/pages/ComplianceOverview/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/TopFailingPoliciesTable.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/TopFailingPoliciesTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/index.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingPoliciesTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/TopFailingResourcesTable/TopFailingResourcesTable.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingResourcesTable/TopFailingResourcesTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/TopFailingResourcesTable/index.tsx
+++ b/web/src/pages/ComplianceOverview/TopFailingResourcesTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/graphql/getOrganizationStats.generated.ts
+++ b/web/src/pages/ComplianceOverview/graphql/getOrganizationStats.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ComplianceOverview/index.tsx
+++ b/web/src/pages/ComplianceOverview/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateComplianceSource/CreateComplianceSource.test.tsx
+++ b/web/src/pages/CreateComplianceSource/CreateComplianceSource.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateComplianceSource/CreateComplianceSource.tsx
+++ b/web/src/pages/CreateComplianceSource/CreateComplianceSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateComplianceSource/graphql/addComplianceSource.generated.ts
+++ b/web/src/pages/CreateComplianceSource/graphql/addComplianceSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateComplianceSource/index.tsx
+++ b/web/src/pages/CreateComplianceSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateCustomLog/CreateCustomLog.test.tsx
+++ b/web/src/pages/CreateCustomLog/CreateCustomLog.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateCustomLog/CreateCustomLog.tsx
+++ b/web/src/pages/CreateCustomLog/CreateCustomLog.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateCustomLog/graphql/createCustomLog.generated.ts
+++ b/web/src/pages/CreateCustomLog/graphql/createCustomLog.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateCustomLog/index.tsx
+++ b/web/src/pages/CreateCustomLog/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDataModel/CreateDataModel.test.tsx
+++ b/web/src/pages/CreateDataModel/CreateDataModel.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDataModel/CreateDataModel.tsx
+++ b/web/src/pages/CreateDataModel/CreateDataModel.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDataModel/graphql/createDataModel.generated.ts
+++ b/web/src/pages/CreateDataModel/graphql/createDataModel.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDataModel/index.tsx
+++ b/web/src/pages/CreateDataModel/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDestination/CreateDestination.test.tsx
+++ b/web/src/pages/CreateDestination/CreateDestination.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDestination/CreateDestination.tsx
+++ b/web/src/pages/CreateDestination/CreateDestination.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateDestination/index.tsx
+++ b/web/src/pages/CreateDestination/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateGlobalPythonModule/CreateGlobalPythonModule.tsx
+++ b/web/src/pages/CreateGlobalPythonModule/CreateGlobalPythonModule.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateGlobalPythonModule/graphql/createGlobalPythonModule.generated.ts
+++ b/web/src/pages/CreateGlobalPythonModule/graphql/createGlobalPythonModule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateGlobalPythonModule/index.tsx
+++ b/web/src/pages/CreateGlobalPythonModule/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateLogSource.tsx
+++ b/web/src/pages/CreateLogSource/CreateLogSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateS3LogSource/CreateS3LogSource.test.tsx
+++ b/web/src/pages/CreateLogSource/CreateS3LogSource/CreateS3LogSource.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateS3LogSource/CreateS3LogSource.tsx
+++ b/web/src/pages/CreateLogSource/CreateS3LogSource/CreateS3LogSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateS3LogSource/graphql/addS3LogSource.generated.ts
+++ b/web/src/pages/CreateLogSource/CreateS3LogSource/graphql/addS3LogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateS3LogSource/index.tsx
+++ b/web/src/pages/CreateLogSource/CreateS3LogSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.test.tsx
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.tsx
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/CreateSqsLogSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/graphql/addSqsLogSource.generated.ts
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/graphql/addSqsLogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/CreateSqsLogSource/index.tsx
+++ b/web/src/pages/CreateLogSource/CreateSqsLogSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateLogSource/index.tsx
+++ b/web/src/pages/CreateLogSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreatePolicy/CreatePolicy.tsx
+++ b/web/src/pages/CreatePolicy/CreatePolicy.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreatePolicy/graphql/createPolicy.generated.ts
+++ b/web/src/pages/CreatePolicy/graphql/createPolicy.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreatePolicy/index.tsx
+++ b/web/src/pages/CreatePolicy/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateRule/CreateRule.tsx
+++ b/web/src/pages/CreateRule/CreateRule.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateRule/graphql/createRule.generated.ts
+++ b/web/src/pages/CreateRule/graphql/createRule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CreateRule/index.tsx
+++ b/web/src/pages/CreateRule/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CustomLogDetails/CustomLogDetails.test.tsx
+++ b/web/src/pages/CustomLogDetails/CustomLogDetails.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CustomLogDetails/CustomLogDetails.tsx
+++ b/web/src/pages/CustomLogDetails/CustomLogDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CustomLogDetails/graphql/getCustomLogDetails.generated.ts
+++ b/web/src/pages/CustomLogDetails/graphql/getCustomLogDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/CustomLogDetails/index.tsx
+++ b/web/src/pages/CustomLogDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditComplianceSource/EditComplianceSource.tsx
+++ b/web/src/pages/EditComplianceSource/EditComplianceSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditComplianceSource/graphql/getComplianceSource.generated.ts
+++ b/web/src/pages/EditComplianceSource/graphql/getComplianceSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditComplianceSource/graphql/updateComplianceSource.generated.ts
+++ b/web/src/pages/EditComplianceSource/graphql/updateComplianceSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditComplianceSource/index.tsx
+++ b/web/src/pages/EditComplianceSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditComplianceSource/ΕditComplianceSource.test.tsx
+++ b/web/src/pages/EditComplianceSource/ΕditComplianceSource.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditDestination/EditDestination.test.tsx
+++ b/web/src/pages/EditDestination/EditDestination.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditDestination/EditDestination.tsx
+++ b/web/src/pages/EditDestination/EditDestination.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditDestination/index.tsx
+++ b/web/src/pages/EditDestination/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditGlobalPythonModule/EditGlobalPythonModule.tsx
+++ b/web/src/pages/EditGlobalPythonModule/EditGlobalPythonModule.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditGlobalPythonModule/Skeleton/Skeleton.tsx
+++ b/web/src/pages/EditGlobalPythonModule/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditGlobalPythonModule/Skeleton/index.tsx
+++ b/web/src/pages/EditGlobalPythonModule/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditGlobalPythonModule/graphql/globalPythonModuleDetails.generated.ts
+++ b/web/src/pages/EditGlobalPythonModule/graphql/globalPythonModuleDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditGlobalPythonModule/graphql/updateGlobalPythonModule.generated.ts
+++ b/web/src/pages/EditGlobalPythonModule/graphql/updateGlobalPythonModule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditGlobalPythonModule/index.tsx
+++ b/web/src/pages/EditGlobalPythonModule/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditPolicy/EditPolicy.tsx
+++ b/web/src/pages/EditPolicy/EditPolicy.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditPolicy/Skeleton/Skeleton.tsx
+++ b/web/src/pages/EditPolicy/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditPolicy/Skeleton/index.tsx
+++ b/web/src/pages/EditPolicy/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditPolicy/graphql/policyDetails.generated.ts
+++ b/web/src/pages/EditPolicy/graphql/policyDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditPolicy/graphql/updatePolicy.generated.ts
+++ b/web/src/pages/EditPolicy/graphql/updatePolicy.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditPolicy/index.tsx
+++ b/web/src/pages/EditPolicy/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditRule/EditRule.tsx
+++ b/web/src/pages/EditRule/EditRule.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditRule/Skeleton/Skeleton.tsx
+++ b/web/src/pages/EditRule/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditRule/Skeleton/index.tsx
+++ b/web/src/pages/EditRule/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditRule/graphql/ruleDetails.generated.ts
+++ b/web/src/pages/EditRule/graphql/ruleDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditRule/graphql/updateRule.generated.ts
+++ b/web/src/pages/EditRule/graphql/updateRule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditRule/index.tsx
+++ b/web/src/pages/EditRule/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditS3LogSource/EditS3LogSource.tsx
+++ b/web/src/pages/EditS3LogSource/EditS3LogSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditS3LogSource/graphql/getS3LogSource.generated.ts
+++ b/web/src/pages/EditS3LogSource/graphql/getS3LogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditS3LogSource/graphql/updateS3LogSource.generated.ts
+++ b/web/src/pages/EditS3LogSource/graphql/updateS3LogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditS3LogSource/index.tsx
+++ b/web/src/pages/EditS3LogSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditS3LogSource/ΕditS3LogSource.test.tsx
+++ b/web/src/pages/EditS3LogSource/ΕditS3LogSource.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditSqsLogSource/EditSqsLogSource.tsx
+++ b/web/src/pages/EditSqsLogSource/EditSqsLogSource.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditSqsLogSource/graphql/getSqsLogSource.generated.ts
+++ b/web/src/pages/EditSqsLogSource/graphql/getSqsLogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditSqsLogSource/graphql/updateSqsLogSource.generated.ts
+++ b/web/src/pages/EditSqsLogSource/graphql/updateSqsLogSource.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditSqsLogSource/index.tsx
+++ b/web/src/pages/EditSqsLogSource/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/EditSqsLogSource/ΕditSqsLogSource.test.tsx
+++ b/web/src/pages/EditSqsLogSource/ΕditSqsLogSource.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ForgotPassword/ForgotPassword.test.tsx
+++ b/web/src/pages/ForgotPassword/ForgotPassword.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/web/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ForgotPassword/index.tsx
+++ b/web/src/pages/ForgotPassword/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ForgotPasswordConfirm/ForgotPasswordConfirm.test.tsx
+++ b/web/src/pages/ForgotPasswordConfirm/ForgotPasswordConfirm.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ForgotPasswordConfirm/ForgotPasswordConfirm.tsx
+++ b/web/src/pages/ForgotPasswordConfirm/ForgotPasswordConfirm.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ForgotPasswordConfirm/index.tsx
+++ b/web/src/pages/ForgotPasswordConfirm/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/GeneralSettings.test.tsx
+++ b/web/src/pages/GeneralSettings/GeneralSettings.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/GeneralSettings.tsx
+++ b/web/src/pages/GeneralSettings/GeneralSettings.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/Skeleton/Skeleton.tsx
+++ b/web/src/pages/GeneralSettings/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/Skeleton/index.tsx
+++ b/web/src/pages/GeneralSettings/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/graphql/getGeneralSettings.generated.ts
+++ b/web/src/pages/GeneralSettings/graphql/getGeneralSettings.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/graphql/updateGeneralSettings.generated.ts
+++ b/web/src/pages/GeneralSettings/graphql/updateGeneralSettings.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/GeneralSettings/index.tsx
+++ b/web/src/pages/GeneralSettings/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Landing/Landing.tsx
+++ b/web/src/pages/Landing/Landing.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Landing/index.tsx
+++ b/web/src/pages/Landing/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListAlerts/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListAlerts/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertBreadcrumbFilters/ListAlertBreadcrumbFilters.tsx
+++ b/web/src/pages/ListAlerts/ListAlertBreadcrumbFilters/ListAlertBreadcrumbFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertBreadcrumbFilters/index.tsx
+++ b/web/src/pages/ListAlerts/ListAlertBreadcrumbFilters/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertFilters/DropdownFilters.tsx
+++ b/web/src/pages/ListAlerts/ListAlertFilters/DropdownFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertFilters/ListAlertFilters.tsx
+++ b/web/src/pages/ListAlerts/ListAlertFilters/ListAlertFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertFilters/index.tsx
+++ b/web/src/pages/ListAlerts/ListAlertFilters/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertSelection/ListAlertSelection.tsx
+++ b/web/src/pages/ListAlerts/ListAlertSelection/ListAlertSelection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertSelection/index.tsx
+++ b/web/src/pages/ListAlerts/ListAlertSelection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlerts.test.tsx
+++ b/web/src/pages/ListAlerts/ListAlerts.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlerts.tsx
+++ b/web/src/pages/ListAlerts/ListAlerts.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertsActions/ListAlertsActions.tsx
+++ b/web/src/pages/ListAlerts/ListAlertsActions/ListAlertsActions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/ListAlertsActions/index.tsx
+++ b/web/src/pages/ListAlerts/ListAlertsActions/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListAlerts/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/Skeleton/index.tsx
+++ b/web/src/pages/ListAlerts/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/graphql/listAlerts.generated.ts
+++ b/web/src/pages/ListAlerts/graphql/listAlerts.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListAlerts/index.tsx
+++ b/web/src/pages/ListAlerts/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCard.test.tsx
+++ b/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCard.tsx
+++ b/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCardOptions.tsx
+++ b/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCardOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ComplianceSourceCard/index.tsx
+++ b/web/src/pages/ListComplianceSources/ComplianceSourceCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListComplianceSources/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListComplianceSources/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ListComplianceSourceCards/ListComplianceSourceCards.tsx
+++ b/web/src/pages/ListComplianceSources/ListComplianceSourceCards/ListComplianceSourceCards.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ListComplianceSourceCards/index.tsx
+++ b/web/src/pages/ListComplianceSources/ListComplianceSourceCards/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ListComplianceSources.test.tsx
+++ b/web/src/pages/ListComplianceSources/ListComplianceSources.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/ListComplianceSources.tsx
+++ b/web/src/pages/ListComplianceSources/ListComplianceSources.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListComplianceSources/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/Skeleton/index.tsx
+++ b/web/src/pages/ListComplianceSources/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/graphql/listComplianceSources.generated.ts
+++ b/web/src/pages/ListComplianceSources/graphql/listComplianceSources.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListComplianceSources/index.tsx
+++ b/web/src/pages/ListComplianceSources/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/CustomLogCard/CustomLogCard.test.tsx
+++ b/web/src/pages/ListCustomLogs/CustomLogCard/CustomLogCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/CustomLogCard/CustomLogCard.tsx
+++ b/web/src/pages/ListCustomLogs/CustomLogCard/CustomLogCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/CustomLogCard/CustomLogCardOptions.tsx
+++ b/web/src/pages/ListCustomLogs/CustomLogCard/CustomLogCardOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/CustomLogCard/index.tsx
+++ b/web/src/pages/ListCustomLogs/CustomLogCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListCustomLogs/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListCustomLogs/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/ListCustomLogs.test.tsx
+++ b/web/src/pages/ListCustomLogs/ListCustomLogs.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/ListCustomLogs.tsx
+++ b/web/src/pages/ListCustomLogs/ListCustomLogs.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/graphql/listCustomLogSchemas.generated.ts
+++ b/web/src/pages/ListCustomLogs/graphql/listCustomLogSchemas.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListCustomLogs/index.tsx
+++ b/web/src/pages/ListCustomLogs/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/AsanaDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/AsanaDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/CustomWebhookDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/CustomWebhookDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/DestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/DestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/DestinationCardOptions.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/DestinationCardOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/GithubDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/GithubDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/JiraDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/JiraDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/MsTeamsDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/MsTeamsDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/OpsGenieDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/OpsGenieDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/PagerDutyDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/PagerDutyDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/SlackDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/SlackDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/SnsDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/SnsDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/SqsDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/SqsDestinationCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/AsanaDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/AsanaDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/CustomWebhookDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/CustomWebhookDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/DestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/DestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/GithubDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/GithubDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/JiraDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/JiraDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/MsTeamsDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/MsTeamsDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/OpsGenieDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/OpsGenieDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/PagerDutyDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/PagerDutyDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/SlackDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/SlackDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/SnsDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/SnsDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/SqsDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/SqsDestinationCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/DestinationCards/index.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListDestinations/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListDestinations/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/ListDestinations.test.tsx
+++ b/web/src/pages/ListDestinations/ListDestinations.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/ListDestinations.tsx
+++ b/web/src/pages/ListDestinations/ListDestinations.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/ListDestinationsCards/ListDestinationsCards.tsx
+++ b/web/src/pages/ListDestinations/ListDestinationsCards/ListDestinationsCards.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/ListDestinationsCards/index.tsx
+++ b/web/src/pages/ListDestinations/ListDestinationsCards/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListDestinations/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/Skeleton/index.tsx
+++ b/web/src/pages/ListDestinations/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/graphql/listDestinationsAndDefaults.generated.ts
+++ b/web/src/pages/ListDestinations/graphql/listDestinationsAndDefaults.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListDestinations/index.tsx
+++ b/web/src/pages/ListDestinations/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListGlobalPythonModules/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListGlobalPythonModules/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/GlobalPythonModuleItem/GlobalPythonModuleItem.tsx
+++ b/web/src/pages/ListGlobalPythonModules/GlobalPythonModuleItem/GlobalPythonModuleItem.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/GlobalPythonModuleItem/index.tsx
+++ b/web/src/pages/ListGlobalPythonModules/GlobalPythonModuleItem/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/ListGlobalPythonModules.tsx
+++ b/web/src/pages/ListGlobalPythonModules/ListGlobalPythonModules.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListGlobalPythonModules/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/Skeleton/index.tsx
+++ b/web/src/pages/ListGlobalPythonModules/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/graphql/listGlobalPythonModules.generated.ts
+++ b/web/src/pages/ListGlobalPythonModules/graphql/listGlobalPythonModules.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListGlobalPythonModules/index.tsx
+++ b/web/src/pages/ListGlobalPythonModules/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListLogSources/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListLogSources/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/ListLogSourceCards/ListLogSourceCards.tsx
+++ b/web/src/pages/ListLogSources/ListLogSourceCards/ListLogSourceCards.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/ListLogSourceCards/index.tsx
+++ b/web/src/pages/ListLogSources/ListLogSourceCards/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/ListLogSources.test.tsx
+++ b/web/src/pages/ListLogSources/ListLogSources.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/ListLogSources.tsx
+++ b/web/src/pages/ListLogSources/ListLogSources.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.test.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/S3LogSourceCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.test.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/SqsLogSourceCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/LogSourceCards/index.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListLogSources/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/Skeleton/index.tsx
+++ b/web/src/pages/ListLogSources/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/graphql/listLogSources.generated.ts
+++ b/web/src/pages/ListLogSources/graphql/listLogSources.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListLogSources/index.tsx
+++ b/web/src/pages/ListLogSources/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListPolicies/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListPolicies/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPolicies.tsx
+++ b/web/src/pages/ListPolicies/ListPolicies.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPoliciesActions/ListPoliciesActions.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesActions/ListPoliciesActions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPoliciesActions/index.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesActions/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTable.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTableRowOptions/ListPoliciesTableRowOptions.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTableRowOptions/ListPoliciesTableRowOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTableRowOptions/index.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTableRowOptions/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/ListPoliciesTable/index.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListPolicies/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/Skeleton/index.tsx
+++ b/web/src/pages/ListPolicies/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/graphql/listPolicies.generated.ts
+++ b/web/src/pages/ListPolicies/graphql/listPolicies.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListPolicies/index.tsx
+++ b/web/src/pages/ListPolicies/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListResources/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListResources/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/ListResources.tsx
+++ b/web/src/pages/ListResources/ListResources.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/ListResourcesActions/ListResourcesActions.tsx
+++ b/web/src/pages/ListResources/ListResourcesActions/ListResourcesActions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/ListResourcesActions/index.tsx
+++ b/web/src/pages/ListResources/ListResourcesActions/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/ListResourcesTable/ListResourcesTable.tsx
+++ b/web/src/pages/ListResources/ListResourcesTable/ListResourcesTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/ListResourcesTable/index.tsx
+++ b/web/src/pages/ListResources/ListResourcesTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListResources/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/Skeleton/index.tsx
+++ b/web/src/pages/ListResources/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/graphql/listResources.generated.ts
+++ b/web/src/pages/ListResources/graphql/listResources.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListResources/index.tsx
+++ b/web/src/pages/ListResources/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListRules/EmptyDataFallback/EmptyDataFallback.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/EmptyDataFallback/index.tsx
+++ b/web/src/pages/ListRules/EmptyDataFallback/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRules.test.tsx
+++ b/web/src/pages/ListRules/ListRules.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRules.tsx
+++ b/web/src/pages/ListRules/ListRules.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRulesBreadcrumbFilters/ListRulesBreadcrumbFilters.tsx
+++ b/web/src/pages/ListRules/ListRulesBreadcrumbFilters/ListRulesBreadcrumbFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRulesBreadcrumbFilters/index.tsx
+++ b/web/src/pages/ListRules/ListRulesBreadcrumbFilters/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRulesFilters/DropdownFilters.tsx
+++ b/web/src/pages/ListRules/ListRulesFilters/DropdownFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRulesFilters/ListRulesFilters.tsx
+++ b/web/src/pages/ListRules/ListRulesFilters/ListRulesFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/ListRulesFilters/index.tsx
+++ b/web/src/pages/ListRules/ListRulesFilters/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ListRules/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/Skeleton/index.tsx
+++ b/web/src/pages/ListRules/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/graphql/listRules.generated.ts
+++ b/web/src/pages/ListRules/graphql/listRules.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ListRules/index.tsx
+++ b/web/src/pages/ListRules/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertSummary/AlertSummary.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertSummary/AlertSummary.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertSummary/DifferenceText/DifferenceText.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertSummary/DifferenceText/DifferenceText.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertSummary/DifferenceText/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertSummary/DifferenceText/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertSummary/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertSummary/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertsBySeverity/AlertsBySeverity.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsBySeverity/AlertsBySeverity.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertsBySeverity/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsBySeverity/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertsCharts/AlertsCharts.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsCharts/AlertsCharts.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertsCharts/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsCharts/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertsSection/AlertsSection.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsSection/AlertsSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/AlertsSection/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/AlertsSection/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/EventsByLatency/EventsByLatency.tsx
+++ b/web/src/pages/LogAnalysisOverview/EventsByLatency/EventsByLatency.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/EventsByLatency/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/EventsByLatency/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/EventsByLogType/EventsByLogType.tsx
+++ b/web/src/pages/LogAnalysisOverview/EventsByLogType/EventsByLogType.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/EventsByLogType/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/EventsByLogType/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/LogAnalysisOverview.test.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogAnalysisOverview.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/LogAnalysisOverview.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogAnalysisOverview.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/LogAnalysisOverviewBreadcrumbFilters/LogAnalysisOverviewBreadcrumbFilters.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogAnalysisOverviewBreadcrumbFilters/LogAnalysisOverviewBreadcrumbFilters.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/LogAnalysisOverviewBreadcrumbFilters/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogAnalysisOverviewBreadcrumbFilters/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/LogTypeCharts/LogTypeCharts.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogTypeCharts/LogTypeCharts.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/LogTypeCharts/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/LogTypeCharts/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/MostActiveRules/MostActiveRules.tsx
+++ b/web/src/pages/LogAnalysisOverview/MostActiveRules/MostActiveRules.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/MostActiveRules/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/MostActiveRules/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/Skeleton/Skeleton.tsx
+++ b/web/src/pages/LogAnalysisOverview/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/Skeleton/TabsSkeleton.tsx
+++ b/web/src/pages/LogAnalysisOverview/Skeleton/TabsSkeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/Skeleton/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.generated.ts
+++ b/web/src/pages/LogAnalysisOverview/graphql/getLogAnalysisMetrics.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/graphql/getOverviewAlerts.generated.ts
+++ b/web/src/pages/LogAnalysisOverview/graphql/getOverviewAlerts.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogAnalysisOverview/index.tsx
+++ b/web/src/pages/LogAnalysisOverview/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogSourceOnboarding/LogSourceCard/LogSourceCard.tsx
+++ b/web/src/pages/LogSourceOnboarding/LogSourceCard/LogSourceCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogSourceOnboarding/LogSourceCard/index.tsx
+++ b/web/src/pages/LogSourceOnboarding/LogSourceCard/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogSourceOnboarding/LogSourceOnboarding.tsx
+++ b/web/src/pages/LogSourceOnboarding/LogSourceOnboarding.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/LogSourceOnboarding/index.tsx
+++ b/web/src/pages/LogSourceOnboarding/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/PolicyDetails.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/PolicyDetailsInfo/PolicyDetailsInfo.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsInfo/PolicyDetailsInfo.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/PolicyDetailsInfo/index.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsInfo/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/PolicyDetailsTable/PolicyDetailsTable.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsTable/PolicyDetailsTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/PolicyDetailsTable/PolicyDetailsTableRowOptions.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsTable/PolicyDetailsTableRowOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/PolicyDetailsTable/index.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/Skeleton/Skeleton.tsx
+++ b/web/src/pages/PolicyDetails/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/Skeleton/index.tsx
+++ b/web/src/pages/PolicyDetails/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/graphql/policyDetails.generated.ts
+++ b/web/src/pages/PolicyDetails/graphql/policyDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/PolicyDetails/index.tsx
+++ b/web/src/pages/PolicyDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetails.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsAttributes/ResourceDetailsAttributes.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsAttributes/ResourceDetailsAttributes.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsAttributes/index.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsAttributes/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsInfo/ResourceDetailsInfo.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsInfo/ResourceDetailsInfo.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsInfo/index.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsInfo/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsTable/ResourceDetailsTable.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsTable/ResourceDetailsTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsTable/ResourceDetailsTableRowOptions.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsTable/ResourceDetailsTableRowOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/ResourceDetailsTable/index.tsx
+++ b/web/src/pages/ResourceDetails/ResourceDetailsTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/Skeleton/Skeleton.tsx
+++ b/web/src/pages/ResourceDetails/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/Skeleton/index.tsx
+++ b/web/src/pages/ResourceDetails/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/graphql/resourceDetails.generated.ts
+++ b/web/src/pages/ResourceDetails/graphql/resourceDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/ResourceDetails/index.tsx
+++ b/web/src/pages/ResourceDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleAlertsListing/RuleAlertsListing.tsx
+++ b/web/src/pages/RuleDetails/RuleAlertsListing/RuleAlertsListing.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleAlertsListing/Skeleton.tsx
+++ b/web/src/pages/RuleDetails/RuleAlertsListing/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleAlertsListing/index.tsx
+++ b/web/src/pages/RuleDetails/RuleAlertsListing/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetails.test.tsx
+++ b/web/src/pages/RuleDetails/RuleDetails.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetails.tsx
+++ b/web/src/pages/RuleDetails/RuleDetails.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetailsBanner/RuleDetailsBanner.test.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsBanner/RuleDetailsBanner.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetailsBanner/RuleDetailsBanner.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsBanner/RuleDetailsBanner.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetailsBanner/index.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsBanner/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetailsInfo/RuleDetailsInfo.test.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsInfo/RuleDetailsInfo.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetailsInfo/RuleDetailsInfo.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsInfo/RuleDetailsInfo.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/RuleDetailsInfo/index.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsInfo/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/Skeleton/Skeleton.tsx
+++ b/web/src/pages/RuleDetails/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/Skeleton/index.tsx
+++ b/web/src/pages/RuleDetails/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/graphql/listAlertsForRule.generated.ts
+++ b/web/src/pages/RuleDetails/graphql/listAlertsForRule.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/graphql/ruleDetails.generated.ts
+++ b/web/src/pages/RuleDetails/graphql/ruleDetails.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/RuleDetails/index.tsx
+++ b/web/src/pages/RuleDetails/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/SignIn/SignIn.tsx
+++ b/web/src/pages/SignIn/SignIn.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/SignIn/index.tsx
+++ b/web/src/pages/SignIn/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Support/Support.test.tsx
+++ b/web/src/pages/Support/Support.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Support/Support.tsx
+++ b/web/src/pages/Support/Support.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Support/SupportItemCard.tsx
+++ b/web/src/pages/Support/SupportItemCard.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Support/index.tsx
+++ b/web/src/pages/Support/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/ListUsers.tsx
+++ b/web/src/pages/Users/ListUsers.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/ListUsersTable/ListUsersTable.tsx
+++ b/web/src/pages/Users/ListUsersTable/ListUsersTable.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/ListUsersTable/ListUsersTableRowOptions/ListUsersTableRowOptions.tsx
+++ b/web/src/pages/Users/ListUsersTable/ListUsersTableRowOptions/ListUsersTableRowOptions.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/ListUsersTable/ListUsersTableRowOptions/index.tsx
+++ b/web/src/pages/Users/ListUsersTable/ListUsersTableRowOptions/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/ListUsersTable/index.tsx
+++ b/web/src/pages/Users/ListUsersTable/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/Skeleton/Skeleton.tsx
+++ b/web/src/pages/Users/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/Skeleton/index.tsx
+++ b/web/src/pages/Users/Skeleton/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/graphql/listUsers.generated.ts
+++ b/web/src/pages/Users/graphql/listUsers.generated.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/pages/Users/index.tsx
+++ b/web/src/pages/Users/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,6 +1,6 @@
 /**
  * Panther is a Cloud-Native SIEM for the Modern Security Team.
- * Copyright (C) 2020 Panther Labs Inc
+ * Copyright (C) 2021 Panther Labs Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
## Background

Change `(c) 2020` to `(c) 2021` in license headers and email footers

## Changes

All of them. Interestingly, we almost have exactly 2021 source files

> 2,002 changed files with 2,022 additions and 2,018 deletions.

## Testing

`mage clean setup gen fmt test:ci`
