### PR TITLE
Introduce AWS WAF Web ACL log parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 .vscode
 .history/
 
+# Temporary files
+tmp/
+
 # Dependencies
 node_modules/
 npm-debug.log*

--- a/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
@@ -36,6 +36,7 @@ const (
 	TypeS3ServerAccess    = "AWS.S3ServerAccess"
 	TypeVPCDns            = "AWS.VPCDns"
 	TypeVPCFlow           = "AWS.VPCFlow"
+	TypeWAFWebACL         = "AWS.WAFWebACL"
 )
 
 // LogTypes exports the available log type entries
@@ -121,5 +122,13 @@ var logTypes = logtypes.Must("AWS",
 		ReferenceURL: `https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-records-examples.html`,
 		Schema:       VPCFlow{},
 		NewParser:    parsers.AdapterFactory(&VPCFlowParser{}),
+	},
+	logtypes.ConfigJSON{
+		Name:         TypeWAFWebACL,
+		Description:  `WAF Web ACL traffic information logs.`,
+		ReferenceURL: `https://docs.aws.amazon.com/waf/latest/developerguide/logging.html`,
+		NewEvent: func () interface{} {
+			return &WAFWebACL{}
+		},
 	},
 )

--- a/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/awslogs.go
@@ -127,7 +127,7 @@ var logTypes = logtypes.Must("AWS",
 		Name:         TypeWAFWebACL,
 		Description:  `WAF Web ACL traffic information logs.`,
 		ReferenceURL: `https://docs.aws.amazon.com/waf/latest/developerguide/logging.html`,
-		NewEvent: func () interface{} {
+		NewEvent: func() interface{} {
 			return &WAFWebACL{}
 		},
 	},

--- a/internal/log_analysis/log_processor/parsers/awslogs/testdata/waf_web_acl_tests.yml
+++ b/internal/log_analysis/log_processor/parsers/awslogs/testdata/waf_web_acl_tests.yml
@@ -1,0 +1,631 @@
+# Panther is a Cloud-Native SIEM for the Modern Security Team.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+name: waf_web_acl_no_match
+logType: AWS.WAFWebACL
+input: |
+  {
+    "timestamp": 1610452695501,
+    "formatVersion": 1,
+    "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+    "terminatingRuleId": "Default_Action",
+    "terminatingRuleType": "REGULAR",
+    "action": "ALLOW",
+    "terminatingRuleMatchDetails": [],
+    "httpSourceName": "ALB",
+    "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+    "ruleGroupList": [],
+    "rateBasedRuleList": [],
+    "nonTerminatingMatchingRules": [],
+    "httpRequest": {
+      "clientIp": "10.0.0.1",
+      "country": "GR",
+      "headers": [
+        {
+          "name": "Host",
+          "value": "web-123456789.us-west-2.elb.amazonaws.com"
+        },
+        {
+          "name": "user-agent",
+          "value": "curl/7.64.1"
+        },
+        {
+          "name": "accept",
+          "value": "*/*"
+        }
+      ],
+      "uri": "/",
+      "args": "o=11 AND 1=1",
+      "httpVersion": "HTTP/2.0",
+      "httpMethod": "HEAD",
+      "requestId": "1-5ffd8ed7-1c9649c448649a15241ac25a"
+    }
+  }
+result: |
+  {
+      "timestamp": 1610452695501,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "Default_Action",
+      "terminatingRuleType": "REGULAR",
+      "action": "ALLOW",
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "httpRequest": {
+        "clientIp": "10.0.0.1",
+        "country": "GR",
+        "headers": [
+          {
+            "name": "Host",
+            "value": "web-123456789.us-west-2.elb.amazonaws.com"
+          },
+          {
+            "name": "user-agent",
+            "value": "curl/7.64.1"
+          },
+          {
+            "name": "accept",
+            "value": "*/*"
+          }
+        ],
+        "uri": "/",
+        "args": "o=11 AND 1=1",
+        "httpVersion": "HTTP/2.0",
+        "httpMethod": "HEAD",
+        "requestId": "1-5ffd8ed7-1c9649c448649a15241ac25a"
+      },
+      "p_event_time": "2021-01-12T11:58:15.501Z",
+      "p_any_ip_addresses": ["10.0.0.1"],
+      "p_any_trace_ids": ["1-5ffd8ed7-1c9649c448649a15241ac25a"],
+      "p_log_type": "AWS.WAFWebACL"
+    }
+---
+name: waf_web_acl_rule_exclusion
+logType: AWS.WAFWebACL
+input: |
+  {
+    "timestamp": 1610450198436,
+    "formatVersion": 1,
+    "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+    "terminatingRuleId": "Default_Action",
+    "terminatingRuleType": "REGULAR",
+    "action": "ALLOW",
+    "terminatingRuleMatchDetails": [],
+    "httpSourceName": "ALB",
+    "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+    "ruleGroupList": [
+      {
+        "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
+        "terminatingRule": null,
+        "nonTerminatingMatchingRules": [],
+        "excludedRules": [
+          {
+            "exclusionType": "EXCLUDED_AS_COUNT",
+            "ruleId": "SQLi_QUERYARGUMENTS"
+          }
+        ]
+      }
+    ],
+    "rateBasedRuleList": [],
+    "nonTerminatingMatchingRules": [],
+    "httpRequest": {
+      "clientIp": "10.0.0.1",
+      "country": "GR",
+      "headers": [
+        {
+          "name": "Host",
+          "value": "web-123456789.us-west-2.elb.amazonaws.com"
+        },
+        {
+          "name": "user-agent",
+          "value": "curl/7.64.1"
+        },
+        {
+          "name": "accept",
+          "value": "*/*"
+        }
+      ],
+      "uri": "/",
+      "args": "o=10 AND 1=1",
+      "httpVersion": "HTTP/2.0",
+      "httpMethod": "HEAD",
+      "requestId": "1-5ffd8516-7f16578f3b0262c41c10f7a9"
+    }
+  }
+result: |
+  {
+    "timestamp": 1610450198436,
+    "formatVersion": 1,
+    "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+    "terminatingRuleId": "Default_Action",
+    "terminatingRuleType": "REGULAR",
+    "action": "ALLOW",
+    "httpSourceName": "ALB",
+    "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+    "ruleGroupList": [
+      {
+        "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
+        "excludedRules": [
+          {
+            "exclusionType": "EXCLUDED_AS_COUNT",
+            "ruleId": "SQLi_QUERYARGUMENTS"
+          }
+        ]
+      }
+    ],
+    "httpRequest": {
+      "clientIp": "10.0.0.1",
+      "country": "GR",
+      "headers": [
+        {
+          "name": "Host",
+          "value": "web-123456789.us-west-2.elb.amazonaws.com"
+        },
+        {
+          "name": "user-agent",
+          "value": "curl/7.64.1"
+        },
+        {
+          "name": "accept",
+          "value": "*/*"
+        }
+      ],
+      "uri": "/",
+      "args": "o=10 AND 1=1",
+      "httpVersion": "HTTP/2.0",
+      "httpMethod": "HEAD",
+      "requestId": "1-5ffd8516-7f16578f3b0262c41c10f7a9"
+    },
+    "p_event_time": "2021-01-12T11:16:38.436Z",
+    "p_any_ip_addresses": ["10.0.0.1"],
+    "p_any_trace_ids": ["1-5ffd8516-7f16578f3b0262c41c10f7a9"],
+    "p_log_type": "AWS.WAFWebACL"
+  }
+---
+name: waf_web_acl_non_terminating_rule
+logType: AWS.WAFWebACL
+input: |
+  {
+      "timestamp": 1610451138169,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "Default_Action",
+      "terminatingRuleType": "REGULAR",
+      "action": "ALLOW",
+      "terminatingRuleMatchDetails": [],
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "ruleGroupList": [
+          {
+              "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
+              "terminatingRule": {
+                  "ruleId": "SQLi_QUERYARGUMENTS",
+                  "action": "BLOCK",
+                  "ruleMatchDetails": null
+              },
+              "nonTerminatingMatchingRules": [],
+              "excludedRules": null
+          }
+      ],
+      "rateBasedRuleList": [],
+      "nonTerminatingMatchingRules": [
+          {
+              "ruleId": "AWS-AWSManagedRulesSQLiRuleSet",
+              "action": "COUNT",
+              "ruleMatchDetails": [
+                  {
+                      "conditionType": "SQL_INJECTION",
+                      "location": "ALL_QUERY_ARGS",
+                      "matchedData": [
+                          "10",
+                          "AND",
+                          "1"
+                      ]
+                  }
+              ]
+          }
+      ],
+      "httpRequest": {
+          "clientIp": "10.0.0.1",
+          "country": "GR",
+          "headers": [
+              {
+                  "name": "Host",
+                  "value": "web-123456789.us-west-2.elb.amazonaws.com"
+              },
+              {
+                  "name": "user-agent",
+                  "value": "curl/7.64.1"
+              },
+              {
+                  "name": "accept",
+                  "value": "*/*"
+              }
+          ],
+          "uri": "/",
+          "args": "o=10 AND 1=1",
+          "httpVersion": "HTTP/2.0",
+          "httpMethod": "HEAD",
+          "requestId": "1-5ffd88c2-174f31437530757342a794dd"
+      }
+  }
+result: |
+  {
+      "timestamp": 1610451138169,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "Default_Action",
+      "terminatingRuleType": "REGULAR",
+      "action": "ALLOW",
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "ruleGroupList": [
+          {
+              "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
+              "terminatingRule": {
+                  "ruleId": "SQLi_QUERYARGUMENTS",
+                  "action": "BLOCK"
+              }
+          }
+      ],
+      "nonTerminatingMatchingRules": [
+          {
+              "ruleId": "AWS-AWSManagedRulesSQLiRuleSet",
+              "action": "COUNT",
+              "ruleMatchDetails": [
+                  {
+                      "conditionType": "SQL_INJECTION",
+                      "location": "ALL_QUERY_ARGS",
+                      "matchedData": [
+                          "10",
+                          "AND",
+                          "1"
+                      ]
+                  }
+              ]
+          }
+      ],
+      "httpRequest": {
+          "clientIp": "10.0.0.1",
+          "country": "GR",
+          "headers": [
+              {
+                  "name": "Host",
+                  "value": "web-123456789.us-west-2.elb.amazonaws.com"
+              },
+              {
+                  "name": "user-agent",
+                  "value": "curl/7.64.1"
+              },
+              {
+                  "name": "accept",
+                  "value": "*/*"
+              }
+          ],
+          "uri": "/",
+          "args": "o=10 AND 1=1",
+          "httpVersion": "HTTP/2.0",
+          "httpMethod": "HEAD",
+          "requestId": "1-5ffd88c2-174f31437530757342a794dd"
+      },
+      "p_event_time": "2021-01-12T11:32:18.169Z",
+      "p_any_ip_addresses": ["10.0.0.1"],
+      "p_any_trace_ids": ["1-5ffd88c2-174f31437530757342a794dd"],
+      "p_log_type": "AWS.WAFWebACL"
+  }
+---
+name: waf_web_acl_regular_rule_block_action
+logType: AWS.WAFWebACL
+input: |
+  {
+      "timestamp": 1610442057134,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "block_badbot_by_user_agent",
+      "terminatingRuleType": "REGULAR",
+      "action": "BLOCK",
+      "terminatingRuleMatchDetails": [],
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "ruleGroupList": [],
+      "rateBasedRuleList": [],
+      "nonTerminatingMatchingRules": [],
+      "httpRequest": {
+          "clientIp": "10.0.0.1",
+          "country": "GR",
+          "headers": [
+              {
+                  "name": "Host",
+                  "value": "web-123456789.us-west-2.elb.amazonaws.com"
+              },
+              {
+                  "name": "accept",
+                  "value": "*/*"
+              },
+              {
+                  "name": "user-agent",
+                  "value": "Badbot"
+              },
+              {
+                  "name": "x-redacted-header",
+                  "value": "REDACTED"
+              }
+          ],
+          "uri": "/",
+          "args": "",
+          "httpVersion": "HTTP/2.0",
+          "httpMethod": "HEAD",
+          "requestId": "1-5ffd6549-297a96021598ace405676378"
+      }
+  }
+result: |
+  {
+      "timestamp": 1610442057134,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "block_badbot_by_user_agent",
+      "terminatingRuleType": "REGULAR",
+      "action": "BLOCK",
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "httpRequest": {
+          "clientIp": "10.0.0.1",
+          "country": "GR",
+          "headers": [
+              {
+                  "name": "Host",
+                  "value": "web-123456789.us-west-2.elb.amazonaws.com"
+              },
+              {
+                  "name": "accept",
+                  "value": "*/*"
+              },
+              {
+                  "name": "user-agent",
+                  "value": "Badbot"
+              },
+              {
+                  "name": "x-redacted-header",
+                  "value": "REDACTED"
+              }
+          ],
+          "uri": "/",
+          "args": "",
+          "httpVersion": "HTTP/2.0",
+          "httpMethod": "HEAD",
+          "requestId": "1-5ffd6549-297a96021598ace405676378"
+      },
+     "p_event_time": "2021-01-12T09:00:57.134Z",
+     "p_any_ip_addresses": ["10.0.0.1"],
+     "p_any_trace_ids": ["1-5ffd6549-297a96021598ace405676378"],
+     "p_log_type": "AWS.WAFWebACL"
+  }
+---
+name: waf_web_acl_rate_based_rule_block_action
+logType: AWS.WAFWebACL
+input: |
+  {
+      "timestamp": 1610380059751,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "sign_in_rate_limiting",
+      "terminatingRuleType": "RATE_BASED",
+      "action": "BLOCK",
+      "terminatingRuleMatchDetails": [],
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "ruleGroupList": [],
+      "rateBasedRuleList": [
+          {
+              "rateBasedRuleId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE_MANAGED:regional/ipset/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f_89ddcf0e-dac0-41af-a40a-a198e316aa04_IPV4/89ddcf0e-dac0-41af-a40a-a198e316aa04",
+              "rateBasedRuleName": "sign_in_rate_limiting",
+              "limitKey": "IP",
+              "maxRateAllowed": 100,
+              "limitValue": "10.0.0.1"
+          }
+      ],
+      "nonTerminatingMatchingRules": [],
+      "httpRequest": {
+          "clientIp": "10.0.0.1",
+          "country": "GR",
+          "headers": [
+              {
+                  "name": "Host",
+                  "value": "web-123456789.us-west-2.elb.amazonaws.com"
+              },
+              {
+                  "name": "user-agent",
+                  "value": "curl/7.64.1"
+              },
+              {
+                  "name": "accept",
+                  "value": "*/*"
+              }
+          ],
+          "uri": "/sign-in",
+          "args": "",
+          "httpVersion": "HTTP/2.0",
+          "httpMethod": "HEAD",
+          "requestId": "1-5ffc731b-3b2ebfc665f7de91566b9199"
+      }
+  }
+result: |
+  {
+      "timestamp": 1610380059751,
+      "formatVersion": 1,
+      "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+      "terminatingRuleId": "sign_in_rate_limiting",
+      "terminatingRuleType": "RATE_BASED",
+      "action": "BLOCK",
+      "httpSourceName": "ALB",
+      "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+      "rateBasedRuleList": [
+          {
+              "rateBasedRuleId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE_MANAGED:regional/ipset/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f_89ddcf0e-dac0-41af-a40a-a198e316aa04_IPV4/89ddcf0e-dac0-41af-a40a-a198e316aa04",
+              "rateBasedRuleName": "sign_in_rate_limiting",
+              "limitKey": "IP",
+              "maxRateAllowed": 100,
+              "limitValue": "10.0.0.1"
+          }
+      ],
+      "httpRequest": {
+          "clientIp": "10.0.0.1",
+          "country": "GR",
+          "headers": [
+              {
+                  "name": "Host",
+                  "value": "web-123456789.us-west-2.elb.amazonaws.com"
+              },
+              {
+                  "name": "user-agent",
+                  "value": "curl/7.64.1"
+              },
+              {
+                  "name": "accept",
+                  "value": "*/*"
+              }
+          ],
+          "uri": "/sign-in",
+          "args": "",
+          "httpVersion": "HTTP/2.0",
+          "httpMethod": "HEAD",
+          "requestId": "1-5ffc731b-3b2ebfc665f7de91566b9199"
+      },
+      "p_event_time": "2021-01-11T15:47:39.751Z",
+      "p_any_ip_addresses": ["10.0.0.1"],
+      "p_any_trace_ids": ["1-5ffc731b-3b2ebfc665f7de91566b9199"],
+      "p_log_type": "AWS.WAFWebACL"
+  }
+---
+name: waf_web_rule_group_block_action
+logType: AWS.WAFWebACL
+input: |
+  {
+    "timestamp": 1610380267298,
+    "formatVersion": 1,
+    "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+    "terminatingRuleId": "AWS-AWSManagedRulesSQLiRuleSet",
+    "terminatingRuleType": "MANAGED_RULE_GROUP",
+    "action": "BLOCK",
+    "terminatingRuleMatchDetails": [
+      {
+        "conditionType": "SQL_INJECTION",
+        "location": "ALL_QUERY_ARGS",
+        "matchedData": [
+          "10",
+          "AND",
+          "1"
+        ]
+      }
+    ],
+    "httpSourceName": "ALB",
+    "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+    "ruleGroupList": [
+      {
+        "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
+        "terminatingRule": {
+          "ruleId": "SQLi_QUERYARGUMENTS",
+          "action": "BLOCK",
+          "ruleMatchDetails": null
+        },
+        "nonTerminatingMatchingRules": [],
+        "excludedRules": null
+      }
+    ],
+    "rateBasedRuleList": [],
+    "nonTerminatingMatchingRules": [],
+    "httpRequest": {
+      "clientIp": "10.0.0.1",
+      "country": "GR",
+      "headers": [
+        {
+          "name": "Host",
+          "value": "web-123456789.us-west-2.elb.amazonaws.com"
+        },
+        {
+          "name": "user-agent",
+          "value": "curl/7.64.1"
+        },
+        {
+          "name": "accept",
+          "value": "*/*"
+        }
+      ],
+      "uri": "/",
+      "args": "o=10 AND 1=1",
+      "httpVersion": "HTTP/2.0",
+      "httpMethod": "HEAD",
+      "requestId": "1-5ffc73eb-280dd24d31bf31450ebdb518"
+    }
+  }
+result: |
+  {
+    "timestamp": 1610380267298,
+    "formatVersion": 1,
+    "webaclId": "arn:aws:wafv2:us-west-2:123456789EXAMPLE:regional/webacl/panther_web_dev/f96fe2f4-a2f4-4c06-a4bc-afd495bd675f",
+    "terminatingRuleId": "AWS-AWSManagedRulesSQLiRuleSet",
+    "terminatingRuleType": "MANAGED_RULE_GROUP",
+    "action": "BLOCK",
+    "terminatingRuleMatchDetails": [
+      {
+        "conditionType": "SQL_INJECTION",
+        "location": "ALL_QUERY_ARGS",
+        "matchedData": [
+          "10",
+          "AND",
+          "1"
+        ]
+      }
+    ],
+    "httpSourceName": "ALB",
+    "httpSourceId": "123456789EXAMPLE-app/web/768dd9170f08bb0d",
+    "ruleGroupList": [
+      {
+        "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
+        "terminatingRule": {
+          "ruleId": "SQLi_QUERYARGUMENTS",
+          "action": "BLOCK"
+        }
+      }
+    ],
+    "httpRequest": {
+      "clientIp": "10.0.0.1",
+      "country": "GR",
+      "headers": [
+        {
+          "name": "Host",
+          "value": "web-123456789.us-west-2.elb.amazonaws.com"
+        },
+        {
+          "name": "user-agent",
+          "value": "curl/7.64.1"
+        },
+        {
+          "name": "accept",
+          "value": "*/*"
+        }
+      ],
+      "uri": "/",
+      "args": "o=10 AND 1=1",
+      "httpVersion": "HTTP/2.0",
+      "httpMethod": "HEAD",
+      "requestId": "1-5ffc73eb-280dd24d31bf31450ebdb518"
+    },
+    "p_event_time": "2021-01-11T15:51:07.298Z",
+    "p_any_ip_addresses": ["10.0.0.1"],
+    "p_any_trace_ids": ["1-5ffc73eb-280dd24d31bf31450ebdb518"],
+    "p_log_type": "AWS.WAFWebACL"
+  }

--- a/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
@@ -28,73 +28,73 @@ import (
 // - The prefix `aws-waf-logs-` is mandatory for Web ACL logging delivery stream names.
 // nolint:lll,maligned
 type WAFWebACL struct {
-	Action pantherlog.String `json:"action" validate:"required" description:"The action applied by WAF. Possible values for a terminating rule: ALLOW and BLOCK. COUNT is not a valid value for a terminating rule."`
-	FormatVersion pantherlog.Uint8 `json:"formatVersion" description:"The format version for the log."`
-	HTTPRequest HTTPRequest `json:"httpRequest" description:"The metadata about the request."`
-	HTTPSourceID pantherlog.String `json:"httpSourceId" description:"The source ID. This field shows the ID of the associated resource."`
-	HTTPSourceName pantherlog.String `json:"httpSourceName" description:"The source of the request. Possible values: CF for Amazon CloudFront, APIGW for Amazon API Gateway, ALB for Application Load Balancer, and APPSYNC for AWS AppSync."`
-	NonTerminatingMatchingRules []RuleDetail `json:"nonTerminatingMatchingRules" description:"The list of non-terminating rules in the rule group that match the request. These are always COUNT rules (non-terminating rules that match)."`
-	RateBasedRuleList []RateBasedRuleListDetail `json:"rateBasedRuleList" description:"The list of rate-based rules that acted on the request."`
-	RuleGroupList []RuleGroupListDetail `json:"ruleGroupList" description:"The list of rule groups that acted on this request. In the preceding code example, there is only one."`
-	TerminatingRuleID pantherlog.String `json:"terminatingRuleId"`
-	TerminatingRuleMatchDetails []RuleMatchDetail `json:"terminatingRuleMatchDetails" description:"Detailed information about the terminating rule that matched the request. A terminating rule has an action that ends the inspection process against a web request. Possible actions for a terminating rule are ALLOW and BLOCK. This is only populated for SQL injection and cross-site scripting (XSS) match rule statements. As with all rule statements that inspect for more than one thing, AWS WAF applies the action on the first match and stops inspecting the web request. A web request with a terminating action could contain other threats, in addition to the one reported in the log."`
-	TerminatingRuleType pantherlog.String `json:"terminatingRuleType" description:"The type of rule that terminated the request. Possible values: RATE_BASED, REGULAR, GROUP, and MANAGED_RULE_GROUP."`
-	Timestamp pantherlog.Time `json:"timestamp" tcodec:"unix_ms" event_time:"true" description:"The timestamp in milliseconds."`
-	WebACLID pantherlog.String `json:"webaclId" description:"The GUID of the web ACL."`
+	Action                      pantherlog.String         `json:"action" validate:"required" description:"The action applied by WAF. Possible values for a terminating rule: ALLOW and BLOCK. COUNT is not a valid value for a terminating rule."`
+	FormatVersion               pantherlog.Uint8          `json:"formatVersion" description:"The format version for the log."`
+	HTTPRequest                 HTTPRequest               `json:"httpRequest" description:"The metadata about the request."`
+	HTTPSourceID                pantherlog.String         `json:"httpSourceId" description:"The source ID. This field shows the ID of the associated resource."`
+	HTTPSourceName              pantherlog.String         `json:"httpSourceName" description:"The source of the request. Possible values: CF for Amazon CloudFront, APIGW for Amazon API Gateway, ALB for Application Load Balancer, and APPSYNC for AWS AppSync."`
+	NonTerminatingMatchingRules []RuleDetail              `json:"nonTerminatingMatchingRules" description:"The list of non-terminating rules in the rule group that match the request. These are always COUNT rules (non-terminating rules that match)."`
+	RateBasedRuleList           []RateBasedRuleListDetail `json:"rateBasedRuleList" description:"The list of rate-based rules that acted on the request."`
+	RuleGroupList               []RuleGroupListDetail     `json:"ruleGroupList" description:"The list of rule groups that acted on this request. In the preceding code example, there is only one."`
+	TerminatingRuleID           pantherlog.String         `json:"terminatingRuleId"`
+	TerminatingRuleMatchDetails []RuleMatchDetail         `json:"terminatingRuleMatchDetails" description:"Detailed information about the terminating rule that matched the request. A terminating rule has an action that ends the inspection process against a web request. Possible actions for a terminating rule are ALLOW and BLOCK. This is only populated for SQL injection and cross-site scripting (XSS) match rule statements. As with all rule statements that inspect for more than one thing, AWS WAF applies the action on the first match and stops inspecting the web request. A web request with a terminating action could contain other threats, in addition to the one reported in the log."`
+	TerminatingRuleType         pantherlog.String         `json:"terminatingRuleType" description:"The type of rule that terminated the request. Possible values: RATE_BASED, REGULAR, GROUP, and MANAGED_RULE_GROUP."`
+	Timestamp                   pantherlog.Time           `json:"timestamp" tcodec:"unix_ms" event_time:"true" description:"The timestamp in milliseconds."`
+	WebACLID                    pantherlog.String         `json:"webaclId" description:"The GUID of the web ACL."`
 }
 
 // nolint:lll,maligned
 type RuleGroupListDetail struct {
-	ExcludedRules []ExcludedRule `json:"excludedRules" description:"The list of rules in the rule group that you have excluded. The action for these rules is set to COUNT."`
-	NonTerminatingMatchingRules []RuleDetail `json:"nonTerminatingMatchingRules"`
-	RuleGroupID pantherlog.String `json:"ruleGroupId"`
-	TerminatingRule *RuleDetail `json:"terminatingRule"`
+	ExcludedRules               []ExcludedRule    `json:"excludedRules" description:"The list of rules in the rule group that you have excluded. The action for these rules is set to COUNT."`
+	NonTerminatingMatchingRules []RuleDetail      `json:"nonTerminatingMatchingRules"`
+	RuleGroupID                 pantherlog.String `json:"ruleGroupId"`
+	TerminatingRule             *RuleDetail       `json:"terminatingRule"`
 }
 
 // nolint:lll,maligned
 type ExcludedRule struct {
 	ExclusionType pantherlog.String `json:"exclusionType" description:"A type that indicates that the excluded rule has the action COUNT (most likely value is EXCLUDED_AS_COUNT)."`
-	RuleID pantherlog.String `json:"ruleId" description:"The ID of the rule within the rule group that is excluded."`
+	RuleID        pantherlog.String `json:"ruleId" description:"The ID of the rule within the rule group that is excluded."`
 }
 
 // nolint:lll,maligned
 type RuleDetail struct {
-	RuleID pantherlog.String `json:"ruleId" description:"The Rule ID."`
-	Action pantherlog.String `json:"action" description:"The configured rule action. For non-terminating rules the value is always COUNT."`
+	RuleID           pantherlog.String  `json:"ruleId" description:"The Rule ID."`
+	Action           pantherlog.String  `json:"action" description:"The configured rule action. For non-terminating rules the value is always COUNT."`
 	RuleMatchDetails *[]RuleMatchDetail `json:"ruleMatchDetails" description:"Detailed information about the rule that matched the request. This field is only populated for SQL injection and cross-site scripting (XSS) match rule statements."`
 }
 
 // nolint:lll,maligned
 type RuleMatchDetail struct {
 	ConditionType pantherlog.String `json:"conditionType" description:"The vulnerability type, either SQL_INJECTION or XSS"`
-	Location pantherlog.String `json:"location" description:"The request parameter type that provided the match. Can be ALL_QUERY_ARGS, HEADER etc."`
-	MatchedData []string `json:"matchedData" description:"The list of strings that provides the match, e.g. [\"10\", \"AND\", \"1\"]"`
+	Location      pantherlog.String `json:"location" description:"The request parameter type that provided the match. Can be ALL_QUERY_ARGS, HEADER etc."`
+	MatchedData   []string          `json:"matchedData" description:"The list of strings that provides the match, e.g. [\"10\", \"AND\", \"1\"]"`
 }
 
 // nolint:lll,maligned
 type RateBasedRuleListDetail struct {
-	LimitKey pantherlog.String `json:"limitKey"`
-	LimitValue pantherlog.String `json:"limitValue"`
-	MaxRateAllowed pantherlog.Uint32 `json:"maxRateAllowed"`
-	RateBasedRuleID pantherlog.String `json:"rateBasedRuleId"`
+	LimitKey          pantherlog.String `json:"limitKey"`
+	LimitValue        pantherlog.String `json:"limitValue"`
+	MaxRateAllowed    pantherlog.Uint32 `json:"maxRateAllowed"`
+	RateBasedRuleID   pantherlog.String `json:"rateBasedRuleId"`
 	RateBasedRuleName pantherlog.String `json:"rateBasedRuleName"`
 }
 
 // nolint:lll,maligned
 type HTTPRequest struct {
-	Args pantherlog.String `json:"args" description:"The HTTP Request query string."`
-	ClientIP pantherlog.String `json:"clientIp" panther:"ip" description:"The IP address of the client sending the request."`
-	Country pantherlog.String `json:"country" description:"The source country of the request. If AWS WAF is unable to determine the country of origin, it sets this field to -."`
-	Headers []HTTPHeader `json:"headers" description:"The list of headers."`
-	HTTPMethod pantherlog.String `json:"httpMethod" description:"The HTTP method in the request."`
+	Args        pantherlog.String `json:"args" description:"The HTTP Request query string."`
+	ClientIP    pantherlog.String `json:"clientIp" panther:"ip" description:"The IP address of the client sending the request."`
+	Country     pantherlog.String `json:"country" description:"The source country of the request. If AWS WAF is unable to determine the country of origin, it sets this field to -."`
+	Headers     []HTTPHeader      `json:"headers" description:"The list of headers."`
+	HTTPMethod  pantherlog.String `json:"httpMethod" description:"The HTTP method in the request."`
 	HTTPVersion pantherlog.String `json:"httpVersion" description:"The HTTP version, e.g. HTTP/2.0."`
-	RequestID pantherlog.String `json:"requestId" panther:"trace_id" description:"The ID of the request, which is generated by the underlying host service. For Application Load Balancer, this is the trace ID. For all others, this is the request ID."`
-	URI pantherlog.String `json:"uri" description:"The URI of the request."`
+	RequestID   pantherlog.String `json:"requestId" panther:"trace_id" description:"The ID of the request, which is generated by the underlying host service. For Application Load Balancer, this is the trace ID. For all others, this is the request ID."`
+	URI         pantherlog.String `json:"uri" description:"The URI of the request."`
 }
 
 // nolint:lll,maligned
 type HTTPHeader struct {
 	// Maybe we should apply some normalization here, e.g. always convert to lowercase?
-	Name pantherlog.String `json:"name" description:"The header name."`
+	Name  pantherlog.String `json:"name" description:"The header name."`
 	Value pantherlog.String `json:"value" description:"The header value."`
 }

--- a/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
@@ -61,7 +61,7 @@ type ExcludedRule struct {
 type RuleDetail struct {
 	RuleID           pantherlog.String  `json:"ruleId" description:"The Rule ID."`
 	Action           pantherlog.String  `json:"action" description:"The configured rule action. For non-terminating rules the value is always COUNT."`
-	RuleMatchDetails *[]RuleMatchDetail `json:"ruleMatchDetails" description:"Detailed information about the rule that matched the request. This field is only populated for SQL injection and cross-site scripting (XSS) match rule statements."`
+	RuleMatchDetails []RuleMatchDetail `json:"ruleMatchDetails" description:"Detailed information about the rule that matched the request. This field is only populated for SQL injection and cross-site scripting (XSS) match rule statements."`
 }
 
 // nolint:lll,maligned

--- a/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
@@ -1,0 +1,100 @@
+package awslogs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+)
+
+// AWS WAF Web ACL Log event structure: https://docs.aws.amazon.com/waf/latest/developerguide/logging.html
+// File naming convention follows the Firehose delivery stream pattern:
+// - https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name
+// - The prefix `aws-waf-logs-` is mandatory for Web ACL logging delivery stream names.
+// nolint:lll,maligned
+type WAFWebACL struct {
+	Action pantherlog.String `json:"action" validate:"required" description:"The action applied by WAF. Possible values for a terminating rule: ALLOW and BLOCK. COUNT is not a valid value for a terminating rule."`
+	FormatVersion pantherlog.Uint8 `json:"formatVersion" description:"The format version for the log."`
+	HTTPRequest HTTPRequest `json:"httpRequest" description:"The metadata about the request."`
+	HTTPSourceID pantherlog.String `json:"httpSourceId" description:"The source ID. This field shows the ID of the associated resource."`
+	HTTPSourceName pantherlog.String `json:"httpSourceName" description:"The source of the request. Possible values: CF for Amazon CloudFront, APIGW for Amazon API Gateway, ALB for Application Load Balancer, and APPSYNC for AWS AppSync."`
+	NonTerminatingMatchingRules []RuleDetail `json:"nonTerminatingMatchingRules" description:"The list of non-terminating rules in the rule group that match the request. These are always COUNT rules (non-terminating rules that match)."`
+	RateBasedRuleList []RateBasedRuleListDetail `json:"rateBasedRuleList" description:"The list of rate-based rules that acted on the request."`
+	RuleGroupList []RuleGroupListDetail `json:"ruleGroupList" description:"The list of rule groups that acted on this request. In the preceding code example, there is only one."`
+	TerminatingRuleID pantherlog.String `json:"terminatingRuleId"`
+	TerminatingRuleMatchDetails []RuleMatchDetail `json:"terminatingRuleMatchDetails" description:"Detailed information about the terminating rule that matched the request. A terminating rule has an action that ends the inspection process against a web request. Possible actions for a terminating rule are ALLOW and BLOCK. This is only populated for SQL injection and cross-site scripting (XSS) match rule statements. As with all rule statements that inspect for more than one thing, AWS WAF applies the action on the first match and stops inspecting the web request. A web request with a terminating action could contain other threats, in addition to the one reported in the log."`
+	TerminatingRuleType pantherlog.String `json:"terminatingRuleType" description:"The type of rule that terminated the request. Possible values: RATE_BASED, REGULAR, GROUP, and MANAGED_RULE_GROUP."`
+	Timestamp pantherlog.Time `json:"timestamp" tcodec:"unix_ms" event_time:"true" description:"The timestamp in milliseconds."`
+	WebACLID pantherlog.String `json:"webaclId" description:"The GUID of the web ACL."`
+}
+
+// nolint:lll,maligned
+type RuleGroupListDetail struct {
+	ExcludedRules []ExcludedRule `json:"excludedRules" description:"The list of rules in the rule group that you have excluded. The action for these rules is set to COUNT."`
+	NonTerminatingMatchingRules []RuleDetail `json:"nonTerminatingMatchingRules"`
+	RuleGroupID pantherlog.String `json:"ruleGroupId"`
+	TerminatingRule *RuleDetail `json:"terminatingRule"`
+}
+
+// nolint:lll,maligned
+type ExcludedRule struct {
+	ExclusionType pantherlog.String `json:"exclusionType" description:"A type that indicates that the excluded rule has the action COUNT (most likely value is EXCLUDED_AS_COUNT)."`
+	RuleID pantherlog.String `json:"ruleId" description:"The ID of the rule within the rule group that is excluded."`
+}
+
+// nolint:lll,maligned
+type RuleDetail struct {
+	RuleID pantherlog.String `json:"ruleId" description:"The Rule ID."`
+	Action pantherlog.String `json:"action" description:"The configured rule action. For non-terminating rules the value is always COUNT."`
+	RuleMatchDetails *[]RuleMatchDetail `json:"ruleMatchDetails" description:"Detailed information about the rule that matched the request. This field is only populated for SQL injection and cross-site scripting (XSS) match rule statements."`
+}
+
+// nolint:lll,maligned
+type RuleMatchDetail struct {
+	ConditionType pantherlog.String `json:"conditionType" description:"The vulnerability type, either SQL_INJECTION or XSS"`
+	Location pantherlog.String `json:"location" description:"The request parameter type that provided the match. Can be ALL_QUERY_ARGS, HEADER etc."`
+	MatchedData []string `json:"matchedData" description:"The list of strings that provides the match, e.g. [\"10\", \"AND\", \"1\"]"`
+}
+
+// nolint:lll,maligned
+type RateBasedRuleListDetail struct {
+	LimitKey pantherlog.String `json:"limitKey"`
+	LimitValue pantherlog.String `json:"limitValue"`
+	MaxRateAllowed pantherlog.Uint32 `json:"maxRateAllowed"`
+	RateBasedRuleID pantherlog.String `json:"rateBasedRuleId"`
+	RateBasedRuleName pantherlog.String `json:"rateBasedRuleName"`
+}
+
+// nolint:lll,maligned
+type HTTPRequest struct {
+	Args pantherlog.String `json:"args" description:"The HTTP Request query string."`
+	ClientIP pantherlog.String `json:"clientIp" panther:"ip" description:"The IP address of the client sending the request."`
+	Country pantherlog.String `json:"country" description:"The source country of the request. If AWS WAF is unable to determine the country of origin, it sets this field to -."`
+	Headers []HTTPHeader `json:"headers" description:"The list of headers."`
+	HTTPMethod pantherlog.String `json:"httpMethod" description:"The HTTP method in the request."`
+	HTTPVersion pantherlog.String `json:"httpVersion" description:"The HTTP version, e.g. HTTP/2.0."`
+	RequestID pantherlog.String `json:"requestId" panther:"trace_id" description:"The ID of the request, which is generated by the underlying host service. For Application Load Balancer, this is the trace ID. For all others, this is the request ID."`
+	URI pantherlog.String `json:"uri" description:"The URI of the request."`
+}
+
+// nolint:lll,maligned
+type HTTPHeader struct {
+	// Maybe we should apply some normalization here, e.g. always convert to lowercase?
+	Name pantherlog.String `json:"name" description:"The header name."`
+	Value pantherlog.String `json:"value" description:"The header value."`
+}

--- a/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl.go
@@ -59,8 +59,8 @@ type ExcludedRule struct {
 
 // nolint:lll,maligned
 type RuleDetail struct {
-	RuleID           pantherlog.String  `json:"ruleId" description:"The Rule ID."`
-	Action           pantherlog.String  `json:"action" description:"The configured rule action. For non-terminating rules the value is always COUNT."`
+	RuleID           pantherlog.String `json:"ruleId" description:"The Rule ID."`
+	Action           pantherlog.String `json:"action" description:"The configured rule action. For non-terminating rules the value is always COUNT."`
 	RuleMatchDetails []RuleMatchDetail `json:"ruleMatchDetails" description:"Detailed information about the rule that matched the request. This field is only populated for SQL injection and cross-site scripting (XSS) match rule statements."`
 }
 

--- a/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl_test.go
+++ b/internal/log_analysis/log_processor/parsers/awslogs/waf_web_acl_test.go
@@ -1,0 +1,29 @@
+package awslogs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/logtypes/logtesting"
+)
+
+func TestWAFWebACL(t *testing.T) {
+	logtesting.RunTestsFromYAML(t, LogTypes(), "./testdata/waf_web_acl_tests.yml")
+}


### PR DESCRIPTION
## Background

Enable log parsing for [AWS WAF Web ACL](https://docs.aws.amazon.com/waf/latest/developerguide/logging.html).

Addresses https://github.com/panther-labs/panther/issues/2341.

## Changes

- Define new log parser `struct` `WAFWebACL` along with nested object `struct` definitions.
- Register the new parser in `internal/log_analysis/log_processor/parsers/awslogs/awslogs.go`.
- Add a list of test cases specified in #2341, in YAML format.

## Testing

- New log type is available on Panther frontend for selection.
- Rule Engine:
  * Composed a rule that checked for specific log event values.
  * Send HTTP requests that were blocked by WAF rule.
  * Alert was triggered in Panther. 
- Verified log processing by inspecting Lambda Cloudwatch Logs.
- Verified AWS Glue Data Catalog registration by running sample Athena queries.
