### PR TITLE
[FE] Backport UI changes from Enterprise

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -373,13 +373,13 @@ input AddRuleInput {
   displayName: String
   enabled: Boolean!
   id: ID!
-  logTypes: [String]
+  logTypes: [String!]
   outputIds: [ID!]
   reference: String
   runbook: String
   severity: SeverityEnum!
-  tags: [String]
-  tests: [DetectionTestDefinitionInput] # Rule and Policy share the same tests structure
+  tags: [String!]
+  tests: [DetectionTestDefinitionInput!]
 }
 
 input UpdateRuleInput {
@@ -390,13 +390,13 @@ input UpdateRuleInput {
   displayName: String
   enabled: Boolean
   id: ID!
-  logTypes: [String]
+  logTypes: [String!]
   outputIds: [ID!]
   reference: String
   runbook: String
   severity: SeverityEnum
-  tags: [String]
-  tests: [DetectionTestDefinitionInput] # Rule and Policy share the same tests structure
+  tags: [String!]
+  tests: [DetectionTestDefinitionInput!]
 }
 
 input GetRuleInput {
@@ -414,24 +414,24 @@ type ListRulesResponse {
 }
 
 type Rule {
-  body: String
-  createdAt: AWSDateTime
+  body: String!
+  createdAt: AWSDateTime!
   createdBy: ID
   dedupPeriodMinutes: Int!
   threshold: Int!
   description: String
   displayName: String
-  enabled: Boolean
+  enabled: Boolean!
   id: String!
   lastModified: AWSDateTime
   lastModifiedBy: ID
-  logTypes: [String]
+  logTypes: [String!]
   outputIds: [ID!]!
   reference: String
   runbook: String
-  severity: SeverityEnum
-  tags: [String]
-  tests: [DetectionTestDefinition] # Policy and Rule have the same tests structure so we reuse the struct here
+  severity: SeverityEnum!
+  tags: [String!]!
+  tests: [DetectionTestDefinition!]!
   versionId: ID
 }
 
@@ -850,13 +850,13 @@ input PagerDutyConfigInput {
 type Policy {
   autoRemediationId: ID
   autoRemediationParameters: AWSJSON
-  body: String
+  body: String!
   complianceStatus: ComplianceStatusEnum
-  createdAt: AWSDateTime
+  createdAt: AWSDateTime!
   createdBy: ID
   description: String
   displayName: String
-  enabled: Boolean
+  enabled: Boolean!
   id: ID!
   lastModified: AWSDateTime
   lastModifiedBy: ID
@@ -864,10 +864,10 @@ type Policy {
   reference: String
   resourceTypes: [String]
   runbook: String
-  severity: SeverityEnum
-  suppressions: [String]
-  tags: [String]
-  tests: [DetectionTestDefinition]
+  severity: SeverityEnum!
+  suppressions: [String!]
+  tags: [String!]!
+  tests: [DetectionTestDefinition!]!
   versionId: ID
 }
 

--- a/internal/log_analysis/rules_engine/src/rule.py
+++ b/internal/log_analysis/rules_engine/src/rule.py
@@ -267,7 +267,7 @@ class Rule:
 
         try:
             command = getattr(self._module, 'alert_context')
-            alert_context = self._run_command(command, event, dict)
+            alert_context = self._run_command(command, event, Mapping)
             serialized_alert_context = json.dumps(alert_context, default=PantherEvent.json_encoder)
         except Exception as err:  # pylint: disable=broad-except
             if use_default_on_exception:

--- a/internal/log_analysis/rules_engine/tests/test_rule.py
+++ b/internal/log_analysis/rules_engine/tests/test_rule.py
@@ -255,7 +255,7 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         expected_alert_context = json.dumps(
             {
                 '_error':
-                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [dict]\')'
+                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [Mapping]\')'  # pylint: disable=C0301
             }
         )
         expected_result = RuleResult(
@@ -291,6 +291,18 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         expected_alert_context = json.dumps({'headers': event['headers'], 'get_params': event['query_string_args']})
         expected_result = RuleResult(
             matched=True, dedup_output='defaultDedupString:test_alert_context_immutable_event', alert_context=expected_alert_context
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent(event, None)))
+
+    def test_alert_context_returns_full_event(self) -> None:
+        alert_context_function = 'def alert_context(event):\n\treturn event'
+        rule_body = 'def rule(event):\n\treturn True\n{}'.format(alert_context_function)
+        rule = Rule({'id': 'test_alert_context_returns_full_event', 'body': rule_body, 'versionId': 'versionId'})
+        event = {'test': 'event'}
+
+        expected_alert_context = json.dumps(event)
+        expected_result = RuleResult(
+            matched=True, dedup_output='defaultDedupString:test_alert_context_returns_full_event', alert_context=expected_alert_context
         )
         self.assertEqual(expected_result, rule.run(PantherEvent(event, None)))
 

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -101,13 +101,13 @@ export type AddRuleInput = {
   displayName?: Maybe<Scalars['String']>;
   enabled: Scalars['Boolean'];
   id: Scalars['ID'];
-  logTypes?: Maybe<Array<Maybe<Scalars['String']>>>;
+  logTypes?: Maybe<Array<Scalars['String']>>;
   outputIds?: Maybe<Array<Scalars['ID']>>;
   reference?: Maybe<Scalars['String']>;
   runbook?: Maybe<Scalars['String']>;
   severity: SeverityEnum;
-  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
-  tests?: Maybe<Array<Maybe<DetectionTestDefinitionInput>>>;
+  tags?: Maybe<Array<Scalars['String']>>;
+  tests?: Maybe<Array<DetectionTestDefinitionInput>>;
 };
 
 export type AddS3LogIntegrationInput = {
@@ -1051,13 +1051,13 @@ export type Policy = {
   __typename?: 'Policy';
   autoRemediationId?: Maybe<Scalars['ID']>;
   autoRemediationParameters?: Maybe<Scalars['AWSJSON']>;
-  body?: Maybe<Scalars['String']>;
+  body: Scalars['String'];
   complianceStatus?: Maybe<ComplianceStatusEnum>;
-  createdAt?: Maybe<Scalars['AWSDateTime']>;
+  createdAt: Scalars['AWSDateTime'];
   createdBy?: Maybe<Scalars['ID']>;
   description?: Maybe<Scalars['String']>;
   displayName?: Maybe<Scalars['String']>;
-  enabled?: Maybe<Scalars['Boolean']>;
+  enabled: Scalars['Boolean'];
   id: Scalars['ID'];
   lastModified?: Maybe<Scalars['AWSDateTime']>;
   lastModifiedBy?: Maybe<Scalars['ID']>;
@@ -1065,10 +1065,10 @@ export type Policy = {
   reference?: Maybe<Scalars['String']>;
   resourceTypes?: Maybe<Array<Maybe<Scalars['String']>>>;
   runbook?: Maybe<Scalars['String']>;
-  severity?: Maybe<SeverityEnum>;
-  suppressions?: Maybe<Array<Maybe<Scalars['String']>>>;
-  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
-  tests?: Maybe<Array<Maybe<DetectionTestDefinition>>>;
+  severity: SeverityEnum;
+  suppressions?: Maybe<Array<Scalars['String']>>;
+  tags: Array<Scalars['String']>;
+  tests: Array<DetectionTestDefinition>;
   versionId?: Maybe<Scalars['ID']>;
 };
 
@@ -1241,24 +1241,24 @@ export type ResourceSummary = {
 
 export type Rule = {
   __typename?: 'Rule';
-  body?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['AWSDateTime']>;
+  body: Scalars['String'];
+  createdAt: Scalars['AWSDateTime'];
   createdBy?: Maybe<Scalars['ID']>;
   dedupPeriodMinutes: Scalars['Int'];
   threshold: Scalars['Int'];
   description?: Maybe<Scalars['String']>;
   displayName?: Maybe<Scalars['String']>;
-  enabled?: Maybe<Scalars['Boolean']>;
+  enabled: Scalars['Boolean'];
   id: Scalars['String'];
   lastModified?: Maybe<Scalars['AWSDateTime']>;
   lastModifiedBy?: Maybe<Scalars['ID']>;
-  logTypes?: Maybe<Array<Maybe<Scalars['String']>>>;
+  logTypes?: Maybe<Array<Scalars['String']>>;
   outputIds: Array<Scalars['ID']>;
   reference?: Maybe<Scalars['String']>;
   runbook?: Maybe<Scalars['String']>;
-  severity?: Maybe<SeverityEnum>;
-  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
-  tests?: Maybe<Array<Maybe<DetectionTestDefinition>>>;
+  severity: SeverityEnum;
+  tags: Array<Scalars['String']>;
+  tests: Array<DetectionTestDefinition>;
   versionId?: Maybe<Scalars['ID']>;
 };
 
@@ -1510,13 +1510,13 @@ export type UpdateRuleInput = {
   displayName?: Maybe<Scalars['String']>;
   enabled?: Maybe<Scalars['Boolean']>;
   id: Scalars['ID'];
-  logTypes?: Maybe<Array<Maybe<Scalars['String']>>>;
+  logTypes?: Maybe<Array<Scalars['String']>>;
   outputIds?: Maybe<Array<Scalars['ID']>>;
   reference?: Maybe<Scalars['String']>;
   runbook?: Maybe<Scalars['String']>;
   severity?: Maybe<SeverityEnum>;
-  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
-  tests?: Maybe<Array<Maybe<DetectionTestDefinitionInput>>>;
+  tags?: Maybe<Array<Scalars['String']>>;
+  tests?: Maybe<Array<DetectionTestDefinitionInput>>;
 };
 
 export type UpdateS3LogIntegrationInput = {
@@ -2902,17 +2902,17 @@ export type PolicyResolvers<
 > = {
   autoRemediationId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   autoRemediationParameters?: Resolver<Maybe<ResolversTypes['AWSJSON']>, ParentType, ContextType>;
-  body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  body?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   complianceStatus?: Resolver<
     Maybe<ResolversTypes['ComplianceStatusEnum']>,
     ParentType,
     ContextType
   >;
-  createdAt?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['AWSDateTime'], ParentType, ContextType>;
   createdBy?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  enabled?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  enabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   lastModified?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
   lastModifiedBy?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
@@ -2920,14 +2920,10 @@ export type PolicyResolvers<
   reference?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   resourceTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   runbook?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  severity?: Resolver<Maybe<ResolversTypes['SeverityEnum']>, ParentType, ContextType>;
-  suppressions?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
-  tags?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
-  tests?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['DetectionTestDefinition']>>>,
-    ParentType,
-    ContextType
-  >;
+  severity?: Resolver<ResolversTypes['SeverityEnum'], ParentType, ContextType>;
+  suppressions?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  tags?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  tests?: Resolver<Array<ResolversTypes['DetectionTestDefinition']>, ParentType, ContextType>;
   versionId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
@@ -3142,28 +3138,24 @@ export type RuleResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Rule'] = ResolversParentTypes['Rule']
 > = {
-  body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
+  body?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['AWSDateTime'], ParentType, ContextType>;
   createdBy?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   dedupPeriodMinutes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   threshold?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  enabled?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  enabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   lastModified?: Resolver<Maybe<ResolversTypes['AWSDateTime']>, ParentType, ContextType>;
   lastModifiedBy?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
-  logTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  logTypes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   outputIds?: Resolver<Array<ResolversTypes['ID']>, ParentType, ContextType>;
   reference?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   runbook?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  severity?: Resolver<Maybe<ResolversTypes['SeverityEnum']>, ParentType, ContextType>;
-  tags?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
-  tests?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['DetectionTestDefinition']>>>,
-    ParentType,
-    ContextType
-  >;
+  severity?: Resolver<ResolversTypes['SeverityEnum'], ParentType, ContextType>;
+  tags?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  tests?: Resolver<Array<ResolversTypes['DetectionTestDefinition']>, ParentType, ContextType>;
   versionId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };

--- a/web/src/components/cards/RuleCard/RuleCard.tsx
+++ b/web/src/components/cards/RuleCard/RuleCard.tsx
@@ -24,14 +24,15 @@ import SeverityBadge from 'Components/badges/SeverityBadge';
 import StatusBadge from 'Components/badges/StatusBadge';
 import BulletedValueList from 'Components/BulletedValueList';
 import urls from 'Source/urls';
-import { Rule, ComplianceStatusEnum } from 'Generated/schema';
+import { ComplianceStatusEnum } from 'Generated/schema';
+import { RuleSummary } from 'Source/graphql/fragments/RuleSummary.generated';
 import { formatDatetime } from 'Helpers/utils';
 import useDetectionDestinations from 'Hooks/useDetectionDestinations';
 import RelatedDestinations from 'Components/RelatedDestinations';
 import RuleCardOptions from './RuleCardOptions';
 
 interface RuleCardProps {
-  rule: Rule;
+  rule: RuleSummary;
 }
 
 const RuleCard: React.FC<RuleCardProps> = ({ rule }) => {

--- a/web/src/components/cards/RuleCard/RuleCardOptions/RuleCardOptions.tsx
+++ b/web/src/components/cards/RuleCard/RuleCardOptions/RuleCardOptions.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { Dropdown, DropdownButton, DropdownItem, DropdownLink, DropdownMenu } from 'pouncejs';
-import { Rule } from 'Generated/schema';
+import { RuleSummary } from 'Source/graphql/fragments/RuleSummary.generated';
 import urls from 'Source/urls';
 import useModal from 'Hooks/useModal';
 import { MODALS } from 'Components/utils/Modal';
@@ -26,7 +26,7 @@ import { Link as RRLink } from 'react-router-dom';
 import GenericItemCard from 'Components/GenericItemCard';
 
 interface RuleCardOptionsProps {
-  rule: Rule;
+  rule: RuleSummary;
 }
 
 const RuleCardOptions: React.FC<RuleCardOptionsProps> = ({ rule }) => {

--- a/web/src/components/forms/RuleForm/RuleFormCoreSection/RuleFormCoreSection.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormCoreSection/RuleFormCoreSection.tsx
@@ -71,7 +71,7 @@ const RuleFormCoreSection: React.FC = () => {
     outputIds: values.outputIds,
   });
 
-  const generateHelperText = React.useCallback(() => {
+  const generateDestinationHelperText = React.useCallback(() => {
     if (destinationsError) {
       return (
         <FormError id="outputIds-description" mt={2}>
@@ -103,7 +103,7 @@ const RuleFormCoreSection: React.FC = () => {
     );
   }, [destinationsError, destinationsLoading, availableOutputIds]);
 
-  const destinationHelperText = React.useMemo(() => generateHelperText(), [
+  const destinationHelperText = React.useMemo(() => generateDestinationHelperText(), [
     destinationsError,
     destinationsLoading,
     availableOutputIds,
@@ -143,7 +143,7 @@ const RuleFormCoreSection: React.FC = () => {
           label="Log Types"
           name="logTypes"
           items={data?.listAvailableLogTypes.logTypes ?? []}
-          placeholder="Where should the rule apply?"
+          placeholder="Which log types should this rule apply to?"
         />
       </Flex>
       <Flex as="section" direction="column" spacing={5}>

--- a/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
+++ b/web/src/components/modals/DeletePolicyModal/DeletePolicyModal.tsx
@@ -18,14 +18,15 @@
 
 import React from 'react';
 import { ModalProps, useSnackbar } from 'pouncejs';
-import { Policy } from 'Generated/schema';
+import { PolicySummary } from 'Source/graphql/fragments/PolicySummary.generated';
+import { PolicyDetails } from 'Source/graphql/fragments/PolicyDetails.generated';
 import useRouter from 'Hooks/useRouter';
 import urls from 'Source/urls';
 import { useDeletePolicy } from './graphql/deletePolicy.generated';
 import OptimisticConfirmModal from '../OptimisticConfirmModal';
 
 export interface DeletePolicyModalProps extends ModalProps {
-  policy: Policy;
+  policy: PolicySummary | PolicyDetails;
 }
 
 const DeletePolicyModal: React.FC<DeletePolicyModalProps> = ({ policy, ...rest }) => {

--- a/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
+++ b/web/src/components/modals/DeleteRuleModal/DeleteRuleModal.tsx
@@ -18,14 +18,15 @@
 
 import React from 'react';
 import { ModalProps, useSnackbar } from 'pouncejs';
-import { Rule } from 'Generated/schema';
+import { RuleSummary } from 'Source/graphql/fragments/RuleSummary.generated';
+import { RuleDetails } from 'Source/graphql/fragments/RuleDetails.generated';
 import useRouter from 'Hooks/useRouter';
 import urls from 'Source/urls';
 import { useDeleteRule } from './graphql/deleteRule.generated';
 import OptimisticConfirmModal from '../OptimisticConfirmModal';
 
 export interface DeleteRuleModalProps extends ModalProps {
-  rule: Rule;
+  rule: RuleSummary | RuleDetails;
 }
 
 const DeleteRuleModal: React.FC<DeleteRuleModalProps> = ({ rule, ...rest }) => {

--- a/web/src/graphql/fragments/PolicyDetails.generated.ts
+++ b/web/src/graphql/fragments/PolicyDetails.generated.ts
@@ -26,9 +26,7 @@ export type PolicyDetails = Pick<
   Types.Policy,
   'autoRemediationId' | 'autoRemediationParameters' | 'suppressions' | 'body'
 > & {
-  tests?: Types.Maybe<
-    Array<Types.Maybe<Pick<Types.DetectionTestDefinition, 'expectedResult' | 'name' | 'resource'>>>
-  >;
+  tests: Array<Pick<Types.DetectionTestDefinition, 'expectedResult' | 'name' | 'resource'>>;
 } & PolicySummary;
 
 export const PolicyDetails = gql`

--- a/web/src/graphql/fragments/RuleDetails.generated.ts
+++ b/web/src/graphql/fragments/RuleDetails.generated.ts
@@ -23,9 +23,7 @@ import { GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 
 export type RuleDetails = Pick<Types.Rule, 'body'> & {
-  tests?: Types.Maybe<
-    Array<Types.Maybe<Pick<Types.DetectionTestDefinition, 'expectedResult' | 'name' | 'resource'>>>
-  >;
+  tests: Array<Pick<Types.DetectionTestDefinition, 'expectedResult' | 'name' | 'resource'>>;
 } & RuleSummary;
 
 export const RuleDetails = gql`

--- a/web/src/hooks/useDetectionDestinations.tsx
+++ b/web/src/hooks/useDetectionDestinations.tsx
@@ -20,7 +20,7 @@ import { Destination, Policy, Rule } from 'Generated/schema';
 import { useListDestinations } from 'Source/graphql/queries';
 
 interface UseDetectionDestinationsProps {
-  detection: Rule | Policy;
+  detection: Pick<Rule | Policy, 'severity' | 'outputIds'>;
 }
 
 interface UseDetectionDestinationsResponse {

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
@@ -45,7 +45,7 @@ const AlertDetailsBanner: React.FC<AlertDetailsBannerProps> = ({ alert }) => {
           </Box>
         </Flex>
       </Flex>
-      <Flex as="dl" fontSize="small-medium" pt={5} spacing={8}>
+      <Flex as="dl" fontSize="small-medium" pt={5} spacing={8} wrap="wrap">
         <Flex>
           <Box color="navyblue-100" as="dt" pr={2}>
             Alert Type

--- a/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/__snapshots__/AlertDetailsBanner.test.tsx.snap
+++ b/web/src/pages/AlertDetails/PolicyAlertDetails/AlertDetailsBanner/__snapshots__/AlertDetailsBanner.test.tsx.snap
@@ -191,6 +191,10 @@ exports[`PolicyAlert - AlertDetailsBanner renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   font-size: 0.813rem;
   padding-top: 20px;
 }

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/AlertDetailsBanner.tsx
@@ -51,7 +51,7 @@ const AlertDetailsBanner: React.FC<AlertDetailsBannerProps> = ({ alert }) => {
           </Box>
         </Flex>
       </Flex>
-      <Flex as="dl" fontSize="small-medium" pt={5} spacing={8}>
+      <Flex as="dl" fontSize="small-medium" pt={5} spacing={8} wrap="wrap">
         <Flex>
           <Box color="navyblue-100" as="dt" pr={2}>
             Alert Type

--- a/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/__snapshots__/AlertDetailsBanner.test.tsx.snap
+++ b/web/src/pages/AlertDetails/RuleAlertDetails/AlertDetailsBanner/__snapshots__/AlertDetailsBanner.test.tsx.snap
@@ -191,6 +191,10 @@ exports[`RuleAlert - AlertDetailsBanner renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   font-size: 0.813rem;
   padding-top: 20px;
 }

--- a/web/src/pages/EditPolicy/graphql/updatePolicy.generated.ts
+++ b/web/src/pages/EditPolicy/graphql/updatePolicy.generated.ts
@@ -44,13 +44,7 @@ export type UpdatePolicy = {
     | 'severity'
     | 'suppressions'
     | 'tags'
-  > & {
-    tests?: Types.Maybe<
-      Array<
-        Types.Maybe<Pick<Types.DetectionTestDefinition, 'expectedResult' | 'name' | 'resource'>>
-      >
-    >;
-  };
+  > & { tests: Array<Pick<Types.DetectionTestDefinition, 'expectedResult' | 'name' | 'resource'>> };
 };
 
 export const UpdatePolicyDocument = gql`

--- a/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTableRowOptions/ListPoliciesTableRowOptions.tsx
+++ b/web/src/pages/ListPolicies/ListPoliciesTable/ListPoliciesTableRowOptions/ListPoliciesTableRowOptions.tsx
@@ -25,14 +25,14 @@ import {
   DropdownMenu,
   IconButton,
 } from 'pouncejs';
-import { Policy } from 'Generated/schema';
+import { PolicySummary } from 'Source/graphql/fragments/PolicySummary.generated';
 import urls from 'Source/urls';
 import useModal from 'Hooks/useModal';
 import { MODALS } from 'Components/utils/Modal';
 import { Link as RRLink } from 'react-router-dom';
 
 interface ListPoliciesTableRowOptionsProps {
-  policy: Policy;
+  policy: PolicySummary;
 }
 
 const ListPoliciesTableRowOptions: React.FC<ListPoliciesTableRowOptionsProps> = ({ policy }) => {

--- a/web/src/pages/PolicyDetails/PolicyDetailsBanner/PolicyDetailsBanner.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsBanner/PolicyDetailsBanner.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { Box, Button, Icon, Flex, Card, Heading, Badge, Tooltip } from 'pouncejs';
-import { Policy } from 'Generated/schema';
+import { PolicyDetails } from 'Source/graphql/fragments/PolicyDetails.generated';
 import urls from 'Source/urls';
 import JsonViewer from 'Components/JsonViewer';
 import Breadcrumbs from 'Components/Breadcrumbs';
@@ -32,7 +32,7 @@ import BulletedValue from 'Components/BulletedValue';
 import RelatedDestinations from 'Components/RelatedDestinations/RelatedDestinations';
 
 interface ResourceDetailsBannerProps {
-  policy?: Policy;
+  policy?: PolicyDetails;
 }
 
 const PolicyDetailsBanner: React.FC<ResourceDetailsBannerProps> = ({ policy }) => {
@@ -112,7 +112,15 @@ const PolicyDetailsBanner: React.FC<ResourceDetailsBannerProps> = ({ policy }) =
             )}
           </Flex>
         </Flex>
-        <Flex as="dl" fontSize="small-medium" pt={5} spacing={8}>
+        <Flex as="dl" fontSize="small-medium" pt={5} spacing={8} wrap="wrap">
+          <Flex>
+            <Box color="navyblue-100" as="dt" pr={2}>
+              Detection Type
+            </Box>
+            <Box as="dd" fontWeight="bold" color="indigo-300">
+              Policy
+            </Box>
+          </Flex>
           <Flex>
             <Box color="navyblue-100" as="dt" pr={2}>
               Policy ID

--- a/web/src/pages/PolicyDetails/PolicyDetailsInfo/PolicyDetailsInfo.tsx
+++ b/web/src/pages/PolicyDetails/PolicyDetailsInfo/PolicyDetailsInfo.tsx
@@ -21,11 +21,11 @@ import { Link as RRLink } from 'react-router-dom';
 import { Box, SimpleGrid, Text, Link, Flex, Card } from 'pouncejs';
 import { formatDatetime } from 'Helpers/utils';
 import Linkify from 'Components/Linkify';
-import { Policy } from 'Generated/schema';
+import { PolicyDetails } from 'Source/graphql/fragments/PolicyDetails.generated';
 import urls from 'Source/urls';
 
 interface ResourceDetailsInfoProps {
-  policy?: Policy;
+  policy?: PolicyDetails;
 }
 
 const PolicyDetailsInfo: React.FC<ResourceDetailsInfoProps> = ({ policy }) => {

--- a/web/src/pages/PolicyDetails/graphql/getPolicyDetails.generated.ts
+++ b/web/src/pages/PolicyDetails/graphql/getPolicyDetails.generated.ts
@@ -18,7 +18,7 @@
 
 import * as Types from '../../../../__generated__/schema';
 
-import { PolicySummary } from '../../../graphql/fragments/PolicySummary.generated';
+import { PolicyDetails } from '../../../graphql/fragments/PolicyDetails.generated';
 import { GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/client';
@@ -30,10 +30,7 @@ export type GetPolicyDetailsVariables = {
 };
 
 export type GetPolicyDetails = {
-  policy?: Types.Maybe<
-    Pick<Types.Policy, 'autoRemediationId' | 'autoRemediationParameters' | 'suppressions'> &
-      PolicySummary
-  >;
+  policy?: Types.Maybe<PolicyDetails>;
   resourcesForPolicy?: Types.Maybe<{
     totals?: Types.Maybe<{
       active?: Types.Maybe<Pick<Types.ComplianceStatusCounts, 'fail' | 'pass' | 'error'>>;
@@ -48,10 +45,7 @@ export const GetPolicyDetailsDocument = gql`
     $resourcesForPolicyInput: ResourcesForPolicyInput!
   ) {
     policy(input: $policyDetailsInput) {
-      ...PolicySummary
-      autoRemediationId
-      autoRemediationParameters
-      suppressions
+      ...PolicyDetails
     }
     resourcesForPolicy(input: $resourcesForPolicyInput) {
       totals {
@@ -68,7 +62,7 @@ export const GetPolicyDetailsDocument = gql`
       }
     }
   }
-  ${PolicySummary}
+  ${PolicyDetails}
 `;
 
 /**

--- a/web/src/pages/PolicyDetails/graphql/getPolicyDetails.graphql
+++ b/web/src/pages/PolicyDetails/graphql/getPolicyDetails.graphql
@@ -3,10 +3,7 @@ query GetPolicyDetails(
   $resourcesForPolicyInput: ResourcesForPolicyInput!
 ) {
   policy(input: $policyDetailsInput) {
-    ...PolicySummary
-    autoRemediationId
-    autoRemediationParameters
-    suppressions
+    ...PolicyDetails
   }
   resourcesForPolicy(input: $resourcesForPolicyInput) {
     totals {

--- a/web/src/pages/RuleDetails/RuleDetailsBanner/RuleDetailsBanner.tsx
+++ b/web/src/pages/RuleDetails/RuleDetailsBanner/RuleDetailsBanner.tsx
@@ -89,7 +89,15 @@ const RuleDetailsBanner: React.FC<ResourceDetailsInfoProps> = ({ rule }) => {
             </Box>
           </Flex>
         </Flex>
-        <Flex as="dl" fontSize="small-medium" pt={5} spacing={8}>
+        <Flex as="dl" fontSize="small-medium" pt={5} spacing={8} wrap="wrap">
+          <Flex>
+            <Box color="navyblue-100" as="dt" pr={2}>
+              Detection Type
+            </Box>
+            <Box as="dd" fontWeight="bold" color="cyan-400">
+              Rule
+            </Box>
+          </Flex>
           <Flex>
             <Box color="navyblue-100" as="dt" pr={2}>
               Rule ID


### PR DESCRIPTION
## Background

This PR backports minor but necessary changes from Scheduled Rules feature, back to the OSS

[Related Enterprise PR](https://github.com/panther-labs/panther-enterprise/pull/2043)

## Changes

- Update typings
- Mark GraphQL fields as required
- Add `flexWrap="wrap"` to propery losts
- Add `Detection Type` in detection banners

## Testing

`npm run test`
