### PR TITLE
Add GetObject to the health checks for an s3 source

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -304,6 +304,7 @@ type S3LogIntegrationHealth {
   processingRoleStatus: IntegrationItemHealthStatus!
   s3BucketStatus: IntegrationItemHealthStatus!
   kmsKeyStatus: IntegrationItemHealthStatus!
+  s3GetObjectStatus: IntegrationItemHealthStatus!
 }
 
 type SqsLogIntegrationHealth {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -304,7 +304,7 @@ type S3LogIntegrationHealth {
   processingRoleStatus: IntegrationItemHealthStatus!
   s3BucketStatus: IntegrationItemHealthStatus!
   kmsKeyStatus: IntegrationItemHealthStatus!
-  s3GetObjectStatus: IntegrationItemHealthStatus!
+  getObjectStatus: IntegrationItemHealthStatus # can be null for sources created in Panther<1.16
 }
 
 type SqsLogIntegrationHealth {

--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -18,7 +18,11 @@ package models
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import "time"
+import (
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+)
 
 // LambdaInput is the collection of all possible args to the Lambda function.
 type LambdaInput struct {
@@ -61,6 +65,17 @@ type CheckIntegrationInput struct {
 
 	// Checks for Sqs configuration
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
+
+	// PantherVersion is the version of Panther that the source was created with. Must follow semver format.
+	PantherVersionStr string `json:"pantherVersion"`
+}
+
+func (i *CheckIntegrationInput) PantherVersion() *semver.Version {
+	v, err := semver.NewVersion(i.PantherVersionStr)
+	if err != nil {
+		return &semver.Version{}
+	}
+	return v
 }
 
 //

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -86,6 +86,9 @@ type SourceIntegrationMetadata struct {
 	StackName string `json:"stackName,omitempty"`
 
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
+
+	// PantherVersion is the version of Panther that the source was created with.
+	PantherVersion string `json:"pantherVersion,omitempty"`
 }
 
 type ManagedS3Resources struct {
@@ -190,7 +193,8 @@ type SourceIntegrationHealth struct {
 	ProcessingRoleStatus SourceIntegrationItemStatus `json:"processingRoleStatus,omitempty"`
 	S3BucketStatus       SourceIntegrationItemStatus `json:"s3BucketStatus,omitempty"`
 	KMSKeyStatus         SourceIntegrationItemStatus `json:"kmsKeyStatus,omitempty"`
-	S3GetObject          SourceIntegrationItemStatus `json:"s3GetObjectStatus,omitempty"`
+	// GetObject check is not available to sources created in Panther<1.16
+	GetObjectStatus *SourceIntegrationItemStatus `json:"getObjectStatus,omitempty"`
 
 	// Checks for Sqs integrations
 	SqsStatus SourceIntegrationItemStatus `json:"sqsStatus"`

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -190,6 +190,7 @@ type SourceIntegrationHealth struct {
 	ProcessingRoleStatus SourceIntegrationItemStatus `json:"processingRoleStatus,omitempty"`
 	S3BucketStatus       SourceIntegrationItemStatus `json:"s3BucketStatus,omitempty"`
 	KMSKeyStatus         SourceIntegrationItemStatus `json:"kmsKeyStatus,omitempty"`
+	S3GetObject          SourceIntegrationItemStatus `json:"s3GetObjectStatus,omitempty"`
 
 	// Checks for Sqs integrations
 	SqsStatus SourceIntegrationItemStatus `json:"sqsStatus"`

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -605,8 +605,9 @@ Resources:
         $util.qr($input.put("awsAccountId", $ctx.source.awsAccountId))
         $util.qr($input.put("integrationLabel", $ctx.source.integrationLabel))
         $util.qr($input.put("s3Bucket", $ctx.source.s3Bucket))
-        $util.qr($input.put("s3Prefix", $ctx.source.s3Prefix))
+        $util.qr($input.put("s3PrefixLogTypes", $ctx.source.s3PrefixLogTypes))
         $util.qr($input.put("kmsKey", $ctx.source.kmsKey))
+        $util.qr($input.put("pantherVersion", $ctx.source.pantherVersion))
         {
           "version" : "2017-02-28",
           "operation": "Invoke",

--- a/deployments/auxiliary/cloudformation/panther-log-analysis-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-analysis-iam.yml
@@ -113,13 +113,9 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: s3:GetBucketLocation
-                Resource: !Sub
-                  - arn:${AWS::Partition}:s3:::${Bucket}
-                  # prettier-ignore
-                  - Bucket: !If [IsGenerated, !FindInMap [PantherParameters, S3Bucket, Value], !Ref S3Bucket]
-              - Effect: Allow
-                Action: s3:ListBucket
+                Action:
+                  - s3:GetBucketLocation
+                  - s3:ListBucket
                 Resource: !Sub
                   - arn:${AWS::Partition}:s3:::${Bucket}
                   # prettier-ignore

--- a/deployments/auxiliary/cloudformation/panther-log-analysis-iam.yml
+++ b/deployments/auxiliary/cloudformation/panther-log-analysis-iam.yml
@@ -117,11 +117,17 @@ Resources:
                 Resource: !Sub
                   - arn:${AWS::Partition}:s3:::${Bucket}
                   # prettier-ignore
-                  - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]
+                  - Bucket: !If [IsGenerated, !FindInMap [PantherParameters, S3Bucket, Value], !Ref S3Bucket]
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - arn:${AWS::Partition}:s3:::${Bucket}
+                  # prettier-ignore
+                  - Bucket: !If [IsGenerated, !FindInMap [PantherParameters, S3Bucket, Value], !Ref S3Bucket]
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub
-                  - 'arn:${AWS::Partition}:s3:::${Bucket}/*'
+                  - arn:${AWS::Partition}:s3:::${Bucket}/*
                   # prettier-ignore
                   - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]
               - !If
@@ -171,6 +177,6 @@ Resources:
           - Effect: Allow
             Action: [s3:GetBucketNotification, s3:PutBucketNotification]
             Resource: !Sub
-              - 'arn:aws:s3:::${Bucket}'
+              - 'arn:${AWS::Partition}:s3:::${Bucket}'
               # prettier-ignore
               - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/panther-labs/panther
 go 1.15
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/anyascii/go v0.1.7
 	github.com/aws-cloudformation/rain v1.1.1
 	github.com/aws/aws-lambda-go v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -19,12 +19,11 @@ package api
  */
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -33,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
@@ -92,59 +92,84 @@ func (api *API) checkAwsS3Integration(input *models.CheckIntegrationInput) *mode
 	var roleCreds *credentials.Credentials
 	logProcessingRole := generateLogProcessingRoleArn(input.AWSAccountID, input.IntegrationLabel)
 	roleCreds, out.ProcessingRoleStatus = api.getCredentialsWithStatus(logProcessingRole)
-	if out.ProcessingRoleStatus.Healthy {
-		bucketStatus, bucketRegion := api.checkBucket(roleCreds, input.S3Bucket)
-		out.S3BucketStatus = bucketStatus
-		out.KMSKeyStatus = api.checkKey(roleCreds, input.KmsKey)
-		s3Client := s3.New(api.AwsSession, &aws.Config{
-			Credentials: roleCreds,
-			Region:      bucketRegion,
-		})
-		out.S3GetObject = checkGetObject(s3Client, input.S3Bucket, input.AWSAccountID)
+
+	if !out.ProcessingRoleStatus.Healthy {
+		return out // can't run the next checks without a working IAM role
 	}
+
+	bucketStatus, bucketRegion := api.checkBucket(roleCreds, input.S3Bucket)
+	out.S3BucketStatus = bucketStatus
+	out.KMSKeyStatus = api.checkKey(roleCreds, input.KmsKey)
+
+	s3Client := s3.New(api.AwsSession, &aws.Config{
+		Credentials: roleCreds,
+		Region:      bucketRegion,
+	})
+	h, skipped := checkGetObject(s3Client, input)
+	if !skipped {
+		out.GetObjectStatus = &h
+	}
+
 	return out
 }
 
-func checkGetObject(s3Client s3iface.S3API, bucket, owner string) models.SourceIntegrationItemStatus {
-	// Check the error for a non-existent key. If the error is s3.ErrCodeNoSuchKey, we are good.
-	// The IAM role should have s3.ListBucket permissions, otherwise s3 will return AccessDenied even for
-	// missing keys.
-	_, err := s3Client.ListObjects(&s3.ListObjectsInput{
-		Bucket:              &bucket,
-		ExpectedBucketOwner: &owner,
-		MaxKeys:             aws.Int64(1),
-	})
-	if err != nil {
-		msg := "Error returned from s3.ListBucket request."
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AccessDenied" {
-			msg = "We couldn't perform the s3.GetObject check because the IAM role doesn't have the s3.ListBucket permission."
-		}
-		return models.SourceIntegrationItemStatus{
-			Healthy:      false,
-			Message:      msg,
-			ErrorMessage: err.Error(),
-		}
+// This function checks if the IAM identity of the s3Client has permissions to
+// read objects on the bucket.
+// For every s3 prefix in the input, it tries to read a random file on the bucket.
+// Even if the IAM role has permissions to read objects, the check may still fail due to a bucket policy or object ACL.
+// See https://github.com/panther-labs/panther/issues/2586 for details.
+func checkGetObject(s3Client s3iface.S3API, input *models.CheckIntegrationInput) (h models.SourceIntegrationItemStatus, skipped bool) {
+	// This check must only run for sources created in Panther >= 1.16, because it needs a new
+	// permission (s3.ListBucket) in the log processing role. The CFN stack of older sources doesn't have it.
+	minVersion := semver.MustParse("1.16.0-a") // 1.16.0-a < 1.16.0-dev (runs in dev env) < 1.16.0
+	if input.PantherVersion().LessThan(minVersion) {
+		return models.SourceIntegrationItemStatus{}, true
 	}
-	nonExistingKey := "panther-health-check"
-	_, err = s3Client.GetObject(&s3.GetObjectInput{
-		Bucket:              &bucket,
-		ExpectedBucketOwner: &owner,
-		Key:                 &nonExistingKey,
-	})
-	awsErr, ok := err.(awserr.Error)
-	if err == nil || (ok && awsErr.Code() == s3.ErrCodeNoSuchKey) {
-		return models.SourceIntegrationItemStatus{
-			Healthy: true,
-			Message: "We were able to use s3:GetObject on the specified S3 bucket.",
+
+	bucket, owner, s3Prefixes := input.S3Bucket, input.AWSAccountID, input.S3PrefixLogTypes.S3Prefixes()
+	prefixes := reduceNoPrefixStrings(s3Prefixes) // no need to check prefixes that overlap
+	for _, p := range prefixes {
+		err := checkGetObjectPrefix(s3Client, bucket, owner, p)
+		if err != nil {
+			return models.SourceIntegrationItemStatus{
+				Healthy:      false,
+				Message:      "Failed to read S3 object",
+				ErrorMessage: err.Error(),
+			}, false
 		}
 	}
 
-	// Something is wrong with bucket permissions.
 	return models.SourceIntegrationItemStatus{
-		Healthy:      false,
-		Message:      "Unexpected error returned from s3.GetObject",
-		ErrorMessage: err.Error(),
+		Healthy: true,
+		Message: "We were able to read an object on the specified S3 bucket.",
+	}, false
+}
+
+func checkGetObjectPrefix(s3Client s3iface.S3API, bucket, owner, prefix string) error {
+	listOutput, err := s3Client.ListObjects(&s3.ListObjectsInput{
+		Bucket:              &bucket,
+		ExpectedBucketOwner: &owner,
+		Prefix:              &prefix,
+		MaxKeys:             aws.Int64(1),
+	})
+	if err != nil {
+		return errors.Wrap(err, "s3.ListObjects request failed")
 	}
+
+	if len(listOutput.Contents) == 0 {
+		return nil
+	}
+
+	s3Obj := listOutput.Contents[0]
+	_, err = s3Client.HeadObject(&s3.HeadObjectInput{
+		Bucket:              &bucket,
+		ExpectedBucketOwner: &owner,
+		Key:                 s3Obj.Key,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "s3.HeadObject request failed for %s", *s3Obj.Key)
+	}
+	return nil
 }
 
 func (api *API) checkKey(roleCredentials *credentials.Credentials, key string) models.SourceIntegrationItemStatus {
@@ -278,8 +303,8 @@ func (api *API) evaluateIntegration(integration *models.CheckIntegrationInput) (
 			return status.KMSKeyStatus.Message, false, nil
 		}
 
-		if !status.S3GetObject.Healthy {
-			return status.S3GetObject.Message, false, nil
+		if !status.GetObjectStatus.Healthy {
+			return status.GetObjectStatus.Message, false, nil
 		}
 
 		return "", true, nil

--- a/internal/core/source_api/api/check_integration_test.go
+++ b/internal/core/source_api/api/check_integration_test.go
@@ -1,0 +1,81 @@
+package api
+
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/pkg/testutils"
+)
+
+type mockAWSError string
+
+func (e mockAWSError) Error() string   { return string(e) }
+func (e mockAWSError) Code() string    { return string(e) }
+func (e mockAWSError) Message() string { panic("implement me") }
+func (e mockAWSError) OrigErr() error  { panic("implement me") }
+
+var _ awserr.Error = (*mockAWSError)(nil)
+
+func Test_CheckGetObject(t *testing.T) {
+	input := &s3.GetObjectInput{
+		Bucket:              aws.String("bucket-name"),
+		ExpectedBucketOwner: aws.String("bucket-owner"),
+		Key:                 aws.String("panther-health-check"),
+	}
+
+	t.Run("healthy", func(t *testing.T) {
+		s3Client := &testutils.S3Mock{}
+		s3Client.On("GetObject", input).Return(&s3.GetObjectOutput{}, nil)
+
+		health := checkGetObject(s3Client, "bucket-name", "bucket-owner")
+
+		require.True(t, health.Healthy)
+	})
+	t.Run(s3.ErrCodeNoSuchKey, func(t *testing.T) {
+		s3Client := &testutils.S3Mock{}
+		s3Client.On("GetObject", input).
+			Return(&s3.GetObjectOutput{}, mockAWSError(s3.ErrCodeNoSuchKey))
+
+		health := checkGetObject(s3Client, "bucket-name", "bucket-owner")
+
+		require.True(t, health.Healthy)
+	})
+	t.Run("AccessDenied", func(t *testing.T) {
+		mockErr := mockAWSError("AccessDenied")
+		s3Client := &testutils.S3Mock{}
+		s3Client.On("GetObject", input).
+			Return(&s3.GetObjectOutput{}, &mockErr)
+
+		health := checkGetObject(s3Client, "bucket-name", "bucket-owner")
+
+		expected := models.SourceIntegrationItemStatus{
+			Healthy:      false,
+			Message:      "Unexpected error returned from s3.GetObject",
+			ErrorMessage: mockErr.Error(),
+		}
+		require.Equal(t, expected, health)
+	})
+}

--- a/internal/core/source_api/api/managed_bucket_notifications.go
+++ b/internal/core/source_api/api/managed_bucket_notifications.go
@@ -97,25 +97,6 @@ func ManageBucketNotifications(
 	return nil
 }
 
-// reduceNoPrefixStrings reduces a list of strings to a list where no string is a prefix of another.
-// e.g [pref, prefi, prefix, abc] -> [pref, abc]
-func reduceNoPrefixStrings(strs []string) (reduced []string) {
-	uniques := make(map[string]struct{})
-	for i := 0; i < len(strs); i++ {
-		smallestPrefix := strs[i]
-		for j := 0; j < len(strs); j++ {
-			if strings.HasPrefix(smallestPrefix, strs[j]) {
-				smallestPrefix = strs[j]
-			}
-		}
-		uniques[smallestPrefix] = struct{}{}
-	}
-	for k := range uniques {
-		reduced = append(reduced, k)
-	}
-	return
-}
-
 func createSNSResources(
 	pantherSess,
 	stsSess *session.Session,

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -283,6 +283,7 @@ func (api *API) generateNewIntegration(input *models.PutIntegrationInput) *model
 		IntegrationID:    uuid.New().String(),
 		IntegrationLabel: input.IntegrationLabel,
 		IntegrationType:  input.IntegrationType,
+		PantherVersion:   api.Config.Version,
 	}
 
 	switch input.IntegrationType {

--- a/internal/core/source_api/api/testdata/panther-log-analysis-iam-updated.yml
+++ b/internal/core/source_api/api/testdata/panther-log-analysis-iam-updated.yml
@@ -115,7 +115,13 @@ Resources:
               - Effect: Allow
                 Action: s3:GetBucketLocation
                 Resource: !Sub
-                  - arn:${AWS::Partition}:s3:::${Bucket}
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
+                  # prettier-ignore
+                  - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
                   # prettier-ignore
                   - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]
               - Effect: Allow

--- a/internal/core/source_api/api/testdata/panther-log-analysis-iam-updated.yml
+++ b/internal/core/source_api/api/testdata/panther-log-analysis-iam-updated.yml
@@ -113,13 +113,9 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: s3:GetBucketLocation
-                Resource: !Sub
-                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
-                  # prettier-ignore
-                  - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]
-              - Effect: Allow
-                Action: s3:ListBucket
+                Action:
+                  - s3:GetBucketLocation
+                  - s3:ListBucket
                 Resource: !Sub
                   - 'arn:${AWS::Partition}:s3:::${Bucket}'
                   # prettier-ignore
@@ -177,6 +173,6 @@ Resources:
           - Effect: Allow
             Action: [s3:GetBucketNotification, s3:PutBucketNotification]
             Resource: !Sub
-              - 'arn:aws:s3:::${Bucket}'
+              - 'arn:${AWS::Partition}:s3:::${Bucket}'
               # prettier-ignore
               - Bucket: !If [ IsGenerated, !FindInMap [ PantherParameters, S3Bucket, Value ], !Ref S3Bucket ]

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -19,6 +19,8 @@ package api
  */
 
 import (
+	"strings"
+
 	"github.com/panther-labs/panther/api/lambda/source/models"
 	"github.com/panther-labs/panther/internal/core/source_api/ddb"
 )
@@ -31,6 +33,7 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		IntegrationID:    input.IntegrationID,
 		IntegrationLabel: input.IntegrationLabel,
 		IntegrationType:  input.IntegrationType,
+		PantherVersion:   input.PantherVersion,
 	}
 	item.LastEventReceived = input.LastEventReceived
 
@@ -83,6 +86,7 @@ func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 	integration.CreatedAtTime = item.CreatedAtTime
 	integration.CreatedBy = item.CreatedBy
 	integration.LastEventReceived = item.LastEventReceived
+	integration.PantherVersion = item.PantherVersion
 	switch item.IntegrationType {
 	case models.IntegrationTypeAWS3:
 		integration.AWSAccountID = item.AWSAccountID
@@ -126,4 +130,23 @@ func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 		}
 	}
 	return integration
+}
+
+// reduceNoPrefixStrings reduces a list of strings to a list where no string is a prefix of another.
+// e.g [pref, prefi, prefix, abc] -> [pref, abc]
+func reduceNoPrefixStrings(strs []string) (reduced []string) {
+	uniques := make(map[string]struct{})
+	for i := 0; i < len(strs); i++ {
+		smallestPrefix := strs[i]
+		for j := 0; j < len(strs); j++ {
+			if strings.HasPrefix(smallestPrefix, strs[j]) {
+				smallestPrefix = strs[j]
+			}
+		}
+		uniques[smallestPrefix] = struct{}{}
+	}
+	for k := range uniques {
+		reduced = append(reduced, k)
+	}
+	return
 }

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -54,14 +54,17 @@ type Integration struct {
 	// Deprecated. Use S3PrefixLogTypes. Kept for backwards compatibility. Don't use omitempty to overwrite to empty during writes.
 	S3Prefix string `json:"s3Prefix"`
 	// Deprecated. Use S3PrefixLogTypes. Kept for backwards compatibility.Don't use omitempty to overwrite to empty during writes.
-	LogTypes          []string `json:"logTypes" dynamodbav:",stringset"`
-	KmsKey            string   `json:"kmsKey,omitempty"`
-	StackName         string   `json:"stackName,omitempty"`
-	LogProcessingRole string   `json:"logProcessingRole,omitempty"`
-
-	SqsConfig                  *SqsConfig                `json:"sqsConfig,omitempty"`
+	LogTypes                   []string                  `json:"logTypes" dynamodbav:",stringset"`
+	KmsKey                     string                    `json:"kmsKey,omitempty"`
+	StackName                  string                    `json:"stackName,omitempty"`
+	LogProcessingRole          string                    `json:"logProcessingRole,omitempty"`
 	ManagedBucketNotifications bool                      `json:"managedBucketNotifications,omitempty"`
 	ManagedS3Resources         models.ManagedS3Resources `json:"managedS3Resources,omitempty"`
+
+	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
+
+	// The Panther version in which this source was created.
+	PantherVersion string `json:"pantherVersion,omitempty"`
 }
 
 type IntegrationStatus struct {

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -81,6 +81,16 @@ func (m *S3Mock) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput,
 	return args.Get(0).(*s3.GetObjectOutput), args.Error(1)
 }
 
+func (m *S3Mock) HeadObject(i *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	args := m.Called(i)
+	return args.Get(0).(*s3.HeadObjectOutput), args.Error(1)
+}
+
+func (m *S3Mock) GetBucketLocation(input *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*s3.GetBucketLocationOutput), args.Error(1)
+}
+
 func (m *S3Mock) GetBucketLocationWithContext(
 	ctx aws.Context,
 	input *s3.GetBucketLocationInput,
@@ -90,7 +100,7 @@ func (m *S3Mock) GetBucketLocationWithContext(
 	return args.Get(0).(*s3.GetBucketLocationOutput), args.Error(1)
 }
 
-func (m *S3Mock) ListObjects(i *s3.ListObjectsInput) (*s3.ListObjectsOutput, error){
+func (m *S3Mock) ListObjects(i *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
 	args := m.Called(i)
 	return args.Get(0).(*s3.ListObjectsOutput), args.Error(1)
 }

--- a/pkg/testutils/awsmocks.go
+++ b/pkg/testutils/awsmocks.go
@@ -90,6 +90,11 @@ func (m *S3Mock) GetBucketLocationWithContext(
 	return args.Get(0).(*s3.GetBucketLocationOutput), args.Error(1)
 }
 
+func (m *S3Mock) ListObjects(i *s3.ListObjectsInput) (*s3.ListObjectsOutput, error){
+	args := m.Called(i)
+	return args.Get(0).(*s3.ListObjectsOutput), args.Error(1)
+}
+
 func (m *S3Mock) ListObjectsV2Pages(input *s3.ListObjectsV2Input, f func(page *s3.ListObjectsV2Output, morePages bool) bool) error {
 	args := m.Called(input, f)
 	f(args.Get(0).(*s3.ListObjectsV2Output), false)

--- a/tools/mage/util/version.go
+++ b/tools/mage/util/version.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/magefile/mage/sh"
 )
 
 var (
-	semver    string
+	version   string
 	commitSha string
 )
 
@@ -34,10 +35,11 @@ var (
 func Semver() string {
 	// We use this rather than the git release tag because the VERSION file is tied to the commit,
 	// whereas tags can be changed at any time (and don't always exist in every branch).
-	if semver == "" {
-		semver = strings.TrimSpace(string(MustReadFile("VERSION")))
+	if version == "" {
+		s := strings.TrimSpace(string(MustReadFile("VERSION")))
+		version = semver.MustParse(s).String() // make sure it is a valid semver cause it is used throughout Panther
 	}
-	return semver
+	return version
 }
 
 // Returns short commit string. For example, "64391f1e"

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -1371,7 +1371,7 @@ export type S3LogIntegrationHealth = {
   processingRoleStatus: IntegrationItemHealthStatus;
   s3BucketStatus: IntegrationItemHealthStatus;
   kmsKeyStatus: IntegrationItemHealthStatus;
-  s3GetObjectStatus: IntegrationItemHealthStatus;
+  getObjectStatus?: Maybe<IntegrationItemHealthStatus>;
 };
 
 export type S3PrefixLogTypes = {
@@ -3389,8 +3389,8 @@ export type S3LogIntegrationHealthResolvers<
   >;
   s3BucketStatus?: Resolver<ResolversTypes['IntegrationItemHealthStatus'], ParentType, ContextType>;
   kmsKeyStatus?: Resolver<ResolversTypes['IntegrationItemHealthStatus'], ParentType, ContextType>;
-  s3GetObjectStatus?: Resolver<
-    ResolversTypes['IntegrationItemHealthStatus'],
+  getObjectStatus?: Resolver<
+    Maybe<ResolversTypes['IntegrationItemHealthStatus']>,
     ParentType,
     ContextType
   >;

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -1371,6 +1371,7 @@ export type S3LogIntegrationHealth = {
   processingRoleStatus: IntegrationItemHealthStatus;
   s3BucketStatus: IntegrationItemHealthStatus;
   kmsKeyStatus: IntegrationItemHealthStatus;
+  s3GetObjectStatus: IntegrationItemHealthStatus;
 };
 
 export type S3PrefixLogTypes = {
@@ -3388,6 +3389,11 @@ export type S3LogIntegrationHealthResolvers<
   >;
   s3BucketStatus?: Resolver<ResolversTypes['IntegrationItemHealthStatus'], ParentType, ContextType>;
   kmsKeyStatus?: Resolver<ResolversTypes['IntegrationItemHealthStatus'], ParentType, ContextType>;
+  s3GetObjectStatus?: Resolver<
+    ResolversTypes['IntegrationItemHealthStatus'],
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -1580,6 +1580,10 @@ export const buildS3LogIntegrationHealth = (
       's3BucketStatus' in overrides ? overrides.s3BucketStatus : buildIntegrationItemHealthStatus(),
     kmsKeyStatus:
       'kmsKeyStatus' in overrides ? overrides.kmsKeyStatus : buildIntegrationItemHealthStatus(),
+    s3GetObjectStatus:
+      's3GetObjectStatus' in overrides
+        ? overrides.s3GetObjectStatus
+        : buildIntegrationItemHealthStatus(),
   };
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -1580,9 +1580,9 @@ export const buildS3LogIntegrationHealth = (
       's3BucketStatus' in overrides ? overrides.s3BucketStatus : buildIntegrationItemHealthStatus(),
     kmsKeyStatus:
       'kmsKeyStatus' in overrides ? overrides.kmsKeyStatus : buildIntegrationItemHealthStatus(),
-    s3GetObjectStatus:
-      's3GetObjectStatus' in overrides
-        ? overrides.s3GetObjectStatus
+    getObjectStatus:
+      'getObjectStatus' in overrides
+        ? overrides.getObjectStatus
         : buildIntegrationItemHealthStatus(),
   };
 };

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -42,6 +42,7 @@ export type S3LogIntegrationDetails = Pick<
     processingRoleStatus: IntegrationItemHealthDetails;
     s3BucketStatus: IntegrationItemHealthDetails;
     kmsKeyStatus: IntegrationItemHealthDetails;
+    s3GetObjectStatus: IntegrationItemHealthDetails;
   };
 };
 
@@ -71,6 +72,9 @@ export const S3LogIntegrationDetails = gql`
         ...IntegrationItemHealthDetails
       }
       kmsKeyStatus {
+        ...IntegrationItemHealthDetails
+      }
+      s3GetObjectStatus {
         ...IntegrationItemHealthDetails
       }
     }

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -42,7 +42,7 @@ export type S3LogIntegrationDetails = Pick<
     processingRoleStatus: IntegrationItemHealthDetails;
     s3BucketStatus: IntegrationItemHealthDetails;
     kmsKeyStatus: IntegrationItemHealthDetails;
-    s3GetObjectStatus: IntegrationItemHealthDetails;
+    getObjectStatus?: Types.Maybe<IntegrationItemHealthDetails>;
   };
 };
 
@@ -74,7 +74,7 @@ export const S3LogIntegrationDetails = gql`
       kmsKeyStatus {
         ...IntegrationItemHealthDetails
       }
-      s3GetObjectStatus {
+      getObjectStatus {
         ...IntegrationItemHealthDetails
       }
     }

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
@@ -25,5 +25,8 @@ fragment S3LogIntegrationDetails on S3LogIntegration {
     kmsKeyStatus {
       ...IntegrationItemHealthDetails
     }
+    s3GetObjectStatus {
+      ...IntegrationItemHealthDetails
+    }
   }
 }

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
@@ -25,7 +25,7 @@ fragment S3LogIntegrationDetails on S3LogIntegration {
     kmsKeyStatus {
       ...IntegrationItemHealthDetails
     }
-    s3GetObjectStatus {
+    getObjectStatus {
       ...IntegrationItemHealthDetails
     }
   }

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
@@ -57,6 +57,7 @@ const LogSourceCard: React.FC<LogSourceCardProps> = ({ source, children, logo })
           sourceHealth.processingRoleStatus,
           sourceHealth.s3BucketStatus,
           sourceHealth.kmsKeyStatus,
+          sourceHealth.s3GetObjectStatus,
         ];
       default:
         throw new Error(`Unknown source health item`);

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
@@ -52,13 +52,17 @@ const LogSourceCard: React.FC<LogSourceCardProps> = ({ source, children, logo })
     switch (sourceHealth.__typename) {
       case 'SqsLogIntegrationHealth':
         return [sourceHealth.sqsStatus];
-      case 'S3LogIntegrationHealth':
-        return [
+      case 'S3LogIntegrationHealth': {
+        const checks = [
           sourceHealth.processingRoleStatus,
           sourceHealth.s3BucketStatus,
           sourceHealth.kmsKeyStatus,
-          sourceHealth.s3GetObjectStatus,
         ];
+        if (sourceHealth.getObjectStatus) {
+          checks.push(sourceHealth.getObjectStatus);
+        }
+        return checks;
+      }
       default:
         throw new Error(`Unknown source health item`);
     }


### PR DESCRIPTION
## Background

This check was missing and is required. Even if the other checks (AssumeRole, GetBucketLocation, DescribeKmsKey) pass, `GetObject` could still fail if the permissions are not correctly set up.

## Changes

- Add a check for `s3.GetObject`

## Testing
- unit
- manual e2e with cross-account s3 source

Closes #2586