### PR TITLE
[FE] Showcase dynamic alert field in details page

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -302,6 +302,9 @@ type AlertDetails implements Alert {
   lastUpdatedByTime: AWSDateTime # stores the timestamp of the last person who modified the Alert
   updateTime: AWSDateTime! # stores the timestamp from an update from a dedup event
   detection: AlertDetailsDetectionInfo!
+  description: String
+  reference: String
+  runbook: String
 }
 
 type AlertSummary implements Alert {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -149,6 +149,9 @@ export type AlertDetails = Alert & {
   lastUpdatedByTime?: Maybe<Scalars['AWSDateTime']>;
   updateTime: Scalars['AWSDateTime'];
   detection: AlertDetailsDetectionInfo;
+  description?: Maybe<Scalars['String']>;
+  reference?: Maybe<Scalars['String']>;
+  runbook?: Maybe<Scalars['String']>;
 };
 
 export type AlertDetailsDetectionInfo = AlertDetailsRuleInfo | AlertSummaryPolicyInfo;
@@ -2068,6 +2071,9 @@ export type AlertDetailsResolvers<
   lastUpdatedByTime?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
   updateTime?: Resolver<ResolversTypes['AWSDateTime'], ParentType, ContextType>;
   detection?: Resolver<ResolversTypes['AlertDetailsDetectionInfo'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  reference?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  runbook?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -318,6 +318,9 @@ export const buildAlertDetails = (overrides: Partial<AlertDetails> = {}): AlertD
       'lastUpdatedByTime' in overrides ? overrides.lastUpdatedByTime : '2020-07-02T20:00:23.050Z',
     updateTime: 'updateTime' in overrides ? overrides.updateTime : '2020-02-22T04:54:35.910Z',
     detection: 'detection' in overrides ? overrides.detection : buildAlertDetailsRuleInfo(),
+    description: 'description' in overrides ? overrides.description : 'Music',
+    reference: 'reference' in overrides ? overrides.reference : 'input',
+    runbook: 'runbook' in overrides ? overrides.runbook : 'Granite',
   };
 };
 

--- a/web/src/graphql/fragments/AlertDetailsFull.generated.ts
+++ b/web/src/graphql/fragments/AlertDetailsFull.generated.ts
@@ -28,6 +28,9 @@ export type AlertDetailsFull = Pick<
   | 'type'
   | 'title'
   | 'creationTime'
+  | 'description'
+  | 'reference'
+  | 'runbook'
   | 'updateTime'
   | 'severity'
   | 'status'
@@ -57,6 +60,9 @@ export const AlertDetailsFull = gql`
     type
     title
     creationTime
+    description
+    reference
+    runbook
     deliveryResponses {
       ...DeliveryResponseFull
     }

--- a/web/src/graphql/fragments/AlertDetailsFull.graphql
+++ b/web/src/graphql/fragments/AlertDetailsFull.graphql
@@ -3,6 +3,9 @@ fragment AlertDetailsFull on AlertDetails {
   type
   title
   creationTime
+  description
+  reference
+  runbook
   deliveryResponses {
     ...DeliveryResponseFull
   }

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.test.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { buildAlertDetails, buildRule, render } from 'test-utils';
+import AlertDetailsInfo from './AlertDetailsInfo';
+
+describe('AlertDetailsInfo', () => {
+  it('matches snapshot', () => {
+    const { container } = render(
+      <AlertDetailsInfo alert={buildAlertDetails()} rule={buildRule()} />
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/AlertDetailsInfo.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { Box, Card, Flex, Link, SimpleGrid } from 'pouncejs';
+import { Box, Card, Flex, Link, SimpleGrid, Text } from 'pouncejs';
 import Linkify from 'Components/Linkify';
 import { Link as RRLink } from 'react-router-dom';
 import urls from 'Source/urls';
@@ -40,44 +40,43 @@ const AlertDetailsInfo: React.FC<AlertDetailsInfoProps> = ({ alert, rule }) => {
   const detectionData = alert.detection as AlertDetailsRuleInfo;
   return (
     <Flex direction="column" spacing={4}>
-      {rule && (
-        <Card variant="dark" as="section" p={4}>
-          <SimpleGrid columns={2} spacing={5}>
-            <Flex direction="column" spacing={2}>
-              <Box
-                color="navyblue-100"
-                fontSize="small-medium"
-                aria-describedby="runbook-description"
-              >
-                Runbook
+      <Card variant="dark" as="section" p={4}>
+        {alert.description && <Text mb={6}>{alert.description}</Text>}
+        <SimpleGrid columns={2} spacing={5}>
+          <Flex direction="column" spacing={2}>
+            <Box
+              color="navyblue-100"
+              fontSize="small-medium"
+              aria-describedby="runbook-description"
+            >
+              Runbook
+            </Box>
+            {alert.runbook ? (
+              <Linkify id="runbook-description">{alert.runbook}</Linkify>
+            ) : (
+              <Box fontStyle="italic" color="navyblue-100" id="runbook-description">
+                No runbook specified
               </Box>
-              {rule.runbook ? (
-                <Linkify id="runbook-description">{rule.runbook}</Linkify>
-              ) : (
-                <Box fontStyle="italic" color="navyblue-100" id="runbook-description">
-                  No runbook specified
-                </Box>
-              )}
-            </Flex>
-            <Flex direction="column" spacing={2}>
-              <Box
-                color="navyblue-100"
-                fontSize="small-medium"
-                aria-describedby="reference-description"
-              >
-                Reference
+            )}
+          </Flex>
+          <Flex direction="column" spacing={2}>
+            <Box
+              color="navyblue-100"
+              fontSize="small-medium"
+              aria-describedby="reference-description"
+            >
+              Reference
+            </Box>
+            {alert.reference ? (
+              <Linkify id="reference-description">{alert.reference}</Linkify>
+            ) : (
+              <Box fontStyle="italic" color="navyblue-100" id="reference-description">
+                No reference specified
               </Box>
-              {rule.reference ? (
-                <Linkify id="reference-description">{rule.reference}</Linkify>
-              ) : (
-                <Box fontStyle="italic" color="navyblue-100" id="reference-description">
-                  No reference specified
-                </Box>
-              )}
-            </Flex>
-          </SimpleGrid>
-        </Card>
-      )}
+            )}
+          </Flex>
+        </SimpleGrid>
+      </Card>
       <Card variant="dark" as="section" p={4}>
         <SimpleGrid columns={2} spacing={5} fontSize="small-medium">
           <Box>

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/__snapshots__/AlertDetailsInfo.test.tsx.snap
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsInfo/__snapshots__/AlertDetailsInfo.test.tsx.snap
@@ -1,0 +1,419 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertDetailsInfo matches snapshot 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0);
+    -moz-transform: rotate(0);
+    -ms-transform: rotate(0);
+    transform: rotate(0);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes animation-1 {
+  0% {
+    stroke-dashoffset: 600;
+  }
+
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+.panther-37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.panther-37>*:not(:last-child) {
+  margin-bottom: 16px;
+}
+
+.panther-6 {
+  background-color: #1d2a3f;
+  border-radius: 4px;
+  padding: 16px;
+}
+
+.panther-0 {
+  margin-bottom: 24px;
+}
+
+.panther-5 {
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.panther-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.panther-2>*:not(:last-child) {
+  margin-bottom: 8px;
+}
+
+.panther-1 {
+  color: #86a3c3;
+  font-size: 0.813rem;
+}
+
+.panther-31 {
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: repeat(2, 1fr);
+  font-size: 0.813rem;
+}
+
+
+
+.panther-18 {
+  display: grid;
+  grid-gap: 8px;
+  grid-template-columns: repeat(8, 1fr);
+}
+
+.panther-7 {
+  color: #86a3c3;
+  grid-column: 1/3;
+}
+
+.panther-8 {
+  -webkit-transition: color 0.1s ease-out;
+  transition: color 0.1s ease-out;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #7fd3ff;
+  grid-column: 3/8;
+}
+
+.panther-8:hover {
+  color: #ace2ff;
+}
+
+.panther-8:focus {
+  color: #ace2ff;
+}
+
+.panther-8:active,
+.panther-8[data-active=true] {
+  color: #11a5f3;
+}
+
+.panther-10 {
+  grid-column: 3/8;
+}
+
+.panther-16 {
+  -webkit-transition: color 0.1s ease-out;
+  transition: color 0.1s ease-out;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #7fd3ff;
+}
+
+.panther-16:hover {
+  color: #ace2ff;
+}
+
+.panther-16:focus {
+  color: #ace2ff;
+}
+
+.panther-16:active,
+.panther-16[data-active=true] {
+  color: #11a5f3;
+}
+
+.panther-27 {
+  height: 18px;
+}
+
+.panther-26 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-animation: animation-0 2s linear infinite;
+  animation: animation-0 2s linear infinite;
+  width: 18px;
+  height: 18px;
+}
+
+.panther-25 {
+  stroke-dashoffset: 600;
+  stroke-dasharray: 300;
+  stroke-width: 13;
+  stroke-miterlimit: 10;
+  stroke-linecap: round;
+  -webkit-animation: animation-1 1.6s cubic-bezier(0.4, 0.15, 0.6, 0.85) infinite;
+  animation: animation-1 1.6s cubic-bezier(0.4, 0.15, 0.6, 0.85) infinite;
+  stroke: currentColor;
+  fill: transparent;
+}
+
+.panther-35 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: warning;
+  -webkit-box-align: warning;
+  -ms-flex-align: warning;
+  align-items: warning;
+}
+
+.panther-35>*:not(:last-child) {
+  margin-right: 16px;
+}
+
+.panther-33 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: #0081c5;
+}
+
+.panther-34 {
+  font-weight: 500;
+}
+
+<div>
+  <header
+    id="main-header"
+  />
+  <div
+    class="panther-37"
+  >
+    <section
+      class="panther-6"
+    >
+      <p
+        class="panther-0"
+      >
+        Music
+      </p>
+      <div
+        class="panther-5"
+      >
+        <div
+          class="panther-2"
+        >
+          <div
+            aria-describedby="runbook-description"
+            class="panther-1"
+          >
+            Runbook
+          </div>
+          <p>
+            Granite
+          </p>
+        </div>
+        <div
+          class="panther-2"
+        >
+          <div
+            aria-describedby="reference-description"
+            class="panther-1"
+          >
+            Reference
+          </div>
+          <p>
+            input
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      class="panther-6"
+    >
+      <div
+        class="panther-31"
+      >
+        <div
+          class="panther-19"
+        >
+          <div
+            class="panther-18"
+          >
+            <div
+              aria-describedby="rule-link"
+              class="panther-7"
+            >
+              Rule
+            </div>
+            <a
+              class="panther-8"
+              href="/log-analysis/rules/panel/"
+              id="rule-link"
+            >
+              AI
+            </a>
+            <div
+              aria-describedby="threshold"
+              class="panther-7"
+            >
+              Rule Threshold
+            </div>
+            <div
+              class="panther-10"
+              id="threshold"
+            >
+              347
+            </div>
+            <div
+              aria-describedby="deduplication-period"
+              class="panther-7"
+            >
+              Deduplication Period
+            </div>
+            <div
+              class="panther-10"
+              id="deduplication-period"
+            >
+              13.466666666666667h
+            </div>
+            <div
+              aria-describedby="deduplication-string"
+              class="panther-7"
+            >
+              Deduplication String
+            </div>
+            <div
+              class="panther-10"
+              id="deduplication-string"
+            >
+              panel
+            </div>
+            <div
+              aria-describedby="tags-list"
+              class="panther-7"
+            >
+              Tags
+            </div>
+            <div
+              class="panther-10"
+              id="tags-list"
+            >
+              <a
+                class="panther-16"
+                href="/log-analysis/rules/?page=1&tags[]=invoice"
+              >
+                invoice
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="panther-19"
+        >
+          <div
+            class="panther-18"
+          >
+            <div
+              aria-describedby="created-at"
+              class="panther-7"
+            >
+              Created
+            </div>
+            <div
+              class="panther-10"
+              id="created-at"
+            >
+              2020-10-28 02:06 GMT
+            </div>
+            <div
+              aria-describedby="last-matched-at"
+              class="panther-7"
+            >
+              Last Matched
+            </div>
+            <div
+              class="panther-10"
+              id="last-matched-at"
+            >
+              2020-02-22 04:54 GMT
+            </div>
+            <div
+              aria-describedby="destinations"
+              class="panther-7"
+            >
+              Destinations
+            </div>
+            <div
+              class="panther-10"
+              id="destinations"
+            >
+              <div
+                class="panther-27"
+              >
+                <svg
+                  aria-label="Loading..."
+                  class="panther-26"
+                  viewBox="0 0 150 150"
+                >
+                  <circle
+                    class="panther-25"
+                    color="current"
+                    cx="75"
+                    cy="75"
+                    r="60"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      class="panther-6"
+    >
+      <div
+        class="panther-35"
+      >
+        <svg
+          class="panther-33"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M13,15.5 L11,15.5 L11,17.5 L13,17.5 L13,15.5 Z M13,7 L11,7 L11,14 L13,14 L13,7 Z"
+            transform="translate(12.000000, 12.000000) rotate(-180.000000) translate(-12.000000, -12.000000) "
+          />
+        </svg>
+        <p
+          class="panther-34"
+        >
+          No delivery information could be found for this alert
+        </p>
+      </div>
+    </section>
+  </div>
+  <footer
+    id="footer"
+  />
+</div>
+`;


### PR DESCRIPTION
## Background

Users are able to dynamically override data for an alert generated by a rule (such as description, reference, etc.), but  - up until now - those weren't showcased in the UI, since we always showed the values that the rule had.

This PR fixes it, by making sure that all dynamic fields originate from the alert item itself.

Closes #2482
Closes #2166 

## Changes

- Add missing fields to schema
- Use new fields in Alert Details page

## Screenshots
<img width="1270" alt="Screen Shot 2021-01-22 at 11 07 24 AM" src="https://user-images.githubusercontent.com/10436045/105470274-08618c00-5ca2-11eb-8644-fd43f5477d08.png">


## Testing

- `npm run test`

## Notes

All dynamic fields **automatically** fallback to the values that the rule has, so no need to add a fallback in the UI ourselves
