### PR TITLE
Update stackset roles

### DIFF
--- a/deployments/auxiliary/cloudformation/panther-stackset-execution-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-execution-role.yml
@@ -15,37 +15,46 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 AWSTemplateFormatVersion: 2010-09-09
-Description: >
-  Panther IAM Role for creating and managing StackSets. The purpose of this role is to assume
-  the execution IAM roles in each target account for configuring various Panther infrastructure.
+Description: IAM roles for an account being scanned by Panther.
 
 Parameters:
+  MasterAccountId:
+    Type: String
+    Default: ''
   MasterAccountRegion:
     Type: String
-    Default: !Ref ${AWS::Region}
+    Default: ''
 
 Resources:
-  CloudFormationStackSetAdminRole:
+  CloudFormationStackSetExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub PantherCloudFormationStackSetAdminRole-${MasterAccountRegion} # DO NOT CHANGE! set in mage deploy
+      RoleName: !Sub PantherCloudFormationStackSetExecutionRole-${MasterAccountRegion}
+      Description: CloudFormation assumes this role to execute a stack set
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
-              Service: cloudformation.amazonaws.com
+              AWS: !Sub arn:${AWS::Partition}:iam::${MasterAccountId}:root
             Action: sts:AssumeRole
       Policies:
-        - PolicyName: AssumeRolesInTargetAccounts
+        - PolicyName: ManageCloudFormationStack
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: sts:AssumeRole
-                Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole-${MasterAccountRegion}
-
-Outputs:
-  CloudFormationStackSetAdminRoleArn:
-    Description: The Arn of the CloudFormation StackSet IAM Role for sending data to Panther.
-    Value: !GetAtt CloudFormationStackSetAdminRole.Arn
+                Action: cloudformation:*
+                Resource: '*'
+        - PolicyName: PantherSetupRealTimeEvents
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - events:*
+                  - sns:*
+                Resource: '*'
+      Tags:
+        - Key: Application
+          Value: Panther

--- a/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
+++ b/deployments/auxiliary/cloudformation/panther-stackset-iam-admin-role.yml
@@ -22,13 +22,19 @@ Description: >
 Parameters:
   MasterAccountRegion:
     Type: String
-    Default: !Ref ${AWS::Region}
+    Default: ''
+
+Conditions:
+  UseCurrentRegion: !Equals ['', !Ref MasterAccountRegion]
 
 Resources:
   CloudFormationStackSetAdminRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub PantherCloudFormationStackSetAdminRole-${MasterAccountRegion} # DO NOT CHANGE! set in mage deploy
+      RoleName: !If
+        - UseCurrentRegion
+        - !Sub PantherCloudFormationStackSetAdminRole-${AWS::Region}
+        - !Sub PantherCloudFormationStackSetAdminRole-${MasterAccountRegion}
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -43,7 +49,10 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole-${MasterAccountRegion}
+                Resource: !If
+                  - UseCurrentRegion
+                  - !Sub arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole-${AWS::Region}
+                  - !Sub arn:${AWS::Partition}:iam::*:role/PantherCloudFormationStackSetExecutionRole-${MasterAccountRegion}
 
 Outputs:
   CloudFormationStackSetAdminRoleArn:


### PR DESCRIPTION
## Background

The stackset roles only work if you deploy the stackset admin role in the same account and region as Panther. This updates the stackset admin role so it is not region dependent (but remains backwards compatible) and adds a new standalone stackset execution role for users who don't want to have panther be the stackset admin accout.

## Changes

- Created new optional standalone stackset execution role
- Updated new stackset admin role to not have to be deployed in the same region as Panther

## Testing

- Deployed the stackset admin & execution role templates into my dev account and validated I could use them
- Deployed the stackset admin role without specifying a region and verified it behaved as it did previously (backwards compatibility) 
