### PR TITLE
Fix placeholder text in Rule Create/Edit form Log Type dropdown

### DIFF
--- a/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/BaseRuleFormCoreSection.tsx
+++ b/web/src/components/forms/BaseRuleForm/BaseRuleFormCoreSection/BaseRuleFormCoreSection.tsx
@@ -240,7 +240,7 @@ const BaseRuleFormCoreSection: React.FC<BaseRuleFormCoreSectionProps> = ({ type 
               label="* Log Types"
               name="logTypes"
               items={data?.listAvailableLogTypes.logTypes ?? []}
-              placeholder="Where should the rule appoly?"
+              placeholder="Where should the rule apply?"
             />
             <FastField
               as={FormikCombobox}


### PR DESCRIPTION
## Background

Fix typo in placeholder word.

## Changes

- Change placeholder in the corresponding `tsx` file.

## Testing

- `mage test:web`
