### PR TITLE
[FE] Fix custom log modal deletion

### DIFF
--- a/web/src/components/modals/DeleteCustomLogModal/DeleteCustomLogModal.tsx
+++ b/web/src/components/modals/DeleteCustomLogModal/DeleteCustomLogModal.tsx
@@ -42,7 +42,18 @@ const DeleteCustomLogModal: React.FC<DeleteCustomLogModalProps> = ({ customLog, 
     },
     // FIXME: We removed optimistic response from this request until we upgrade apollo-client
     // issue: https://github.com/apollographql/apollo-client/issues/5790
-    update: (cache, { data: { deleteCustomLog: deletionResponse } }) => {
+    update: (
+      cache,
+      {
+        data: {
+          deleteCustomLog: { error },
+        },
+      }
+    ) => {
+      if (error) {
+        return;
+      }
+
       cache.modify('ROOT_QUERY', {
         listCustomLogs(customLogs, { toReference }) {
           const deletedCustomLog = toReference({
@@ -54,9 +65,7 @@ const DeleteCustomLogModal: React.FC<DeleteCustomLogModalProps> = ({ customLog, 
         listAvailableLogTypes: queryData => {
           return {
             ...queryData,
-            logTypes: deletionResponse.error
-              ? queryData.logTypes
-              : queryData.logTypes.filter(logType => logType !== customLog.logType),
+            logTypes: queryData.logTypes.filter(logType => logType !== customLog.logType),
           };
         },
       });


### PR DESCRIPTION
## Background

When deleting a Custom Log item, we remove the item from the list even when the BE has returned an error. This removes the custom log from the UI but doesn't restore it back unless the user refreshes.

This PR addresses that

## Changes

- Check for BE errors before removing a Custom log from the UI
