### PR TITLE
Add DeleteDetections endpoint

### DIFF
--- a/api/lambda/analysis/models/api.go
+++ b/api/lambda/analysis/models/api.go
@@ -29,8 +29,9 @@ const (
 
 type LambdaInput struct {
 	// Shared
-	BulkUpload     *BulkUploadInput     `json:"bulkUpload,omitempty"`
-	ListDetections *ListDetectionsInput `json:"listDetections,omitempty"`
+	BulkUpload       *BulkUploadInput     `json:"bulkUpload,omitempty"`
+	ListDetections   *ListDetectionsInput `json:"listDetections,omitempty"`
+	DeleteDetections *DeletePoliciesInput `json:"deleteDetections,omitempty"`
 
 	// Globals
 	CreateGlobal  *CreateGlobalInput  `json:"createGlobal,omitempty"`

--- a/internal/core/analysis_api/handlers/delete.go
+++ b/internal/core/analysis_api/handlers/delete.go
@@ -55,15 +55,15 @@ func (API) DeleteRules(input *models.DeleteRulesInput) *events.APIGatewayProxyRe
 }
 
 func (API) DeleteDetections(input *models.DeletePoliciesInput) *events.APIGatewayProxyResponse {
-	if err := dynamoBatchDelete(input); err != nil {
-		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
-	}
-
 	if err := s3BatchDelete(input); err != nil {
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 
 	if err := complianceBatchDelete(input.Entries, []string{}); err != nil {
+		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
+	}
+
+	if err := dynamoBatchDelete(input); err != nil {
 		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 	}
 

--- a/internal/core/analysis_api/handlers/delete.go
+++ b/internal/core/analysis_api/handlers/delete.go
@@ -54,6 +54,22 @@ func (API) DeleteRules(input *models.DeleteRulesInput) *events.APIGatewayProxyRe
 	return &events.APIGatewayProxyResponse{StatusCode: http.StatusOK}
 }
 
+func (API) DeleteDetections(input *models.DeletePoliciesInput) *events.APIGatewayProxyResponse {
+	if err := dynamoBatchDelete(input); err != nil {
+		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
+	}
+
+	if err := s3BatchDelete(input); err != nil {
+		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
+	}
+
+	if err := complianceBatchDelete(input.Entries, []string{}); err != nil {
+		return &events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
+	}
+
+	return &events.APIGatewayProxyResponse{StatusCode: http.StatusOK}
+}
+
 func (api API) DeleteDataModels(input *models.DeleteDataModelsInput) *events.APIGatewayProxyResponse {
 	return api.DeleteRules(input)
 }


### PR DESCRIPTION
## Background

Add a DeleteDetections endpoint.

## Changes

- Add DeleteDetections

## Testing

- Manually tested in dev account. This deleted a rule and a policy:
```
{
  "DeleteDetections": {
    "entries": [
      {
        "id": "AWS.CloudTrail.RootFailedConsoleLogin"
      },
      {
        "id": "AWS.ACM.Certificate.Valid"
      }
    ]
  }
}
```
