### PR TITLE
Fixes for ELBV2 scanning

### DIFF
--- a/internal/compliance/aws_event_processor/processor/process.go
+++ b/internal/compliance/aws_event_processor/processor/process.go
@@ -161,6 +161,13 @@ var (
 		"RegisterTargets":             {},
 		"DeregisterTargets":           {},
 
+		// These are elb classic events that we don't support but can't differentiate from elbv2
+		// events
+		"RegisterInstancesWithLoadBalancer": {},
+		"ConfigureHealthCheck":              {},
+		"SetLoadBalancerPoliciesOfListener": {},
+		"CreateLoadBalancerPolicy":          {},
+
 		// guardduty
 		"ArchiveFindings":             {},
 		"CreateIPSet":                 {},
@@ -202,6 +209,7 @@ var (
 		"Invoke":                    {},
 		"InvokeAsync":               {},
 		"InvokeFunction":            {},
+		"InvokeExecution":           {},
 
 		// rds
 		// TODO get suffixes

--- a/internal/compliance/snapshot_poller/pollers/aws/clients.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/clients.go
@@ -37,7 +37,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -92,21 +91,23 @@ var (
 		awsmodels.Ec2VpcSchema:              ec2.ServiceName,
 		awsmodels.EcsClusterSchema:          ecs.ServiceName,
 		awsmodels.EksClusterSchema:          eks.ServiceName,
-		awsmodels.Elbv2LoadBalancerSchema:   elbv2.ServiceName,
-		awsmodels.GuardDutySchema:           guardduty.ServiceName,
-		awsmodels.IAMGroupSchema:            iam.ServiceName,
-		awsmodels.IAMPolicySchema:           iam.ServiceName,
-		awsmodels.IAMRoleSchema:             iam.ServiceName,
-		awsmodels.IAMRootUserSchema:         iam.ServiceName,
-		awsmodels.IAMUserSchema:             iam.ServiceName,
-		awsmodels.KmsKeySchema:              kms.ServiceName,
-		awsmodels.LambdaFunctionSchema:      lambda.ServiceName,
-		awsmodels.PasswordPolicySchema:      iam.ServiceName,
-		awsmodels.RDSInstanceSchema:         rds.ServiceName,
-		awsmodels.RedshiftClusterSchema:     redshift.ServiceName,
-		awsmodels.S3BucketSchema:            s3.ServiceName,
-		awsmodels.WafRegionalWebAclSchema:   waf.ServiceName,
-		awsmodels.WafWebAclSchema:           wafregional.ServiceName,
+		// For every other service, the service name aligns with how SSM refers to the service. For
+		// just the elb and elbv2 service, this is not the case. AWS just had to do it to 'em.
+		awsmodels.Elbv2LoadBalancerSchema: "elb",
+		awsmodels.GuardDutySchema:         guardduty.ServiceName,
+		awsmodels.IAMGroupSchema:          iam.ServiceName,
+		awsmodels.IAMPolicySchema:         iam.ServiceName,
+		awsmodels.IAMRoleSchema:           iam.ServiceName,
+		awsmodels.IAMRootUserSchema:       iam.ServiceName,
+		awsmodels.IAMUserSchema:           iam.ServiceName,
+		awsmodels.KmsKeySchema:            kms.ServiceName,
+		awsmodels.LambdaFunctionSchema:    lambda.ServiceName,
+		awsmodels.PasswordPolicySchema:    iam.ServiceName,
+		awsmodels.RDSInstanceSchema:       rds.ServiceName,
+		awsmodels.RedshiftClusterSchema:   redshift.ServiceName,
+		awsmodels.S3BucketSchema:          s3.ServiceName,
+		awsmodels.WafRegionalWebAclSchema: waf.ServiceName,
+		awsmodels.WafWebAclSchema:         wafregional.ServiceName,
 	}
 
 	// These services do not support regional scans, either because the resource itself is not


### PR DESCRIPTION
## Background

This PR fixes one major and three minor bugs related to Cloud Security scanning found during on call.

## Changes

- Add several events to the `aws-event-processor` ignore list that were causing hiccups in the `aws-event-processor`
  - elb `RegisterInstancesWithLoadBalancer`, `ConfigureHealthCheck`, `SetLoadBalancerPoliciesOfListener`, and `CreateLoadBalancerPolicy` are all elb classic events. We don't support elb classic, but are unable to differentiate between elb classic and elbv2 events explicitly. These were causing `warn` messages.
  - lambda `InvokeExecution`. Processing this API call raised errors when trying to extract the account ID. Luckily this event does not indicate to us that we need to scan, as no infrastructure is changing.
- Added special error handling to the elb `ModifyLoadBalancerAttributes` event in the `aws-event-processor`. This is related to the above issue in that we can't differentiate elb classic and elbv2 events. In this case though the event `ModifyLoadBalancerAttributes` may occur for both elb and elbv2 resources, and we can only differentiate between the two by inspecting the format of the request
- This is the big one. We were incorrectly generating the list of available regions when conducting full account ELBV2 scans. This means that the baseline scans (initial scan & daily scan) were skipping all ELBV2 resources. Initially I was concerned this may affect many resource types, but I wrote a quick script to test and it luckily only affects ELBV2 resources.

## Testing

- Unit testing
- Deployed to dev account & manually initiated scans to test the ELBV2 region bug
