### PR TITLE
Fixing flaky test and few S3 destination bugs

### DIFF
--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -152,8 +152,6 @@ func (d *S3Destination) SendEvents(parsedEventChannel chan *parsers.Result, errC
 	// accumulate results gzip'd in a buffer
 	failed := false // set to true on error and loop will drain channel
 	bufferSet := d.newS3EventBufferSet()
-	eventsProcessed := 0
-
 	zap.L().Debug("starting to read events from channel")
 	run := true
 	for run {
@@ -212,7 +210,7 @@ func (d *S3Destination) SendEvents(parsedEventChannel chan *parsers.Result, errC
 	close(sendChan)
 	sendWaitGroup.Wait() // wait until all writes to s3 are done
 
-	zap.L().Debug("finished sending s3 files", zap.Int("events", eventsProcessed))
+	zap.L().Debug("finished sending s3 files")
 }
 
 // sendData puts data in S3 and sends notification to SNS

--- a/internal/log_analysis/log_processor/destinations/s3.go
+++ b/internal/log_analysis/log_processor/destinations/s3.go
@@ -174,8 +174,9 @@ func (d *S3Destination) SendEvents(parsedEventChannel chan *parsers.Result, errC
 			}
 
 			if failed {
-				// If we have encountered already a failure
-				// just ignore the messages
+				// If we have encountered already a failure just ignore the messages
+				// Note that we don't stop when we encounter a failure but use this control variable
+				// since we want to make sure we drain the `parsedEventChannel`
 				break
 			}
 


### PR DESCRIPTION
## Background
Closes #2179 

* Fixing flaky test: TestSendDataIfTimeLimitHasBeenReached
* It was possible for S3 destination to block indefinitely while waiting for new events to become available from the parsers and wouldn't flush buffers on schedule. Fixed.
* Updating behavior of S3 destination so that if it has encountered a failure, we no longer try to flush buffers to S3. 

## Testing

- mage test:ci
