### PR TITLE
Reduce deleted resource TTL

### DIFF
--- a/internal/compliance/resources_api/handlers/delete_resources.go
+++ b/internal/compliance/resources_api/handlers/delete_resources.go
@@ -30,8 +30,8 @@ import (
 	"github.com/panther-labs/panther/api/lambda/resources/models"
 )
 
-// Deleted resources are retained for 30 days in the database
-const deleteWindowSecs = 30 * 24 * 60 * 60
+// Deleted resources are retained for 2 days in the database
+const deleteWindowSecs = 2 * 24 * 60 * 60
 
 // DeleteResources marks one or more resources as deleted.
 func (API) DeleteResources(input *models.DeleteResourcesInput) *events.APIGatewayProxyResponse {


### PR DESCRIPTION
## Background

Now that resource snapshots are persisted to the data lake, maintaining a deleted resource snapshot in dynamo has significantly less value but still incurs a large cost in high churn environments.

## Changes

- Reduce TTL on deleted resources from 30 days to 2 days

## Testing

- None YOLO
