### PR TITLE
FE: Alert Routing for Destinations

### DIFF
--- a/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.test.tsx
+++ b/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor, waitMs, fireClickAndMouseEvents } from 'test-utils';
+import { AlertTypesEnum, SeverityEnum } from 'Generated/schema';
+import { Field } from 'formik';
+import FormikTextInput from 'Components/fields/TextInput';
+import BaseDestinationForm, { BaseDestinationFormValues, defaultValidationSchema } from './index';
+
+const emptyInitialValues = {
+  displayName: '',
+  defaultForSeverity: [],
+  alertTypes: [],
+  outputConfig: {},
+};
+
+const displayName = 'Base form';
+const criticalSeverity = SeverityEnum.Critical;
+const criticalText = 'Critical';
+const ruleMatchText = 'Rule Matches';
+
+const defaultInitialValues = {
+  outputId: 'id',
+  displayName,
+  outputConfig: {},
+  defaultForSeverity: [criticalSeverity],
+  alertTypes: Object.values(AlertTypesEnum),
+};
+
+const BasicForm: React.FC<{
+  initialValues: BaseDestinationFormValues<any>;
+  onSubmit: () => void;
+}> = ({ initialValues, onSubmit }) => {
+  return (
+    <BaseDestinationForm
+      onSubmit={onSubmit}
+      initialValues={initialValues}
+      validationSchema={defaultValidationSchema}
+    >
+      <Field
+        name="displayName"
+        as={FormikTextInput}
+        label="* Display Name"
+        placeholder="How should we name this?"
+        required
+      />
+    </BaseDestinationForm>
+  );
+};
+
+describe('BaseDestinationForm', () => {
+  it('renders the correct fields', () => {
+    const { getAllByLabelText, getByLabelText, getByText } = render(
+      <BasicForm initialValues={emptyInitialValues} onSubmit={() => {}} />
+    );
+    const displayNameField = getByLabelText('* Display Name');
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypesField = getAllByLabelText('Alert Types')[0];
+    const submitButton = getByText('Add Destination');
+    expect(displayNameField).toBeInTheDocument();
+    expect(severityField).toBeInTheDocument();
+    expect(alertTypesField).toBeInTheDocument();
+    expect(submitButton).toBeInTheDocument();
+
+    expect(submitButton).toHaveAttribute('disabled');
+  });
+
+  it('has proper validation', async () => {
+    const { getAllByLabelText, getByLabelText, getByText } = render(
+      <BasicForm initialValues={emptyInitialValues} onSubmit={() => {}} />
+    );
+    const displayNameField = getByLabelText('* Display Name');
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypesField = getAllByLabelText('Alert Types')[0];
+    const submitButton = getByText('Add Destination');
+    expect(displayNameField).toBeInTheDocument();
+    expect(severityField).toBeInTheDocument();
+    expect(alertTypesField).toBeInTheDocument();
+    expect(submitButton).toBeInTheDocument();
+
+    expect(submitButton).toHaveAttribute('disabled');
+    fireEvent.change(displayNameField, { target: { value: displayName } });
+    await waitMs(1);
+    expect(submitButton).toHaveAttribute('disabled');
+    fireEvent.change(severityField, { target: { value: criticalText } });
+    fireClickAndMouseEvents(getByText(criticalText));
+    await waitMs(1);
+    expect(submitButton).toHaveAttribute('disabled');
+    fireEvent.change(alertTypesField, { target: { value: ruleMatchText } });
+    fireClickAndMouseEvents(getByText(ruleMatchText));
+    await waitMs(1);
+    expect(submitButton).not.toHaveAttribute('disabled');
+  });
+
+  it('should trigger submit successfully', async () => {
+    const submitMockFunc = jest.fn();
+    const { getAllByLabelText, getByLabelText, getByText } = render(
+      <BasicForm initialValues={emptyInitialValues} onSubmit={submitMockFunc} />
+    );
+    const displayNameField = getByLabelText('* Display Name');
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypesField = getAllByLabelText('Alert Types')[0];
+    const submitButton = getByText('Add Destination');
+    expect(submitButton).toHaveAttribute('disabled');
+
+    fireEvent.change(displayNameField, { target: { value: displayName } });
+    fireEvent.change(severityField, { target: { value: criticalText } });
+    fireClickAndMouseEvents(getByText(criticalText));
+    fireEvent.change(alertTypesField, { target: { value: ruleMatchText } });
+    fireClickAndMouseEvents(getByText(ruleMatchText));
+
+    await waitMs(1);
+    expect(submitButton).not.toHaveAttribute('disabled');
+
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        displayName,
+        outputConfig: {},
+        defaultForSeverity: [SeverityEnum.Critical],
+        alertTypes: [AlertTypesEnum.Rule],
+      },
+      expect.toBeObject()
+    );
+  });
+
+  it('should edit successfully', async () => {
+    const submitMockFunc = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <BasicForm onSubmit={submitMockFunc} initialValues={defaultInitialValues} />
+    );
+    const displayNameField = getByLabelText('* Display Name');
+    const submitButton = getByText('Update Destination');
+    expect(displayNameField).toHaveValue(defaultInitialValues.displayName);
+    expect(submitButton).toHaveAttribute('disabled');
+
+    const newDisplayName = 'New Display Name';
+    fireEvent.change(displayNameField, { target: { value: newDisplayName } });
+    await waitMs(1);
+    expect(submitButton).not.toHaveAttribute('disabled');
+
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: defaultInitialValues.outputId,
+        displayName: newDisplayName,
+        outputConfig: defaultInitialValues.outputConfig,
+        defaultForSeverity: defaultInitialValues.defaultForSeverity,
+        alertTypes: defaultInitialValues.alertTypes,
+      },
+      expect.toBeObject()
+    );
+  });
+});

--- a/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
+++ b/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
@@ -62,7 +62,9 @@ interface BaseDestinationFormProps<AdditionalValues extends Partial<DestinationC
 export const defaultValidationSchema = Yup.object().shape({
   displayName: Yup.string().required(),
   defaultForSeverity: Yup.array().of(Yup.mixed().oneOf(Object.values(SeverityEnum)).required()),
-  alertTypes: Yup.array().of(Yup.mixed().oneOf(Object.values(AlertTypesEnum)).required()),
+  alertTypes: Yup.array()
+    .min(1)
+    .of(Yup.mixed().oneOf(Object.values(AlertTypesEnum)).required()),
 });
 
 function BaseDestinationForm<AdditionalValues extends Partial<DestinationConfigInput>>({
@@ -121,6 +123,7 @@ function BaseDestinationForm<AdditionalValues extends Partial<DestinationConfigI
             itemToString={alertTypeToString}
             label="Alert Types"
             placeholder="Select Alert Types"
+            required
             aria-describedby="alert-type-disclaimer"
           />
         </SimpleGrid>

--- a/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
+++ b/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
@@ -16,18 +16,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import React from 'react';
 import * as Yup from 'yup';
 import { SeverityEnum, DestinationConfigInput, AlertTypesEnum } from 'Generated/schema';
-import { Box, Flex, Text } from 'pouncejs';
+import { Box, SimpleGrid, Flex, Text } from 'pouncejs';
 import { Field, Form, Formik } from 'formik';
 import urls from 'Source/urls';
-import React from 'react';
-import FormikCheckbox from 'Components/fields/Checkbox';
-import SeverityBadge from 'Components/badges/SeverityBadge';
 import Breadcrumbs from 'Components/Breadcrumbs';
 import SaveButton from 'Components/buttons/SaveButton';
 import LinkButton from 'Components/buttons/LinkButton';
 import SubmitButton from 'Components/buttons/SubmitButton';
+import FormikMultiCombobox from 'Components/fields/MultiComboBox';
+import { getEnumKeyByValue } from 'Helpers/utils';
 
 export interface BaseDestinationFormValues<
   AdditionalValues extends Partial<DestinationConfigInput>
@@ -37,15 +37,6 @@ export interface BaseDestinationFormValues<
   outputConfig: AdditionalValues;
   defaultForSeverity: SeverityEnum[];
   alertTypes: AlertTypesEnum[];
-}
-
-// Converts the `defaultForSeverity` from an array to an object in order to handle it properly
-// internally within the form. Essentially converts ['CRITICAL', 'LOW'] to
-// { CRITICAL: true, LOW: true }
-interface PrivateBaseDestinationFormValues<
-  AdditionalValues extends Partial<DestinationConfigInput>
-> extends Omit<BaseDestinationFormValues<AdditionalValues>, 'defaultForSeverity'> {
-  defaultForSeverity: { [key in SeverityEnum]: boolean };
 }
 
 interface BaseDestinationFormProps<AdditionalValues extends Partial<DestinationConfigInput>> {
@@ -60,7 +51,7 @@ interface BaseDestinationFormProps<AdditionalValues extends Partial<DestinationC
    * The validation schema for the form
    */
   validationSchema?: Yup.ObjectSchema<
-    Yup.Shape<Record<string, unknown>, Partial<PrivateBaseDestinationFormValues<AdditionalValues>>>
+    Yup.Shape<Record<string, unknown>, Partial<BaseDestinationFormValues<AdditionalValues>>>
   >;
 
   /** callback for the submission of the form */
@@ -70,7 +61,8 @@ interface BaseDestinationFormProps<AdditionalValues extends Partial<DestinationC
 // The validation checks that Formik will run
 export const defaultValidationSchema = Yup.object().shape({
   displayName: Yup.string().required(),
-  defaultForSeverity: Yup.object<{ [key in SeverityEnum]: boolean }>(),
+  defaultForSeverity: Yup.array().of(Yup.mixed().oneOf(Object.values(SeverityEnum)).required()),
+  alertTypes: Yup.array().of(Yup.mixed().oneOf(Object.values(AlertTypesEnum)).required()),
 });
 
 function BaseDestinationForm<AdditionalValues extends Partial<DestinationConfigInput>>({
@@ -79,72 +71,59 @@ function BaseDestinationForm<AdditionalValues extends Partial<DestinationConfigI
   onSubmit,
   children,
 }: React.PropsWithChildren<BaseDestinationFormProps<AdditionalValues>>): React.ReactElement {
-  // Converts the `defaultForSeverity` from an array to an object in order to handle it properly
-  // internally within the form. Essentially converts ['CRITICAL', 'LOW'] to
-  // { CRITICAL: true, LOW: true }
-  const convertedInitialValues = React.useMemo(() => {
-    const { defaultForSeverity, ...otherInitialValues } = initialValues;
-    return {
-      ...otherInitialValues,
-      defaultForSeverity: Object.values(SeverityEnum).reduce(
-        (acc, severity) => ({ ...acc, [severity]: defaultForSeverity.includes(severity) }),
-        {}
-      ) as PrivateBaseDestinationFormValues<AdditionalValues>['defaultForSeverity'],
-    };
-  }, [initialValues]);
-
-  // makes sure that the internal representation of `defaultForSeverity` doesn't leak outside to
-  // the components. For this reason, we revert the value of it back to an array of Severities, the
-  // same way it was passed in as a prop.
-  const onSubmitWithConvertedValues = React.useCallback(
-    ({ defaultForSeverity, ...rest }: PrivateBaseDestinationFormValues<AdditionalValues>) =>
-      onSubmit({
-        ...rest,
-        defaultForSeverity: Object.values(SeverityEnum).filter(
-          (severity: SeverityEnum) => defaultForSeverity[severity]
-        ),
-      }),
-    [onSubmit]
-  );
-
   return (
-    <Formik<PrivateBaseDestinationFormValues<AdditionalValues>>
-      initialValues={convertedInitialValues}
+    <Formik<BaseDestinationFormValues<AdditionalValues>>
+      initialValues={initialValues}
       validationSchema={validationSchema}
-      onSubmit={onSubmitWithConvertedValues}
+      onSubmit={onSubmit}
     >
       <Form autoComplete="off">
         {children}
-        <Box my={8} aria-describedby="severity-disclaimer" textAlign="center">
-          Severity Levels
-          <Text
-            color="gray-300"
-            fontSize="small-medium"
-            id="severity-disclaimer"
-            mt={1}
-            mb={4}
-            fontWeight="medium"
-          >
-            We will only notify you on issues related to the severity types chosen above
-          </Text>
-          <Flex spacing={5} cursor="pointer">
-            {Object.values(SeverityEnum)
-              .reverse()
-              .map(severity => (
-                <Field name="defaultForSeverity" key={severity}>
-                  {() => (
-                    <Field
-                      as={FormikCheckbox}
-                      name={`defaultForSeverity.${severity}`}
-                      id={severity}
-                      label={<SeverityBadge severity={severity} />}
-                    />
-                  )}
-                </Field>
-              ))}
-          </Flex>
-        </Box>
+        <SimpleGrid columns={2} gap={5} my={4} textAlign="left">
+          <Box width={1}>
+            Severity Levels
+            <Text
+              color="gray-300"
+              fontSize="small-medium"
+              id="severity-disclaimer"
+              mt={1}
+              fontWeight="medium"
+            >
+              We will only notify you on issues related to these severity types
+            </Text>
+          </Box>
+          <Field
+            name="defaultForSeverity"
+            as={FormikMultiCombobox}
+            items={Object.values(SeverityEnum)}
+            itemToString={value => getEnumKeyByValue(SeverityEnum, value)}
+            label="Severity"
+            placeholder="Select severities"
+            aria-describedby="severity-disclaimer"
+          />
 
+          <Box>
+            Default Alert Types
+            <Text
+              color="gray-300"
+              fontSize="small-medium"
+              id="alert-type-disclaimer"
+              mt={1}
+              fontWeight="medium"
+            >
+              The selected alert types will be default for this destination
+            </Text>
+          </Box>
+          <Field
+            name="alertTypes"
+            as={FormikMultiCombobox}
+            items={Object.values(AlertTypesEnum)}
+            itemToString={value => getEnumKeyByValue(AlertTypesEnum, value)}
+            label="Alert Types"
+            placeholder="Select Alert Types"
+            aria-describedby="alert-type-disclaimer"
+          />
+        </SimpleGrid>
         {initialValues.outputId ? (
           <Breadcrumbs.Actions>
             <Flex spacing={4} justify="flex-end">

--- a/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
+++ b/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
@@ -27,7 +27,7 @@ import SaveButton from 'Components/buttons/SaveButton';
 import LinkButton from 'Components/buttons/LinkButton';
 import SubmitButton from 'Components/buttons/SubmitButton';
 import FormikMultiCombobox from 'Components/fields/MultiComboBox';
-import { getEnumKeyByValue } from 'Helpers/utils';
+import { alertTypeToString, getEnumKeyByValue } from 'Helpers/utils';
 
 export interface BaseDestinationFormValues<
   AdditionalValues extends Partial<DestinationConfigInput>
@@ -118,7 +118,7 @@ function BaseDestinationForm<AdditionalValues extends Partial<DestinationConfigI
             name="alertTypes"
             as={FormikMultiCombobox}
             items={Object.values(AlertTypesEnum)}
-            itemToString={value => getEnumKeyByValue(AlertTypesEnum, value)}
+            itemToString={alertTypeToString}
             label="Alert Types"
             placeholder="Select Alert Types"
             aria-describedby="alert-type-disclaimer"

--- a/web/src/components/forms/CustomWebhookDestinationForm/CustomWebhookDestinationForm.test.tsx
+++ b/web/src/components/forms/CustomWebhookDestinationForm/CustomWebhookDestinationForm.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor, waitMs, faker } from 'test-utils';
+import { render, fireEvent, waitFor, waitMs, faker, fireClickAndMouseEvents } from 'test-utils';
 import { AlertTypesEnum, SeverityEnum } from 'Generated/schema';
 import CustomWebhookDestinationForm from './index';
 
@@ -51,7 +51,7 @@ const initialValues = {
 
 describe('CustomWebhookDestinationForm', () => {
   it('renders the correct fields', () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <CustomWebhookDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
@@ -59,63 +59,71 @@ describe('CustomWebhookDestinationForm', () => {
     const submitButton = getByText('Add Destination');
     expect(displayNameField).toBeInTheDocument();
     expect(webhookUrl).toBeInTheDocument();
-    Object.values(SeverityEnum).forEach(sev => {
-      expect(getByText(sev)).toBeInTheDocument();
-    });
+    expect(getAllByLabelText('Severity')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Alert Types')[0]).toBeInTheDocument();
 
     expect(submitButton).toHaveAttribute('disabled');
   });
 
   it('has proper validation', async () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <CustomWebhookDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const webhookUrl = getByLabelText('Custom Webhook URL');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(webhookUrl, { target: { value: 'notAUrl' } });
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(webhookUrl, { target: { value: validUrl } });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
   });
 
   it('submit is triggering successfully', async () => {
     const submitMockFunc = jest.fn();
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <CustomWebhookDestinationForm onSubmit={submitMockFunc} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const webhookUrl = getByLabelText('Custom Webhook URL');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     fireEvent.change(webhookUrl, { target: { value: validUrl } });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: null,
-      displayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: [severity],
-      alertTypes: [],
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: null,
+        displayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: [severity],
+        alertTypes: [AlertTypesEnum.Rule],
+      },
+      expect.toBeObject()
+    );
   });
 
   it('should edit Custom webhook Destination successfully', async () => {
@@ -135,12 +143,15 @@ describe('CustomWebhookDestinationForm', () => {
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: initialValues.outputId,
-      displayName: newDisplayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: initialValues.defaultForSeverity,
-      alertTypes: initialValues.alertTypes,
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: initialValues.outputId,
+        displayName: newDisplayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: initialValues.defaultForSeverity,
+        alertTypes: initialValues.alertTypes,
+      },
+      expect.toBeObject()
+    );
   });
 });

--- a/web/src/components/forms/GithubDestinationForm/GithubDestinationForm.test.tsx
+++ b/web/src/components/forms/GithubDestinationForm/GithubDestinationForm.test.tsx
@@ -17,7 +17,14 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor, waitMs, buildGithubConfigInput } from 'test-utils';
+import {
+  render,
+  fireEvent,
+  waitFor,
+  waitMs,
+  buildGithubConfigInput,
+  fireClickAndMouseEvents,
+} from 'test-utils';
 import { AlertTypesEnum, SeverityEnum } from 'Generated/schema';
 import GithubDestinationForm from './index';
 
@@ -52,7 +59,7 @@ const initialValues = {
 
 describe('GithubDestinationForm', () => {
   it('renders the correct fields', () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <GithubDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
@@ -62,40 +69,42 @@ describe('GithubDestinationForm', () => {
     expect(displayNameField).toBeInTheDocument();
     expect(repoNameField).toBeInTheDocument();
     expect(tokenField).toBeInTheDocument();
-    Object.values(SeverityEnum).forEach(sev => {
-      expect(getByText(sev)).toBeInTheDocument();
-    });
+    expect(getAllByLabelText('Severity')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Alert Types')[0]).toBeInTheDocument();
 
     expect(submitButton).toHaveAttribute('disabled');
   });
 
   it('has proper validation', async () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <GithubDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const repoNameField = getByLabelText('Repository name');
     const tokenField = getByLabelText('Token');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(repoNameField, { target: { value: 'repo' } });
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(tokenField, { target: { value: 'someToken' } });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
   });
 
   it('should trigger submit successfully', async () => {
     const submitMockFunc = jest.fn();
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <GithubDestinationForm onSubmit={submitMockFunc} initialValues={emptyInitialValues} />
     );
     const githubInput = buildGithubConfigInput();
@@ -103,26 +112,32 @@ describe('GithubDestinationForm', () => {
     const repoNameField = getByLabelText('Repository name');
     const tokenField = getByLabelText('Token');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     fireEvent.change(repoNameField, { target: { value: githubInput.repoName } });
     fireEvent.change(tokenField, { target: { value: githubInput.token } });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: null,
-      displayName,
-      outputConfig: { github: githubInput },
-      defaultForSeverity: [severity],
-      alertTypes: [],
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: null,
+        displayName,
+        outputConfig: { github: githubInput },
+        defaultForSeverity: [severity],
+        alertTypes: [AlertTypesEnum.Rule],
+      },
+      expect.toBeObject()
+    );
   });
 
   it('should edit Github Destination successfully', async () => {
@@ -146,12 +161,15 @@ describe('GithubDestinationForm', () => {
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: initialValues.outputId,
-      displayName: newDisplayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: initialValues.defaultForSeverity,
-      alertTypes: initialValues.alertTypes,
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: initialValues.outputId,
+        displayName: newDisplayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: initialValues.defaultForSeverity,
+        alertTypes: initialValues.alertTypes,
+      },
+      expect.toBeObject()
+    );
   });
 });

--- a/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.test.tsx
+++ b/web/src/components/forms/MicrosoftTeamsDestinationForm/MicrosoftTeamsDestinationForm.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor, waitMs, faker } from 'test-utils';
+import { render, fireEvent, waitFor, waitMs, faker, fireClickAndMouseEvents } from 'test-utils';
 import { AlertTypesEnum, SeverityEnum } from 'Generated/schema';
 import MicrosoftTeamsDestinationForm from './index';
 
@@ -51,7 +51,7 @@ const initialValues = {
 
 describe('MicrosoftTeamsDestinationForm', () => {
   it('renders the correct fields', () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <MicrosoftTeamsDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
@@ -59,65 +59,73 @@ describe('MicrosoftTeamsDestinationForm', () => {
     const submitButton = getByText('Add Destination');
     expect(displayNameField).toBeInTheDocument();
     expect(webhookUrl).toBeInTheDocument();
-    Object.values(SeverityEnum).forEach(sev => {
-      expect(getByText(sev)).toBeInTheDocument();
-    });
+    expect(getAllByLabelText('Severity')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Alert Types')[0]).toBeInTheDocument();
 
     expect(submitButton).toHaveAttribute('disabled');
   });
 
   it('has proper validation', async () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <MicrosoftTeamsDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const webhookUrl = getByLabelText('Microsoft Teams Webhook URL');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(webhookUrl, { target: { value: 'notAUrl' } });
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(webhookUrl, { target: { value: validUrl } });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
   });
 
   it('submit is triggering successfully', async () => {
     const submitMockFunc = jest.fn();
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <MicrosoftTeamsDestinationForm onSubmit={submitMockFunc} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const webhookUrl = getByLabelText('Microsoft Teams Webhook URL');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     fireEvent.change(webhookUrl, {
       target: { value: initialValues.outputConfig.msTeams.webhookURL },
     });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: null,
-      displayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: [severity],
-      alertTypes: [],
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: null,
+        displayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: [severity],
+        alertTypes: [AlertTypesEnum.Rule],
+      },
+      expect.toBeObject()
+    );
   });
 
   it('should edit Microsoft Teams Destination successfully', async () => {
@@ -137,12 +145,15 @@ describe('MicrosoftTeamsDestinationForm', () => {
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: initialValues.outputId,
-      displayName: newDisplayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: initialValues.defaultForSeverity,
-      alertTypes: initialValues.alertTypes,
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: initialValues.outputId,
+        displayName: newDisplayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: initialValues.defaultForSeverity,
+        alertTypes: initialValues.alertTypes,
+      },
+      expect.toBeObject()
+    );
   });
 });

--- a/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.test.tsx
+++ b/web/src/components/forms/SlackDestinationForm/SlackDestinationForm.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor, waitMs, faker } from 'test-utils';
+import { render, fireEvent, waitFor, waitMs, faker, fireClickAndMouseEvents } from 'test-utils';
 import { AlertTypesEnum, SeverityEnum } from 'Generated/schema';
 import SlackDestinationForm from './index';
 
@@ -51,7 +51,7 @@ const initialValues = {
 
 describe('SlackDestinationForm', () => {
   it('renders the correct fields', () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <SlackDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
@@ -59,63 +59,74 @@ describe('SlackDestinationForm', () => {
     const submitButton = getByText('Add Destination');
     expect(displayNameField).toBeInTheDocument();
     expect(webhookUrl).toBeInTheDocument();
-    Object.values(SeverityEnum).forEach(sev => {
-      expect(getByText(sev)).toBeInTheDocument();
-    });
+    expect(getAllByLabelText('Severity')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Alert Types')[0]).toBeInTheDocument();
 
     expect(submitButton).toHaveAttribute('disabled');
   });
 
   it('has proper validation', async () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <SlackDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const webhookUrl = getByLabelText('Slack Webhook URL');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(webhookUrl, { target: { value: 'notAUrl' } });
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(webhookUrl, { target: { value: validUrl } });
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
+
     expect(submitButton).not.toHaveAttribute('disabled');
   });
 
   it('submit is triggering successfully', async () => {
     const submitMockFunc = jest.fn();
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <SlackDestinationForm onSubmit={submitMockFunc} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const webhookUrl = getByLabelText('Slack Webhook URL');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     fireEvent.change(webhookUrl, { target: { value: validUrl } });
+
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
+
     expect(submitButton).not.toHaveAttribute('disabled');
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: null,
-      displayName,
-      outputConfig: { slack: { webhookURL: validUrl } },
-      defaultForSeverity: [severity],
-      alertTypes: [],
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: null,
+        displayName,
+        outputConfig: { slack: { webhookURL: validUrl } },
+        defaultForSeverity: [severity],
+        alertTypes: [AlertTypesEnum.Rule],
+      },
+      expect.toBeObject()
+    );
   });
 
   it('should edit Slack Destination successfully', async () => {
@@ -135,12 +146,15 @@ describe('SlackDestinationForm', () => {
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: initialValues.outputId,
-      displayName: newDisplayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: initialValues.defaultForSeverity,
-      alertTypes: initialValues.alertTypes,
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: initialValues.outputId,
+        displayName: newDisplayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: initialValues.defaultForSeverity,
+        alertTypes: initialValues.alertTypes,
+      },
+      expect.toBeObject()
+    );
   });
 });

--- a/web/src/components/forms/SnsDestinationForm/SnsDestinationForm.test.tsx
+++ b/web/src/components/forms/SnsDestinationForm/SnsDestinationForm.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor, waitMs } from 'test-utils';
+import { render, fireEvent, waitFor, waitMs, fireClickAndMouseEvents } from 'test-utils';
 import { AlertTypesEnum, SeverityEnum } from 'Generated/schema';
 import SnsDestinationForm from './index';
 
@@ -51,7 +51,7 @@ const initialValues = {
 
 describe('SnsDestinationForm', () => {
   it('renders the correct fields', () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <SnsDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
@@ -59,26 +59,24 @@ describe('SnsDestinationForm', () => {
     const submitButton = getByText('Add Destination');
     expect(displayNameField).toBeInTheDocument();
     expect(topicArnField).toBeInTheDocument();
-    Object.values(SeverityEnum).forEach(sev => {
-      expect(getByText(sev)).toBeInTheDocument();
-    });
+    expect(getAllByLabelText('Severity')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Alert Types')[0]).toBeInTheDocument();
 
     expect(submitButton).toHaveAttribute('disabled');
   });
 
   it('has proper validation', async () => {
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <SnsDestinationForm onSubmit={() => {}} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const topicArnField = getByLabelText('Topic ARN');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     await waitMs(1);
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(topicArnField, { target: { value: 'notValidTopicArn' } });
@@ -86,37 +84,50 @@ describe('SnsDestinationForm', () => {
     // Topic ARN has specific form
     expect(submitButton).toHaveAttribute('disabled');
     fireEvent.change(topicArnField, { target: { value: validTopicArn } });
+
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
   });
 
   it('submit is triggering successfully', async () => {
     const submitMockFunc = jest.fn();
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByText, getAllByLabelText } = render(
       <SnsDestinationForm onSubmit={submitMockFunc} initialValues={emptyInitialValues} />
     );
     const displayNameField = getByLabelText('* Display Name');
     const topicArnField = getByLabelText('Topic ARN');
     const submitButton = getByText('Add Destination');
-    const criticalSeverityCheckBox = document.getElementById(severity);
-    expect(criticalSeverityCheckBox).not.toBeNull();
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
     expect(submitButton).toHaveAttribute('disabled');
 
     fireEvent.change(displayNameField, { target: { value: displayName } });
-    fireEvent.click(criticalSeverityCheckBox);
     fireEvent.change(topicArnField, { target: { value: validTopicArn } });
+
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     await waitMs(1);
     expect(submitButton).not.toHaveAttribute('disabled');
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: null,
-      displayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: [severity],
-      alertTypes: [],
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: null,
+        displayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: [severity],
+        alertTypes: [AlertTypesEnum.Rule],
+      },
+      expect.toBeObject()
+    );
   });
 
   it('should edit SNS Destination successfully', async () => {
@@ -136,12 +147,15 @@ describe('SnsDestinationForm', () => {
 
     fireEvent.click(submitButton);
     await waitFor(() => expect(submitMockFunc).toHaveBeenCalledTimes(1));
-    expect(submitMockFunc).toHaveBeenCalledWith({
-      outputId: initialValues.outputId,
-      displayName: newDisplayName,
-      outputConfig: initialValues.outputConfig,
-      defaultForSeverity: initialValues.defaultForSeverity,
-      alertTypes: initialValues.alertTypes,
-    });
+    expect(submitMockFunc).toHaveBeenCalledWith(
+      {
+        outputId: initialValues.outputId,
+        displayName: newDisplayName,
+        outputConfig: initialValues.outputConfig,
+        defaultForSeverity: initialValues.defaultForSeverity,
+        alertTypes: initialValues.alertTypes,
+      },
+      expect.toBeObject()
+    );
   });
 });

--- a/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
+++ b/web/src/components/wizards/CreateDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
@@ -128,7 +128,7 @@ const ConfigureDestinationPanel: React.FC = () => {
       : selectedDestinationType
   );
   return (
-    <Box maxWidth={700} mx="auto">
+    <Box maxWidth={800} mx="auto">
       <WizardPanel.Heading
         title={`Configure Your ${destinationDisplayName} Destination`}
         subtitle="Fill out the form below to configure your Destination"

--- a/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
+++ b/web/src/components/wizards/EditDestinationWizard/ConfigureDestinationPanel/ConfigureDestinationPanel.tsx
@@ -103,7 +103,7 @@ const ConfigureDestinationPanel: React.FC = () => {
   );
 
   return (
-    <Box maxWidth={700} mx="auto">
+    <Box maxWidth={800} mx="auto">
       <WizardPanel.Heading
         title={`Update Your ${destinationDisplayName} Destination`}
         subtitle="Make changes to the form below in order to update your Destination"

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -22,6 +22,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import * as Yup from 'yup';
 import {
   ActiveSuppressCount,
+  AlertTypesEnum,
   ComplianceIntegration,
   ComplianceStatusCounts,
   OrganizationReportBySeverity,
@@ -404,6 +405,22 @@ export const downloadData = (data: string, filename: string) => {
 export function getEnumKeyByValue(object: { [key: string]: string }, value: string) {
   return Object.keys(object).find(key => object[key] === value);
 }
+
+/**
+ * Helper function that returns proper text for Alert Type
+ * @param item AlertTypesEnum
+ */
+export const alertTypeToString = (item: AlertTypesEnum) => {
+  switch (item) {
+    case AlertTypesEnum.Rule:
+      return 'Rule Matches';
+    case AlertTypesEnum.RuleError:
+      return 'Rule Errors';
+    case AlertTypesEnum.Policy:
+    default:
+      return 'Policy Failures';
+  }
+};
 
 /**
  * Converts a word to its plural form

--- a/web/src/helpers/utils.tsx
+++ b/web/src/helpers/utils.tsx
@@ -397,6 +397,15 @@ export const downloadData = (data: string, filename: string) => {
 };
 
 /**
+ * Helper function that return key from Enumaration value
+ * @param object
+ * @param value
+ */
+export function getEnumKeyByValue(object: { [key: string]: string }, value: string) {
+  return Object.keys(object).find(key => object[key] === value);
+}
+
+/**
  * Converts a word to its plural form
  *
  * @returns {String} pluralized word
@@ -419,5 +428,4 @@ function toPlural(word: string, pluralFormOrCount?: number | string, count?: num
 
   return cnt === 1 ? word : pluralForm;
 }
-
-export default toPlural;
+export { toPlural };

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsEvents/AlertDetailsEvents.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsEvents/AlertDetailsEvents.tsx
@@ -22,7 +22,7 @@ import { Box, Card, Flex, Heading, Icon, Tooltip } from 'pouncejs';
 import { AlertDetailsRuleInfo } from 'Generated/schema';
 import { TableControlsPagination as PaginationControls } from 'Components/utils/TableControls';
 import { DEFAULT_LARGE_PAGE_SIZE } from 'Source/constants';
-import toPlural from 'Helpers/utils';
+import { toPlural } from 'Helpers/utils';
 import { AlertDetails } from '../../graphql/alertDetails.generated';
 
 // Given an event received as a string, this function converts it to JSON

--- a/web/src/pages/CreateDestination/CreateDestination.test.tsx
+++ b/web/src/pages/CreateDestination/CreateDestination.test.tsx
@@ -31,6 +31,7 @@ import {
   buildMsTeamsConfigInput,
   buildOpsgenieConfigInput,
   buildAsanaConfigInput,
+  fireClickAndMouseEvents,
 } from 'test-utils';
 import urls from 'Source/urls';
 import { mockAddDestination } from 'Components/wizards/CreateDestinationWizard';
@@ -110,21 +111,28 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Slack
     fireEvent.click(getByText('Slack'));
 
     const displayInput = getByLabelText('* Display Name');
     const webhookUrlInput = getByLabelText('Slack Webhook URL');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: slackDisplayName } });
     fireEvent.change(webhookUrlInput, { target: { value: validUrl } });
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     fireEvent.click(getByText('Add Destination'));
 
     // Expect success screen with proper redirect link
@@ -152,9 +160,12 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Github
     fireEvent.click(getByText('Github'));
@@ -162,13 +173,17 @@ describe('CreateDestination', () => {
     const displayInput = getByLabelText('* Display Name');
     const repositoryInput = getByLabelText('Repository name');
     const tokenInput = getByLabelText('Token');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: githubDisplayName } });
     fireEvent.change(repositoryInput, { target: { value: githubConfig.repoName } });
     fireEvent.change(tokenInput, { target: { value: githubConfig.token } });
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -193,9 +208,12 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Jira
     fireEvent.click(getByText('Jira'));
@@ -208,7 +226,8 @@ describe('CreateDestination', () => {
     const issueInput = getByLabelText('* Issue Type');
     const labelsInput = getByLabelText('Labels', { selector: 'input' });
     const assigneeInput = getByLabelText('Assignee ID');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: jiraDisplayName } });
@@ -226,7 +245,11 @@ describe('CreateDestination', () => {
       });
       fireEvent.blur(labelsInput);
     });
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -252,22 +275,30 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select PagerDuty
     fireEvent.click(getByText('PagerDuty'));
 
     const displayInput = getByLabelText('* Display Name');
     const integrationKeyInput = getByLabelText('Integration Key');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: pageDutyDisplayName } });
     fireEvent.change(integrationKeyInput, { target: { value: pagerDutyConfig.integrationKey } });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -292,22 +323,30 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select SQS
     fireEvent.click(getByText('AWS SQS'));
 
     const displayInput = getByLabelText('* Display Name');
     const queueUrlInput = getByLabelText('Queue URL');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: sqsDisplayName } });
     fireEvent.change(queueUrlInput, { target: { value: sqsConfig.queueUrl } });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -334,22 +373,30 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select SNS
     fireEvent.click(getByText('AWS SNS'));
 
     const displayInput = getByLabelText('* Display Name');
     const topicArnInput = getByLabelText('Topic ARN');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: snsDisplayName } });
     fireEvent.change(topicArnInput, { target: { value: snsConfig.topicArn } });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -374,22 +421,30 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Custom Webhook
     fireEvent.click(getByText('Custom Webhook'));
 
     const displayInput = getByLabelText('* Display Name');
     const webhookUrlInput = getByLabelText('Custom Webhook URL');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: webhookDisplayName } });
     fireEvent.change(webhookUrlInput, { target: { value: webhookConfig.webhookURL } });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -414,22 +469,30 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Microsoft Teams
     fireEvent.click(getByText('Microsoft Teams'));
 
     const displayInput = getByLabelText('* Display Name');
     const webhookUrlInput = getByLabelText('Microsoft Teams Webhook URL');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: teamsDisplayName } });
     fireEvent.change(webhookUrlInput, { target: { value: teamsConfig.webhookURL } });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -454,22 +517,30 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Opsgenie
     fireEvent.click(getByText('Opsgenie'));
 
     const displayInput = getByLabelText('* Display Name');
     const opsgenieApiKey = getByLabelText('Opsgenie API key');
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: opsgenieDisplayName } });
     fireEvent.change(opsgenieApiKey, { target: { value: opsgenieConfig.apiKey } });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
@@ -494,9 +565,12 @@ describe('CreateDestination', () => {
         data: { addDestination: createdDestination },
       }),
     ];
-    const { getByText, findByText, getByLabelText } = render(<CreateDestination />, {
-      mocks,
-    });
+    const { getByText, findByText, getByLabelText, getAllByLabelText } = render(
+      <CreateDestination />,
+      {
+        mocks,
+      }
+    );
 
     // Select Asana
     fireEvent.click(getByText('Asana'));
@@ -504,7 +578,8 @@ describe('CreateDestination', () => {
     const displayInput = getByLabelText('* Display Name');
     const tokenInput = getByLabelText('Access Token');
     const projectGidsInput = getByLabelText('Project GIDs', { selector: 'input' });
-    const criticalSeverityCheckbox = getByLabelText(criticalSeverity);
+    const severityField = getAllByLabelText('Severity')[0];
+    const alertTypeField = getAllByLabelText('Alert Types')[0];
 
     // Fill in the correct data + submit
     fireEvent.change(displayInput, { target: { value: asanaDisplayName } });
@@ -518,7 +593,11 @@ describe('CreateDestination', () => {
       fireEvent.blur(projectGidsInput);
     });
 
-    fireEvent.click(criticalSeverityCheckbox);
+    fireEvent.change(severityField, { target: { value: 'Critical' } });
+    fireClickAndMouseEvents(getByText('Critical'));
+    fireEvent.change(alertTypeField, { target: { value: 'Rule Matches' } });
+    fireClickAndMouseEvents(getByText('Rule Matches'));
+
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));

--- a/web/src/pages/EditDestination/EditDestination.test.tsx
+++ b/web/src/pages/EditDestination/EditDestination.test.tsx
@@ -44,7 +44,9 @@ describe('EditDestination', () => {
 
     const mocks = [mockGetDestinationDetails({ data: { destination } })];
 
-    const { findByLabelText, getByAriaLabel } = render(<EditDestination />, { mocks });
+    const { findByLabelText, getByAriaLabel, getAllByLabelText } = render(<EditDestination />, {
+      mocks,
+    });
 
     // Expect loading
     expect(getByAriaLabel('Loading...')).toBeInTheDocument();
@@ -52,15 +54,12 @@ describe('EditDestination', () => {
     // Expect a form
     const displayInput = (await findByLabelText('* Display Name')) as HTMLInputElement;
     const webhookUrlInput = (await findByLabelText('Slack Webhook URL')) as HTMLInputElement;
-    const criticalSeverityCheckbox = (await findByLabelText(
-      SeverityEnum.Critical
-    )) as HTMLInputElement;
+    expect(getAllByLabelText('Severity')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Alert Types')[0]).toBeInTheDocument();
 
     // With correct pre-populated values
     expect(displayInput.value).toEqual(destination.displayName);
     expect(webhookUrlInput.value).toEqual(destination.outputConfig.slack.webhookURL);
-    expect(criticalSeverityCheckbox.checked).toBeTruthy();
-    expect(criticalSeverityCheckbox.value).toBeTruthy();
   });
 
   it('can successfully edit Slack destination', async () => {

--- a/web/src/pages/ListAlerts/ListAlertFilters/DropdownFilters.tsx
+++ b/web/src/pages/ListAlerts/ListAlertFilters/DropdownFilters.tsx
@@ -30,7 +30,7 @@ import {
 } from 'pouncejs';
 import { AlertStatusesEnum, AlertTypesEnum, ListAlertsInput, SeverityEnum } from 'Generated/schema';
 import useRequestParamsWithoutPagination from 'Hooks/useRequestParamsWithoutPagination';
-import { capitalize } from 'Helpers/utils';
+import { capitalize, alertTypeToString } from 'Helpers/utils';
 import pick from 'lodash/pick';
 import FormikMultiCombobox from 'Components/fields/MultiComboBox';
 import TextButton from 'Components/buttons/TextButton';
@@ -45,18 +45,6 @@ export type ListAlertsDropdownFiltersValues = Pick<
 
 const filterItemToString = (item: SeverityEnum | AlertStatusesEnum) =>
   capitalize(item.toLowerCase());
-
-const alertTypeToString = (item: AlertTypesEnum) => {
-  switch (item) {
-    case AlertTypesEnum.Rule:
-      return 'Rule Matches';
-    case AlertTypesEnum.RuleError:
-      return 'Rule Errors';
-    case AlertTypesEnum.Policy:
-    default:
-      return 'Policy Failures';
-  }
-};
 
 const statusOptions = Object.values(AlertStatusesEnum);
 const severityOptions = Object.values(SeverityEnum);

--- a/web/src/pages/ListDestinations/DestinationCards/AsanaDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/AsanaDestinationCard.tsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -34,15 +33,6 @@ const AsanaDestinationCard: React.FC<AsanaDestinationCardProps> = ({ destination
       <GenericItemCard.Value
         label="Project GIDs"
         value={destination.outputConfig.asana.projectGids.join(', ')}
-      />
-      <GenericItemCard.LineBreak />
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
       />
     </DestinationCard>
   );

--- a/web/src/pages/ListDestinations/DestinationCards/CustomWebhookDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/CustomWebhookDestinationCard.tsx
@@ -17,9 +17,7 @@
  */
 
 import React from 'react';
-import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -35,16 +33,7 @@ const CustomWebhookDestinationCard: React.FC<CustomWebhookDestinationCardProps> 
     <DestinationCard
       logo={DESTINATIONS[DestinationTypeEnum.Customwebhook].logo}
       destination={destination}
-    >
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
-    </DestinationCard>
+    />
   );
 };
 

--- a/web/src/pages/ListDestinations/DestinationCards/DestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/DestinationCard.tsx
@@ -24,11 +24,12 @@ import React from 'react';
 import DestinationCardOptions from 'Pages/ListDestinations/DestinationCards/DestinationCardOptions';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import urls from 'Source/urls';
+import { alertTypeToString, formatDatetime } from 'Helpers/utils';
 
 interface DestinationCardProps {
   destination: DestinationFull;
   logo: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const DestinationCard: React.FC<DestinationCardProps> = ({ destination, logo, children }) => {
@@ -42,9 +43,15 @@ const DestinationCard: React.FC<DestinationCardProps> = ({ destination, logo, ch
               {destination.displayName}
             </Link>
           </GenericItemCard.Heading>
+          <GenericItemCard.Date date={formatDatetime(destination.lastModifiedTime)} />
           <DestinationCardOptions destination={destination} />
         </GenericItemCard.Header>
+
         <GenericItemCard.ValuesGroup>
+          <GenericItemCard.Value
+            label="Alert Types"
+            value={destination.alertTypes.map(alertTypeToString).join(', ')}
+          />
           {children}
           <Flex ml="auto" mr={0} mt={4} align="flex-end" spacing={2}>
             {destination.defaultForSeverity.map(severity => (

--- a/web/src/pages/ListDestinations/DestinationCards/GithubDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/GithubDestinationCard.tsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -32,15 +31,6 @@ const GithubDestinationCard: React.FC<GithubDestinationCardProps> = ({ destinati
   return (
     <DestinationCard logo={DESTINATIONS[DestinationTypeEnum.Github].logo} destination={destination}>
       <GenericItemCard.Value label="Repository" value={destination.outputConfig.github.repoName} />
-      <GenericItemCard.LineBreak />
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
     </DestinationCard>
   );
 };

--- a/web/src/pages/ListDestinations/DestinationCards/JiraDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/JiraDestinationCard.tsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -35,23 +34,8 @@ const JiraDestinationCard: React.FC<JiraDestinationCardProps> = ({ destination }
         label="Organization Domain"
         value={destination.outputConfig.jira.orgDomain}
       />
-      <GenericItemCard.Value label="Project Key" value={destination.outputConfig.jira.projectKey} />
-      <GenericItemCard.Value label="Email" value={destination.outputConfig.jira.userName} />
       <GenericItemCard.Value label="Assignee ID" value={destination.outputConfig.jira.assigneeId} />
       <GenericItemCard.Value label="Issue Type" value={destination.outputConfig.jira.issueType} />
-      <GenericItemCard.Value
-        label="Labels"
-        value={destination.outputConfig.jira.labels.join(', ')}
-      />
-      <GenericItemCard.LineBreak />
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
     </DestinationCard>
   );
 };

--- a/web/src/pages/ListDestinations/DestinationCards/MsTeamsDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/MsTeamsDestinationCard.tsx
@@ -17,9 +17,7 @@
  */
 
 import React from 'react';
-import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -33,16 +31,7 @@ const MsTeamsDestinationCard: React.FC<MsTeamsDestinationCardProps> = ({ destina
     <DestinationCard
       logo={DESTINATIONS[DestinationTypeEnum.Msteams].logo}
       destination={destination}
-    >
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
-    </DestinationCard>
+    />
   );
 };
 

--- a/web/src/pages/ListDestinations/DestinationCards/OpsGenieDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/OpsGenieDestinationCard.tsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum, OpsgenieServiceRegionEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -41,15 +40,6 @@ const OpsGenieDestinationCard: React.FC<OpsGenieDestinationCardProps> = ({ desti
             ? 'European'
             : 'American (Default)'
         }
-      />
-      <GenericItemCard.LineBreak />
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
       />
     </DestinationCard>
   );

--- a/web/src/pages/ListDestinations/DestinationCards/PagerDutyDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/PagerDutyDestinationCard.tsx
@@ -17,9 +17,7 @@
  */
 
 import React from 'react';
-import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -33,16 +31,7 @@ const PagerDutyDestinationCard: React.FC<PagerDutyDestinationCardProps> = ({ des
     <DestinationCard
       logo={DESTINATIONS[DestinationTypeEnum.Pagerduty].logo}
       destination={destination}
-    >
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
-    </DestinationCard>
+    />
   );
 };
 

--- a/web/src/pages/ListDestinations/DestinationCards/SlackDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/SlackDestinationCard.tsx
@@ -17,9 +17,7 @@
  */
 
 import React from 'react';
-import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -30,16 +28,10 @@ interface SlackDestinationCardProps {
 
 const SlackDestinationCard: React.FC<SlackDestinationCardProps> = ({ destination }) => {
   return (
-    <DestinationCard logo={DESTINATIONS[DestinationTypeEnum.Slack].logo} destination={destination}>
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
-    </DestinationCard>
+    <DestinationCard
+      logo={DESTINATIONS[DestinationTypeEnum.Slack].logo}
+      destination={destination}
+    />
   );
 };
 

--- a/web/src/pages/ListDestinations/DestinationCards/SnsDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/SnsDestinationCard.tsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -32,15 +31,6 @@ const SnsDestinationCard: React.FC<SnsDestinationCardProps> = ({ destination }) 
   return (
     <DestinationCard logo={DESTINATIONS[DestinationTypeEnum.Sns].logo} destination={destination}>
       <GenericItemCard.Value label="Topic ARN" value={destination.outputConfig.sns.topicArn} />
-      <GenericItemCard.LineBreak />
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
     </DestinationCard>
   );
 };

--- a/web/src/pages/ListDestinations/DestinationCards/SqsDestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/SqsDestinationCard.tsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import GenericItemCard from 'Components/GenericItemCard';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
-import { formatDatetime } from 'Helpers/utils';
 import { DESTINATIONS } from 'Source/constants';
 import { DestinationTypeEnum } from 'Generated/schema';
 import DestinationCard from './DestinationCard';
@@ -32,15 +31,6 @@ const SqsDestinationCard: React.FC<SqsDestinationCardProps> = ({ destination }) 
   return (
     <DestinationCard logo={DESTINATIONS[DestinationTypeEnum.Sqs].logo} destination={destination}>
       <GenericItemCard.Value label="Queue URL" value={destination.outputConfig.sqs.queueUrl} />
-      <GenericItemCard.LineBreak />
-      <GenericItemCard.Value
-        label="Date Created"
-        value={formatDatetime(destination.creationTime, true)}
-      />
-      <GenericItemCard.Value
-        label="Last Updated"
-        value={formatDatetime(destination.lastModifiedTime, true)}
-      />
     </DestinationCard>
   );
 };

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/AsanaDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/AsanaDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildAsanaConfig, buildDestination, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { AsanaDestinationCard } from '../index';
 
 describe('AsanaDestinationCard', () => {
@@ -36,7 +37,8 @@ describe('AsanaDestinationCard', () => {
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(asanaDestination.displayName)).toBeInTheDocument();
     expect(getByText('Project GIDs')).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(asanaDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/CustomWebhookDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/CustomWebhookDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildCustomWebhookConfigInput, buildDestination, render } from 'test-ut
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { CustomWebhookDestinationCard } from '../index';
 
 describe('CustomWebhookDestinationCard', () => {
@@ -35,7 +36,8 @@ describe('CustomWebhookDestinationCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(customWebhookDestination.displayName)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(customWebhookDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/DestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/DestinationCard.test.tsx
@@ -42,7 +42,7 @@ describe('Generic Destination Card', () => {
     }) as DestinationFull;
     const { container } = render(
       <DestinationCard destination={destination} logo={logo}>
-        A required children
+        A children
       </DestinationCard>
     );
 

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/GithubDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/GithubDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildGithubConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { GithubDestinationCard } from '../index';
 
 describe('GithubDestinationCard', () => {
@@ -36,7 +37,8 @@ describe('GithubDestinationCard', () => {
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(githubDestination.displayName)).toBeInTheDocument();
     expect(getByText(githubDestination.outputConfig.github.repoName)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(githubDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/JiraDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/JiraDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildJiraConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { JiraDestinationCard } from '../index';
 
 describe('JiraDestinationCard', () => {
@@ -35,13 +36,11 @@ describe('JiraDestinationCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(jiraDestination.displayName)).toBeInTheDocument();
-    expect(getByText(jiraDestination.outputConfig.jira.projectKey)).toBeInTheDocument();
-    expect(getByText(jiraDestination.outputConfig.jira.userName)).toBeInTheDocument();
     expect(getByText(jiraDestination.outputConfig.jira.assigneeId)).toBeInTheDocument();
     expect(getByText(jiraDestination.outputConfig.jira.issueType)).toBeInTheDocument();
     expect(getByText(jiraDestination.outputConfig.jira.orgDomain)).toBeInTheDocument();
-    expect(getByText('Labels')).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(jiraDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/MsTeamsDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/MsTeamsDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildMsTeamsConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { MsTeamsDestinationCard } from '../index';
 
 describe('MsTeamsDestinationCard', () => {
@@ -35,7 +36,8 @@ describe('MsTeamsDestinationCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(msTeamsDestination.displayName)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(msTeamsDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/OpsGenieDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/OpsGenieDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildOpsgenieConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum, OpsgenieServiceRegionEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { OpsGenieDestinationCard } from '../index';
 
 describe('OpsGenieDestinationCard', () => {
@@ -40,8 +41,9 @@ describe('OpsGenieDestinationCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(opsGenieDestination.displayName)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(opsGenieDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
     expect(getByText('European')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/PagerDutyDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/PagerDutyDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildPagerDutyConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { PagerDutyDestinationCard } from '../index';
 
 describe('PagerDutyDestinationCard', () => {
@@ -35,7 +36,8 @@ describe('PagerDutyDestinationCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(pageDutyDestination.displayName)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(pageDutyDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/SlackDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/SlackDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildSlackConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { SlackDestinationCard } from '../index';
 
 describe('SlackDestinationCard', () => {
@@ -35,7 +36,8 @@ describe('SlackDestinationCard', () => {
     expect(getByAltText(/Logo/i)).toBeInTheDocument();
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(slackDestination.displayName)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(slackDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/SnsDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/SnsDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildSnsConfig, render } from 'test-utils';
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { SnsDestinationCard } from '../index';
 
 describe('SnsDestinationCard', () => {
@@ -36,7 +37,8 @@ describe('SnsDestinationCard', () => {
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(snsDestination.displayName)).toBeInTheDocument();
     expect(getByText(snsDestination.outputConfig.sns.topicArn)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(snsDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/SqsDestinationCard.test.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/SqsDestinationCard.test.tsx
@@ -20,6 +20,7 @@ import { buildDestination, buildSqsDestinationConfig, render } from 'test-utils'
 import React from 'react';
 import { DestinationFull } from 'Source/graphql/fragments/DestinationFull.generated';
 import { DestinationTypeEnum } from 'Generated/schema';
+import { alertTypeToString } from 'Helpers/utils';
 import { SqsDestinationCard } from '../index';
 
 describe('SqsDestinationCard', () => {
@@ -36,7 +37,8 @@ describe('SqsDestinationCard', () => {
     expect(getByAriaLabel(/Toggle Options/i)).toBeInTheDocument();
     expect(getByText(sqsDestination.displayName)).toBeInTheDocument();
     expect(getByText(sqsDestination.outputConfig.sqs.queueUrl)).toBeInTheDocument();
-    expect(getByText('Date Created')).toBeInTheDocument();
-    expect(getByText('Last Updated')).toBeInTheDocument();
+    expect(
+      getByText(sqsDestination.alertTypes.map(alertTypeToString).join(' ,'))
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/__snapshots__/DestinationCard.test.tsx.snap
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/__snapshots__/DestinationCard.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Generic Destination Card should match snapshot 1`] = `
-.panther-13 {
+.panther-17 {
   background-color: #1d2a3f;
   border-radius: 4px;
   padding: 16px;
@@ -10,7 +10,7 @@ exports[`Generic Destination Card should match snapshot 1`] = `
 
 
 
-.panther-11 {
+.panther-15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -24,7 +24,7 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   margin-right: 20px;
 }
 
-.panther-10 {
+.panther-14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -38,7 +38,7 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   width: 100%;
 }
 
-.panther-6 {
+.panther-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,12 +79,17 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   color: #11a5f3;
 }
 
-.panther-5 {
+.panther-3 {
+  font-size: 0.75rem;
+  color: #86a3c3;
+}
+
+.panther-6 {
   margin-left: 8px;
   margin-top: -4px;
 }
 
-.panther-4 {
+.panther-5 {
   outline: none;
   line-height: 1;
   border-radius: 99999px;
@@ -101,20 +106,20 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   text-decoration: none;
 }
 
-.panther-4:hover {
+.panther-5:hover {
   background-color: rgba(62,81,107,0.3);
 }
 
-.panther-4:focus {
+.panther-5:focus {
   background-color: rgba(62,81,107,0.3);
 }
 
-.panther-4:active,
-.panther-4[data-active=true] {
+.panther-5:active,
+.panther-5[data-active=true] {
   background-color: #3e516b;
 }
 
-.panther-3 {
+.panther-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -125,7 +130,7 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   color: currentColor;
 }
 
-.panther-9 {
+.panther-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -136,11 +141,47 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   flex-wrap: wrap;
 }
 
-.panther-9>*:not(:last-child) {
+.panther-13>*:not(:last-child) {
   margin-right: 32px;
 }
 
+.panther-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-top: 8px;
+}
+
 .panther-8 {
+  color: #bdbdbd;
+  font-size: 0.563rem;
+  font-weight: 500;
+}
+
+.panther-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  font-size: 0.875rem;
+  font-weight: 500;
+  opacity: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-height: 24px;
+}
+
+.panther-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -154,11 +195,11 @@ exports[`Generic Destination Card should match snapshot 1`] = `
   margin-top: 16px;
 }
 
-.panther-8>*:not(:last-child) {
+.panther-12>*:not(:last-child) {
   margin-right: 8px;
 }
 
-.panther-7 {
+.panther-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -194,13 +235,13 @@ exports[`Generic Destination Card should match snapshot 1`] = `
     id="main-header"
   />
   <section
-    class="panther-13"
+    class="panther-17"
   >
     <div
-      class="panther-12"
+      class="panther-16"
     >
       <div
-        class="panther-11"
+        class="panther-15"
       >
         <img
           alt="Logo"
@@ -210,10 +251,10 @@ exports[`Generic Destination Card should match snapshot 1`] = `
           width="20"
         />
         <div
-          class="panther-10"
+          class="panther-14"
         >
           <header
-            class="panther-6"
+            class="panther-7"
           >
             <h4
               class="panther-2"
@@ -225,21 +266,26 @@ exports[`Generic Destination Card should match snapshot 1`] = `
                 Accountability
               </a>
             </h4>
+            <span
+              class="panther-3"
+            >
+              2020-07-05 06:23 GMT
+            </span>
             <div
-              class="panther-5"
+              class="panther-6"
             >
               <button
                 aria-controls="menu--1"
                 aria-haspopup="true"
                 aria-label="Toggle Options"
                 aria-pressed="false"
-                class="panther-4"
+                class="panther-5"
                 data-reach-menu-button=""
                 id="menu-button--menu--1"
                 type="button"
               >
                 <svg
-                  class="panther-3"
+                  class="panther-4"
                   role="presentation"
                   viewBox="0 0 24 24"
                 >
@@ -251,15 +297,31 @@ exports[`Generic Destination Card should match snapshot 1`] = `
             </div>
           </header>
           <div
-            class="panther-9"
+            class="panther-13"
           >
-            A required children
+            <dl
+              class="panther-10"
+            >
+              <dt
+                aria-labelledby="alert-typespolicy-failures"
+                class="panther-8"
+              >
+                Alert Types
+              </dt>
+              <dd
+                aria-labelledby="alert-typespolicy-failures"
+                class="panther-9"
+              >
+                Policy Failures
+              </dd>
+            </dl>
+            A children
             <div
-              class="panther-8"
+              class="panther-12"
             >
               <div
                 aria-atomic="true"
-                class="panther-7"
+                class="panther-11"
                 role="status"
               >
                 CRITICAL


### PR DESCRIPTION
## Description

With the latest changes in the BE, we allow users to use specific destinations for sending alerts based on Alert Type (Rule Match, Rule Error, Policy Fail).

This PR reflects those changes needed from the FE side to allow users to choose if they want route alerts of a specific type to a destinations 

Closes #2385 
### Designs

Designs for Creating/Editing [here](https://app.abstract.com/projects/558a8de6-7134-4c8b-91c5-62074bb1279b/branches/0d293ff7-a6c6-4ddc-9dd0-442c63b91995/collections/4c465cf2-53df-4aab-830a-f57ad4e3a7f5)

Design for Cards [here](https://app.abstract.com/projects/558a8de6-7134-4c8b-91c5-62074bb1279b/branches/df9d59c8-eeb1-452d-a5f5-3712b64010be/commits/0c52e7c01e4403134ed1a4265348369827334643/files/29396687-8ca0-4c55-a4c7-2399489f10a9/layers/9DF07065-5715-406A-9D19-E731CD57539D?mode=design&sha=0c52e7c01e4403134ed1a4265348369827334643)

### Screencast

https://user-images.githubusercontent.com/14179917/105988963-1865db00-60a9-11eb-902d-26cf68805017.mov


### Checklist:

- [x] Make sure you give a high-level overview of the problem & the solution
- [x] Make sure the related issue is referenced
- [x] Make sure screenshots are added if the UI is changed in any way
- [x] Make sure all of the significant logic is covered by tests
- [x] Make sure your changes are accessible (addition of aria-attributes & correct HTML semantics)
- [x] Make sure you reference the related design document if it exists
- [x] Make sure telemetry is added (analytics & errors)
- [x] ~~Make sure the changes are responsive (appearing decently on devices)~~