### PR TITLE
Standardize mfa qr code

### DIFF
--- a/web/src/components/forms/TotpForm/TotpForm.tsx
+++ b/web/src/components/forms/TotpForm/TotpForm.tsx
@@ -68,8 +68,10 @@ export const TotpForm: React.FC = () => {
         <Flex justify="center" mb={6} width={1} aria-describedby="totp-helper-text">
           <QRCode
             value={formatSecretCode(code, userInfo.email)}
-            fgColor={theme.colors['gray-50']}
-            bgColor={theme.colors['navyblue-600']}
+            includeMargin
+            size={150}
+            fgColor={theme.colors['navyblue-600']}
+            bgColor={theme.colors['gray-50']}
           />
         </Flex>
         <Text color="gray-300" textAlign="center" my={2}>
@@ -77,7 +79,7 @@ export const TotpForm: React.FC = () => {
         </Text>
         <Box justify="center" textAlign="center" mb={6}>
           {showCode ? (
-            <Text color="gray-300" my={2}>
+            <Text color="gray-300" wordBreak="break-word" my={2}>
               {code}
             </Text>
           ) : (


### PR DESCRIPTION
## Description

While most QR Code scanners can read an inverted Code, some apps are not able to scan them.
To make sure that our QR Code is scannable, we have to stick with a light colored background and dark foreground.

#### Changes
- Invert the colors of the QR code.
- Add margin to the QR code for easier detection.

Closes #1740 

### Screenshots:
![image](https://user-images.githubusercontent.com/15084305/104911795-15296b80-5994-11eb-9925-127233527b6e.png)


### Checklist:

- [x] Make sure you give an high-level overview of the problem & the solution
- [x] Make sure the related issue is referenced
- [x] Make sure screenshots are added if the UI is changed in any way
- [ ] Make sure all of the significant logic is covered by tests
- [x] Make sure your changes are accessible (addition of aria-attributes & correct HTML semantics)
- [x] Make sure you reference the related design document if it exists
- [ ] Make sure telemetry is added (analytics & errors)