### PR TITLE
Pass stack name correctly during master:deploy

### DIFF
--- a/tools/mage/master/deploy.go
+++ b/tools/mage/master/deploy.go
@@ -119,7 +119,7 @@ func Deploy() error {
 		params = append(params, strings.Split(p, " ")...)
 	}
 
-	return util.SamDeploy(defaultStackName, pkg, params...)
+	return util.SamDeploy(stack, pkg, params...)
 }
 
 // Stop early if there is a known issue with the dev environment.


### PR DESCRIPTION
## Background

My release testing failed when I tried to upgrade a v1.14.3 stack to v1.15.0-RC. Turns out I had deployed the root stack with a non-traditional name, but `STACK=my-stack-name mage master:deploy` did not work as it should have - `mage` still passed the default `panther` stack name instead of the one I specified in the environment.

## Changes

- Correctly pass STACK environment variable to the deploy code

## Testing

- Searched for all references to the default stack name to make sure there were no other places that were using it
- Release upgrade testing (ongoing)
