### PR TITLE
fix: issue where alert wouldn't render if rule got deleted

### DIFF
--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
@@ -32,7 +32,7 @@ import { GetPolicySummary } from '../graphql/getPolicySummary.generated';
 
 interface AlertDetailsInfoProps {
   alert: AlertDetails['alert'];
-  policy: GetPolicySummary['policy'];
+  policy?: GetPolicySummary['policy'];
 }
 
 const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, policy }) => {

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/PolicyAlertDetails.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/PolicyAlertDetails.tsx
@@ -17,10 +17,9 @@
  */
 
 import React from 'react';
-import { Alert, Box, Card, Flex } from 'pouncejs';
+import { Box, Card, Flex } from 'pouncejs';
 import Skeleton from 'Pages/AlertDetails/Skeleton';
 import ErrorBoundary from 'Components/ErrorBoundary';
-import { extractErrorMessage } from 'Helpers/utils';
 import { AlertDetailsFull } from 'Source/graphql/fragments/AlertDetailsFull.generated';
 import { AlertSummaryPolicyInfo } from 'Generated/schema';
 import { useGetPolicySummary } from './graphql/getPolicySummary.generated';
@@ -33,27 +32,12 @@ interface PolicyAlertDetailsProps {
 
 const PolicyAlertDetails: React.FC<PolicyAlertDetailsProps> = ({ alert }) => {
   const alertDetectionInfo = alert.detection as AlertSummaryPolicyInfo;
-  const { data, loading, error } = useGetPolicySummary({
+  const { data, loading } = useGetPolicySummary({
     variables: { input: { id: alertDetectionInfo.policyId } },
   });
 
   if (loading && !data) {
     return <Skeleton />;
-  }
-
-  if (error) {
-    return (
-      <Box mb={6}>
-        <Alert
-          variant="error"
-          title="Couldn't load alert"
-          description={
-            extractErrorMessage(error) ||
-            "An unknown error occurred and we couldn't load the alert details from the server"
-          }
-        />
-      </Box>
-    );
   }
 
   return (

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
@@ -31,7 +31,7 @@ import { GetRuleSummary } from '../graphql/getRuleSummary.generated';
 
 interface AlertDetailsInfoProps {
   alert: AlertDetails['alert'];
-  rule: GetRuleSummary['rule'];
+  rule?: GetRuleSummary['rule'];
 }
 
 const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, rule }) => {

--- a/web/src/pages/AlertDetails/RuleAlertDetails/RuleAlertDetails.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/RuleAlertDetails.tsx
@@ -17,12 +17,11 @@
  */
 
 import React from 'react';
-import { Alert, Box, Card, Flex, TabList, TabPanel, TabPanels, Tabs } from 'pouncejs';
+import { Box, Card, Flex, TabList, TabPanel, TabPanels, Tabs } from 'pouncejs';
 import ErrorBoundary from 'Components/ErrorBoundary';
 import { AlertDetailsRuleInfo } from 'Generated/schema';
 import { AlertDetailsFull } from 'Source/graphql/fragments/AlertDetailsFull.generated';
 import { BorderedTab, BorderTabDivider } from 'Components/BorderedTab';
-import { extractErrorMessage } from 'Helpers/utils';
 import { DEFAULT_LARGE_PAGE_SIZE } from 'Source/constants';
 import { AlertDetails } from 'Pages/AlertDetails';
 import invert from 'lodash/invert';
@@ -57,7 +56,7 @@ const RuleAlertDetails: React.FC<RuleAlertDetailsProps> = ({ alert, fetchMore })
 
   const alertDetectionInfo = alert.detection as AlertDetailsRuleInfo;
 
-  const { data, loading, error } = useGetRuleSummary({
+  const { data, loading } = useGetRuleSummary({
     variables: { input: { id: alertDetectionInfo.ruleId } },
   });
 
@@ -96,21 +95,6 @@ const RuleAlertDetails: React.FC<RuleAlertDetailsProps> = ({ alert, fetchMore })
 
   if (loading && !data) {
     return <Skeleton />;
-  }
-
-  if (error) {
-    return (
-      <Box mb={6}>
-        <Alert
-          variant="error"
-          title="Couldn't load alert"
-          description={
-            extractErrorMessage(error) ||
-            "An unknown error occurred and we couldn't load the alert details from the server"
-          }
-        />
-      </Box>
-    );
   }
 
   return (


### PR DESCRIPTION
## Background

When a rule is deleted you are expected to be able to still see the alerts that this rule has generated. This used to work, but in the previous sprint we modified some code and now it doesn't. This PR fixes that.

## Changes

- Allow rendering of Alert when associated Rule or Policy has been deleted

## Testing

- Locally
