### PR TITLE
Generated Alert Fields - Destinations Fix

### DIFF
--- a/api/lambda/analysis/engine.go
+++ b/api/lambda/analysis/engine.go
@@ -90,23 +90,23 @@ type RuleResult struct {
 	RuleID     string `json:"ruleId"`
 	RuleOutput bool   `json:"ruleOutput"`
 	// Rule function outputs
-	RuleError          string `json:"ruleError"`
-	TitleOutput        string `json:"titleOutput"`
-	TitleError         string `json:"titleError"`
-	DescriptionOutput  string `json:"descriptionOutput"`
-	DescriptionError   string `json:"descriptionError"`
-	ReferenceOutput    string `json:"referenceOutput"`
-	ReferenceError     string `json:"referenceError"`
-	SeverityOutput     string `json:"severityOutput"`
-	SeverityError      string `json:"severityError"`
-	RunbookOutput      string `json:"runbookOutput"`
-	RunbookError       string `json:"runbookError"`
-	DestinationsOutput string `json:"destinationsOutput"`
-	DestinationsError  string `json:"destinationsError"`
-	DedupOutput        string `json:"dedupOutput"`
-	DedupError         string `json:"dedupError"`
-	AlertContextOutput string `json:"alertContextOutput"`
-	AlertContextError  string `json:"alertContextError"`
+	RuleError          string   `json:"ruleError"`
+	TitleOutput        string   `json:"titleOutput"`
+	TitleError         string   `json:"titleError"`
+	DescriptionOutput  string   `json:"descriptionOutput"`
+	DescriptionError   string   `json:"descriptionError"`
+	ReferenceOutput    string   `json:"referenceOutput"`
+	ReferenceError     string   `json:"referenceError"`
+	SeverityOutput     string   `json:"severityOutput"`
+	SeverityError      string   `json:"severityError"`
+	RunbookOutput      string   `json:"runbookOutput"`
+	RunbookError       string   `json:"runbookError"`
+	DestinationsOutput []string `json:"destinationsOutput"`
+	DestinationsError  string   `json:"destinationsError"`
+	DedupOutput        string   `json:"dedupOutput"`
+	DedupError         string   `json:"dedupError"`
+	AlertContextOutput string   `json:"alertContextOutput"`
+	AlertContextError  string   `json:"alertContextError"`
 	// Indicates general error in the Python script (import error, syntax error, etc).
 	GenericError string `json:"genericError"`
 	// True if any error (generic or from rule functions) is included in the result.

--- a/internal/core/analysis_api/analysis/rule_engine.go
+++ b/internal/core/analysis_api/analysis/rule_engine.go
@@ -145,7 +145,7 @@ func buildTestSubRecordList(output []string, error string) *models.TestDetection
 	result := &models.TestDetectionSubRecord{}
 
 	if len(output) != 0 {
-		result.Output = aws.String(strings.Join(output, ","))
+		result.Output = aws.String(strings.Join(output, ", "))
 	}
 	if error != "" {
 		result.Error = &models.TestError{Message: error}

--- a/internal/core/analysis_api/analysis/rule_engine.go
+++ b/internal/core/analysis_api/analysis/rule_engine.go
@@ -20,10 +20,10 @@ package analysis
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"

--- a/internal/core/analysis_api/analysis/rule_engine.go
+++ b/internal/core/analysis_api/analysis/rule_engine.go
@@ -20,7 +20,9 @@ package analysis
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	jsoniter "github.com/json-iterator/go"
@@ -112,7 +114,7 @@ func (e *RuleEngine) TestRule(rule *models.TestRuleInput) (*models.TestRuleOutpu
 			record.Functions.Reference = buildTestSubRecord(result.ReferenceOutput, result.ReferenceError)
 			record.Functions.Severity = buildTestSubRecord(result.SeverityOutput, result.SeverityError)
 			record.Functions.Runbook = buildTestSubRecord(result.RunbookOutput, result.RunbookError)
-			record.Functions.Destinations = buildTestSubRecord(result.DestinationsOutput, result.DestinationsError)
+			record.Functions.Destinations = buildTestSubRecordList(result.DestinationsOutput, result.DestinationsError)
 		}
 
 		testResult.Results[i] = record
@@ -128,6 +130,22 @@ func buildTestSubRecord(output, error string) *models.TestDetectionSubRecord {
 	result := &models.TestDetectionSubRecord{}
 	if output != "" {
 		result.Output = &output
+	}
+	if error != "" {
+		result.Error = &models.TestError{Message: error}
+	}
+	return result
+}
+
+func buildTestSubRecordList(output []string, error string) *models.TestDetectionSubRecord {
+	if len(output) == 0 && error == "" {
+		return nil
+	}
+
+	result := &models.TestDetectionSubRecord{}
+
+	if len(output) != 0 {
+		result.Output = aws.String(strings.Join(output, ","))
 	}
 	if error != "" {
 		result.Error = &models.TestError{Message: error}


### PR DESCRIPTION
## Background

Related to some issues discovered when debugging the FE implementation. 

The analysis-api test record expects a string to be returned from DDB for the destinationsOutput, however it will return a string set (since that's what the rules-engine will store in DDB)

## Changes

- Changed analysis-api model destinationsOutput field to be `[]string`
- Patched the `buildTestSubRecord` for `Destinations` with `buildTestSubRecordList` which handles the case of 

## Testing

- `mage test:ci`
- Deployment and manual testing in `us-east-1`
