### PR TITLE
Pass through Log Types filter

### DIFF
--- a/internal/core/analysis_api/handlers/list_rules.go
+++ b/internal/core/analysis_api/handlers/list_rules.go
@@ -92,6 +92,7 @@ func ruleScanInput(input *models.ListRulesInput) (*dynamodb.ScanInput, error) {
 		LastModifiedBy: input.LastModifiedBy,
 		NameContains:   input.NameContains,
 		Severity:       input.Severity,
+		ResourceTypes: 	input.LogTypes,
 		Tags:           input.Tags,
 	}
 

--- a/internal/core/analysis_api/handlers/list_rules.go
+++ b/internal/core/analysis_api/handlers/list_rules.go
@@ -92,7 +92,7 @@ func ruleScanInput(input *models.ListRulesInput) (*dynamodb.ScanInput, error) {
 		LastModifiedBy: input.LastModifiedBy,
 		NameContains:   input.NameContains,
 		Severity:       input.Severity,
-		ResourceTypes: 	input.LogTypes,
+		ResourceTypes:  input.LogTypes,
 		Tags:           input.Tags,
 	}
 


### PR DESCRIPTION
## Background

The `ListRules` endpoint currently drops the `LogTypes` filter entirely (ignoring it). This fix just passes that filter through.

## Changes

- Pass `LogTypes` filter through when calling `ListRules`

## Testing

- Deployed to dev env and tested manually
