### PR TITLE
Allow users to return event from alert_context

### DIFF
--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -490,7 +490,7 @@ class Rule:
     def _run_command(self, function: Callable, event: PantherEvent, expected_type: Any) -> Any:
         result = function(event)
         # Branch in case of list
-        if not isinstance(expected_type, list):
+        if expected_type is not list:
             if not isinstance(result, expected_type):
                 raise Exception(
                     'rule [{}] function [{}] returned [{}], expected [{}]'.format(
@@ -501,7 +501,7 @@ class Rule:
                     )
                 )
         else:
-            if not isinstance(expected_type, list) or not all([isinstance(x, (str, bool)) for x in result]):
+            if expected_type is not list or not all([isinstance(x, (str, bool)) for x in result]):
                 raise Exception(
                     'rule [{}] function [{}] returned [{}], expected a list'.format(self.rule_id, function.__name__,
                                                                                     type(result).__name__)

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -23,6 +23,7 @@ import traceback
 from dataclasses import dataclass
 from typing import Any, Optional, Callable, List
 
+from .immutable import ImmutableDict
 from .logging import get_logger
 from .util import id_to_path, import_file_as_module, store_modules
 from .enriched_event import PantherEvent
@@ -267,7 +268,7 @@ class Rule:
 
         try:
             command = getattr(self._module, 'alert_context')
-            alert_context = self._run_command(command, event, dict)
+            alert_context = self._run_command(command, event, (ImmutableDict, dict))
             serialized_alert_context = json.dumps(alert_context, default=PantherEvent.json_encoder)
         except Exception as err:  # pylint: disable=broad-except
             if use_default_on_exception:

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -302,7 +302,7 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
 
         expected_alert_context = json.dumps(event)
         expected_result = RuleResult(
-            matched=True, dedup_output='defaultDedupString:test_alert_context_immutable_event', alert_context=expected_alert_context
+            matched=True, dedup_output='defaultDedupString:test_alert_context_returns_full_event', alert_context=expected_alert_context
         )
         self.assertEqual(expected_result, rule.run(PantherEvent(event, None)))
 

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -255,7 +255,7 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         expected_alert_context = json.dumps(
             {
                 '_error':
-                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [dict]\')'
+                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [Mapping]\')'
             }
         )
         expected_result = RuleResult(

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -255,7 +255,7 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         expected_alert_context = json.dumps(
             {
                 '_error':
-                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [Mapping]\')'
+                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [Mapping]\')'  # pylint: disable=C0301
             }
         )
         expected_result = RuleResult(

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -294,6 +294,18 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(expected_result, rule.run(PantherEvent(event, None)))
 
+    def test_alert_context_returns_full_event(self) -> None:
+        alert_context_function = 'def alert_context(event):\n\treturn event'
+        rule_body = 'def rule(event):\n\treturn True\n{}'.format(alert_context_function)
+        rule = Rule({'id': 'test_alert_context_returns_full_event', 'body': rule_body, 'versionId': 'versionId'})
+        event = {'test': 'event'}
+
+        expected_alert_context = json.dumps(event)
+        expected_result = RuleResult(
+            matched=True, dedup_output='defaultDedupString:test_alert_context_immutable_event', alert_context=expected_alert_context
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent(event, None)))
+
     # Generated Fields Tests
     def test_rule_with_all_generated_fields(self) -> None:
         rule_body = 'def rule(event):\n\treturn True\n' \


### PR DESCRIPTION
## Background

Closes #2515

## Changes

- Allow users to return object from `alert_context` method

## Testing

- mage test:ci
- E2E after deploying to my account and defining a rule:
```
def rule(event): 
    return True

def alert_context(event): 
    return event
```
