### PR TITLE
source-api: Don't return sources without populated IntegrationType

### DIFF
--- a/internal/core/source_api/api/list_integrations_test.go
+++ b/internal/core/source_api/api/list_integrations_test.go
@@ -123,3 +123,31 @@ func TestHandleListIntegrationsScanError(t *testing.T) {
 	require.NotNil(t, err)
 	assert.Nil(t, out)
 }
+
+func TestListIntegrations_ExcludeSourcesWithoutType(t *testing.T) {
+	dynamoClient := &ddb.DDB{
+		Client: &modelstest.MockDDBClient{
+			MockScanAttributes: []map[string]*dynamodb.AttributeValue{
+				{
+					"integrationId":    {S: aws.String("123")},
+					"integrationLabel": {S: aws.String("with-type")},
+					"integrationType":  {S: aws.String(models.IntegrationTypeAWS3)},
+				}, {
+					"integrationId":    {S: aws.String("456")},
+					"integrationLabel": {S: aws.String("without-type")},
+				},
+			},
+			TestErr: false,
+		},
+		TableName: "test",
+	}
+
+	testAPI := API{
+		DdbClient: dynamoClient,
+	}
+	out, err := testAPI.ListIntegrations(&models.ListIntegrationsInput{})
+
+	require.NoError(t, err)
+	require.Equal(t, len(out), 1)
+	require.Equal(t, out[0].IntegrationID, "123")
+}


### PR DESCRIPTION
## Background

Due to a previous bug, a deleted integration could be re-created in the DB without the `IntegrationType` field. This would break Panther in many places in addition to breaking Panther upgrades. 


## Changes

- The `ListIntegrations` endpoint in source-api now doesn't return sources that don't have a valid `IntegrationType` field.

## Testing

- unit
