### PR TITLE
Update pounce version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17039,9 +17039,9 @@
       "dev": true
     },
     "pouncejs": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/pouncejs/-/pouncejs-0.80.0.tgz",
-      "integrity": "sha512-kUIUpsfmHm2pSIfYKtcLy0MtAV5u/kCHR1lFUze1CiTZQD8CXviv6OI63CQsEKPBx/3wV80Pfu6kcFtxG7+apA==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/pouncejs/-/pouncejs-0.80.1.tgz",
+      "integrity": "sha512-+hV+jDNOmOv7jL2Zc7r8zOeIAZTLJzNInUQ1gfPH8k8ikclH2qh97BirfVqwZCWArJ89lBZR+EWnZeCZEm4eZg==",
       "requires": {
         "@emotion/react": "^11.0.0-next.12",
         "@emotion/styled": "^11.0.0-next.12",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "linkifyjs": "^2.1.9",
     "lodash": "^4.17.20",
     "mixpanel-browser": "^2.39.0",
-    "pouncejs": "^0.80.0",
+    "pouncejs": "^0.80.1",
     "qrcode.react": "^1.0.0",
     "query-string": "^6.10.1",
     "react": "^16.12.0",

--- a/web/src/components/fields/DateRangeInput/DateRangeInput.test.tsx
+++ b/web/src/components/fields/DateRangeInput/DateRangeInput.test.tsx
@@ -88,7 +88,7 @@ describe('FormikDateRangeInput', () => {
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({
         start: '2020-11-02T13:00:00.000Z',
-        end: '2020-11-03T13:00:00.000Z',
+        end: '2020-11-03T13:00:59.999Z',
       });
     });
   });

--- a/web/src/pages/ListAlerts/ListAlerts.test.tsx
+++ b/web/src/pages/ListAlerts/ListAlerts.test.tsx
@@ -591,7 +591,7 @@ describe('ListAlerts', () => {
             sortDir: SortDirEnum.Descending,
             logTypes: [mockedLogType],
             createdAtAfter: '2000-01-29T00:00:00.000Z',
-            createdAtBefore: '2000-01-30T00:00:00.000Z',
+            createdAtBefore: '2000-01-30T00:00:59.999Z',
           },
         },
         data: {
@@ -669,7 +669,7 @@ describe('ListAlerts', () => {
     await waitMs(1);
 
     // Expect the URL to be updated
-    const completeParams = `${paramsWithSortingAndTextFilter}&createdAtAfter=2000-01-29T00:00:00.000Z&createdAtBefore=2000-01-30T00:00:00.000Z`;
+    const completeParams = `${paramsWithSortingAndTextFilter}&createdAtAfter=2000-01-29T00:00:00.000Z&createdAtBefore=2000-01-30T00:00:59.999Z`;
     expect(parseParams(history.location.search)).toEqual(parseParams(completeParams));
 
     // Expect the API request to have fired and a new alert to have returned (verifies API execution)


### PR DESCRIPTION
## Background

Update pounce to the latest version to fix the inconsistent dates in the date range picker.

## Changes

Update pounce to v0.80.1.

## Testing

- npm run test
- Manually tested date range picker
