### PR TITLE
CrowdStrike parsers: UserIdentity & GroupIdentity

### DIFF
--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs.go
@@ -42,6 +42,8 @@ var logTypes = logtypes.Must(TypePrefix,
 	TypeNetworkListen,
 	TypeProcessRollup2,
 	TypeSyntheticProcessRollup2,
+	TypeUserIdentity,
+	TypeGroupIdentity,
 	// Falcon Insight Special Raw Events
 	TypeAIDMaster,
 	TypeManagedAssets,
@@ -49,12 +51,13 @@ var logTypes = logtypes.Must(TypePrefix,
 	// Falcon Discover Processed Events
 	TypeUserInfo,
 	TypeAppInfo,
+	// All other event types
 	TypeUnknownEvent,
 )
 
-// WARNING: Remember to use mustRegisterCrowdstrikeEvent to add new events so known event names are up-to-date
+// WARNING: Remember to use mustBuild to add new events so known event names are up-to-date.
 
-// mustRegisterCrowdstrikeEvent validates that the event has an EventSimpleName field with a proper `validate` tag and
+// mustBuild validates that the event has an EventSimpleName field with a proper `validate` tag and
 // updates the knownEventNames index so that the parsers for UnknownEvent can distinguish which events to pick.
 func mustBuild(config logtypes.ConfigJSON) logtypes.Entry {
 	event := config.NewEvent()
@@ -98,7 +101,7 @@ func getEventSimpleName(typ reflect.Type) ([]string, error) {
 	return nil, fmt.Errorf(`invalid validate tag %q`, validateTag)
 }
 
-// Common fields for all croudstrike events
+// Common fields for all Crowdstrike events
 // nolint:lll
 type BaseEvent struct {
 	Name           null.String `json:"name" validate:"required" description:"The event name"`

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs_test.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/crowdstrikelogs_test.go
@@ -94,7 +94,7 @@ func TestUnknownEventParser(t *testing.T) {
 		"p_any_ip_addresses": ["71.198.164.96"],
 		"p_log_type": "Crowdstrike.Unknown",
 		"p_event_time": "%s"
-}`,
+		}`,
 		ts.UTC().Format(time.RFC3339Nano),
 	)
 

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/identity.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/identity.go
@@ -1,0 +1,86 @@
+package crowdstrikelogs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/logtypes"
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/pantherlog"
+)
+
+// nolint:lll
+var (
+	TypeUserIdentity = mustBuild(logtypes.ConfigJSON{
+		Name:         TypePrefix + ".UserIdentity",
+		Description:  `The UserIdentity event is generated when a user logs in to a host. It conveys important security-related characteristics associated with a user to the CrowdStrike cloud, such as the user name. It’s normally generated once per security principal, and is thus not on its own a sign of a suspicious activity. Available for Mac & Windows platforms.`,
+		ReferenceURL: `https://developer.crowdstrike.com/crowdstrike/page/event-explorer#section-event-UserIdentity`,
+		NewEvent:     func() interface{} { return &UserIdentity{} },
+	})
+
+	TypeGroupIdentity = mustBuild(logtypes.ConfigJSON{
+		Name:         TypePrefix + ".GroupIdentity",
+		Description:  `Provides the sensor boot unique mapping between GID, AuthenticationId, UserPrincipal, and UserSid. Available only for the Mac platform.`,
+		ReferenceURL: `https://developer.crowdstrike.com/crowdstrike/page/event-explorer#section-event-GroupIdentity`,
+		NewEvent:     func() interface{} { return &GroupIdentity{} },
+	})
+)
+
+// nolint:lll
+type UserIdentity struct {
+	ContextEvent
+	EventSimpleName pantherlog.String `json:"event_simpleName" validate:"required,eq=UserIdentity" description:"Event Name"`
+	CommonIdentityFields
+
+	// Mac Only
+	AuthenticationUUID         pantherlog.String `json:"AuthenticationUuid"`
+	AuthenticationUUIDAsString pantherlog.String `json:"AuthenticationUuidAsString"`
+	UID                        pantherlog.Int64  `json:"UID" description:"The User ID."`
+
+	// Windows only
+	UserName              pantherlog.String `json:"UserName" panther:"username"`
+	UserCanonical         pantherlog.String `json:"UserCanonical"`
+	LogonID               pantherlog.String `json:"LogonId"`
+	LogonDomain           pantherlog.String `json:"LogonDomain"`
+	AuthenticationPackage pantherlog.String `json:"AuthenticationPackage"`
+	LogonType             pantherlog.Int32  `json:"LogonType" description:"Values: INTERACTIVE (2), NETWORK (3), BATCH (4), SERVICE (5), PROXY (6), UNLOCK (7), NETWORK_CLEARTEXT (8), CACHED_UNLOCK (13), NEW_CREDENTIALS (9), REMOTE_INTERACTIVE (10), CACHED_INTERACTIVE (11), CACHED_REMOTE_INTERACTIVE (12)"`
+	LogonTime             pantherlog.Time   `json:"LogonTime" tcodec:"unix"`
+	LogonServer           pantherlog.String `json:"LogonServer"`
+	UserFlags             pantherlog.Int64  `json:"UserFlags" description:"Values: LOGON_OPTIMIZED (0x4000), LOGON_WINLOGON (0x8000), LOGON_PKINIT (0x10000), LOGON_NOT_OPTIMIZED (0x20000)"`
+	PasswordLastSet       pantherlog.Time   `json:"PasswordLastSet" tcodec:"unix"`
+	RemoteAccount         pantherlog.Int32  `json:"RemoteAccount"`
+	UserIsAdmin           pantherlog.Int32  `json:"UserIsAdmin"`
+	SessionID             pantherlog.String `json:"SessionId" panther:"trace_id"`
+	UserLogonFlags        pantherlog.Int32  `json:"UserLogonFlags" description:"Values: LOGON_IS_SYNTHETIC (0x00000001), USER_IS_ADMIN (0x00000002), USER_IS_LOCAL (0x00000004), USER_IS_BUILT_IN (0x00000008), USER_IDENTITY_MISSING (0x00000010)"`
+}
+
+// nolint:lll
+type GroupIdentity struct {
+	ContextEvent
+	EventSimpleName            pantherlog.String `json:"event_simpleName" validate:"required,eq=GroupIdentity" description:"Event Name"`
+	GID                        pantherlog.Int64  `json:"GID" validate:"required" description:"The user Group ID."`
+	AuthenticationUUID         pantherlog.String `json:"AuthenticationUuid" validate:"required"`
+	AuthenticationUUIDAsString pantherlog.String `json:"AuthenticationUuidAsString" validate:"required"`
+	CommonIdentityFields
+}
+
+// nolint:lll
+type CommonIdentityFields struct {
+	AuthenticationID pantherlog.Int32  `json:"AuthenticationId" validate:"required" description:"Values: INVALID_LUID (0), NETWORK_SERVICE (996), LOCAL_SERVICE (997), SYSTEM (999), RESERVED_LUID_MAX (1000)"`
+	UserPrincipal    pantherlog.String `json:"UserPrincipal" validate:"required"`
+	UserSid          pantherlog.String `json:"UserSid" validate:"required" description:"The User Security Identifier (UserSID) of the user who executed the command. A UserSID uniquely identifies a user in a system."`
+}

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/identity_test.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/identity_test.go
@@ -1,0 +1,29 @@
+package crowdstrikelogs
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/panther-labs/panther/internal/log_analysis/log_processor/logtypes/logtesting"
+)
+
+func TestIdentityParsers(t *testing.T) {
+	logtesting.RunTestsFromYAML(t, LogTypes(), "./testdata/identity.yml")
+}

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/testdata/identity.yml
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/testdata/identity.yml
@@ -1,0 +1,149 @@
+# Panther is a Cloud-Native SIEM for the Modern Security Team.
+# Copyright (C) 2020 Panther Labs Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+name: crowdstrike_user_identity_mac_event
+logType: Crowdstrike.UserIdentity
+input: |
+  {
+    "event_simpleName": "UserIdentity",
+    "name": "UserIdentity",
+    "AuthenticationId": 996,
+    "UserPrincipal": "Test-User-Principal",
+    "UserSid": "S-1-2-3",
+    "UID": 7893,
+    "id": "5eb49a6f-9e19-11ea-b387-06c8bf30f3b9",
+    "aid": "5be0664506294ed0427671ed0563f1f8",
+    "timestamp": 1590364238848,
+    "event_platform": "Mac",
+    "aip": "10.0.0.1"
+  }
+result: |
+  {
+    "event_simpleName": "UserIdentity",
+    "name": "UserIdentity",
+    "AuthenticationId": 996,
+    "UserPrincipal": "Test-User-Principal",
+    "UserSid": "S-1-2-3",
+    "UID": 7893,
+    "id": "5eb49a6f-9e19-11ea-b387-06c8bf30f3b9",
+    "aid": "5be0664506294ed0427671ed0563f1f8",
+    "timestamp": 1590364238848,
+    "event_platform": "Mac",
+    "aip": "10.0.0.1",
+    "p_any_ip_addresses": ["10.0.0.1"],
+    "p_event_time": "2020-05-24T23:50:38.848Z",
+    "p_log_type": "Crowdstrike.UserIdentity"
+  }
+---
+name: crowdstrike_user_identity_windows_event
+logType: Crowdstrike.UserIdentity
+input: |
+  {
+    "event_simpleName": "UserIdentity",
+    "name": "UserIdentity",
+    "AuthenticationId": 996,
+    "UserPrincipal": "Test-User-Principal",
+    "UserSid": "S-1-2-3",
+    "id": "5eb49a6f-9e19-11ea-b387-06c8bf30f3b9",
+    "aid": "5be0664506294ed0427671ed0563f1f8",
+    "timestamp": 1590364238848,
+    "event_platform": "Win",
+    "aip": "10.0.0.1",
+    "UserName": "TestUser",
+    "UserCanonical": "TestUserCanonical",
+    "LogonId": 123456789,
+    "LogonDomain": "Test/Domain",
+    "AuthenticationPackage": "Package1",
+    "LogonType": 2,
+    "LogonTime": 1590364238,
+    "LogonServer": "TestLogonServer",
+    "UserFlags": 32768,
+    "PasswordLastSet": 1590064127,
+    "RemoteAccount": 0,
+    "UserIsAdmin": 0,
+    "SessionId": 1929203,
+    "UserLogonFlags": 4
+  }
+result: |
+  {
+    "event_simpleName": "UserIdentity",
+    "name": "UserIdentity",
+    "AuthenticationId": 996,
+    "UserPrincipal": "Test-User-Principal",
+    "UserSid": "S-1-2-3",
+    "UserName": "TestUser",
+    "UserCanonical": "TestUserCanonical",
+    "LogonId": "123456789",
+    "LogonDomain": "Test/Domain",
+    "AuthenticationPackage": "Package1",
+    "LogonType": 2,
+    "LogonTime": 1590364238,
+    "LogonServer": "TestLogonServer",
+    "UserFlags": 32768,
+    "PasswordLastSet": 1590064127,
+    "RemoteAccount": 0,
+    "UserIsAdmin": 0,
+    "SessionId": "1929203",
+    "UserLogonFlags": 4,
+    "id": "5eb49a6f-9e19-11ea-b387-06c8bf30f3b9",
+    "aid": "5be0664506294ed0427671ed0563f1f8",
+    "timestamp": 1590364238848,
+    "event_platform": "Win",
+    "aip": "10.0.0.1",
+    "p_any_ip_addresses": ["10.0.0.1"],
+    "p_any_trace_ids": ["1929203"],
+    "p_event_time": "2020-05-24T23:50:38.848Z",
+    "p_log_type": "Crowdstrike.UserIdentity",
+    "p_any_usernames": ["TestUser"]
+  }
+---
+name: crowdstrike_group_identity_event
+logType: Crowdstrike.GroupIdentity
+input: |
+  {
+    "event_simpleName": "GroupIdentity",
+    "name": "GroupIdentity",
+    "AuthenticationId": 996,
+    "UserPrincipal": "Test-User-Principal",
+    "UserSid": "5eb49a6fae459e19",
+    "AuthenticationUuid": "abcdefghi",
+    "AuthenticationUuidAsString": "abcdefghi",
+    "GID": 7893,
+    "id": "5eb49a6f-9e19-11ea-b387-06c8bf30f3b9",
+    "aid": "5be0664506294ed0427671ed0563f1f8",
+    "timestamp": 1590364238848,
+    "event_platform": "Mac",
+    "aip": "10.0.0.1"
+  }
+result: |
+  {
+    "event_simpleName": "GroupIdentity",
+    "name": "GroupIdentity",
+    "AuthenticationUuid": "abcdefghi",
+    "AuthenticationUuidAsString": "abcdefghi",
+    "AuthenticationId": 996,
+    "UserPrincipal": "Test-User-Principal",
+    "UserSid": "5eb49a6fae459e19",
+    "GID": 7893,
+    "id": "5eb49a6f-9e19-11ea-b387-06c8bf30f3b9",
+    "aid": "5be0664506294ed0427671ed0563f1f8",
+    "timestamp": 1590364238848,
+    "event_platform": "Mac",
+    "aip": "10.0.0.1",
+    "p_any_ip_addresses": ["10.0.0.1"],
+    "p_event_time": "2020-05-24T23:50:38.848Z",
+    "p_log_type": "Crowdstrike.GroupIdentity"
+   }

--- a/internal/log_analysis/log_processor/parsers/crowdstrikelogs/unknown.go
+++ b/internal/log_analysis/log_processor/parsers/crowdstrikelogs/unknown.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	// This index is filled by mustRegisterCrowdstrikeEvent
+	// This index is filled by mustBuild
 	knownEventNames = map[string]bool{}
 	// TypeUnknownEvent is a special event collects all crowdstrike events that don't yet have a registered log type
 	TypeUnknownEvent = logtypes.MustBuild(logtypes.ConfigJSON{


### PR DESCRIPTION
## Background

These events are significant during investigation. Specifying a custom parser facilitates querying, since the `Unknown` parser doesn't generate structured records.

## Changes

- Define parser for [`GroupIdentity` event](https://developer.crowdstrike.com/crowdstrike/page/event-explorer#section-event-GroupIdentity) (applicable only to Mac platform) and [`UserIdentity` event](https://developer.crowdstrike.com/crowdstrike/page/event-explorer#section-event-UserIdentity).

## Testing

- `mage test:go`
