### PR TITLE
[FE][BUGFIX] Remove stale appsync resolvers

### DIFF
--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -870,23 +870,6 @@ Resources:
         }
       ResponseMappingTemplate: !FindInMap [ResponseTemplates, Lambda, VTL]
 
-  ListPoliciesResolver:
-    Type: AWS::AppSync::Resolver
-    Properties:
-      ApiId: !Ref ApiId
-      TypeName: Query
-      FieldName: policies
-      DataSourceName: !GetAtt AnalysisAPILambdaDataSource.Name
-      RequestMappingTemplate: |
-        {
-          "version" : "2017-02-28",
-          "operation": "Invoke",
-          "payload": $util.toJson({
-            "listPolicies": $util.defaultIfNull($ctx.args.input, {})
-          })
-        }
-      ResponseMappingTemplate: !FindInMap [ResponseTemplates, LambdaStatusCode, VTL]
-
   GetPolicyResolver:
     Type: AWS::AppSync::Resolver
     Properties:
@@ -1189,23 +1172,6 @@ Resources:
               "paging": $result.paging
           })
         #end
-
-  ListRulesResolver:
-    Type: AWS::AppSync::Resolver
-    Properties:
-      ApiId: !Ref ApiId
-      TypeName: Query
-      FieldName: rules
-      DataSourceName: !GetAtt AnalysisAPILambdaDataSource.Name
-      RequestMappingTemplate: |
-        {
-          "version" : "2017-02-28",
-          "operation": "Invoke",
-          "payload": $util.toJson({
-            "listRules": $util.defaultIfNull($ctx.args.input, {})
-          })
-        }
-      ResponseMappingTemplate: !FindInMap [ResponseTemplates, LambdaStatusCode, VTL]
 
   GetRuleResolver:
     Type: AWS::AppSync::Resolver


### PR DESCRIPTION
## Background

When merging policies & rules page together, we removed the `listRules` and `listPolicies` GraphQL queries from the schema, since they were not longer needed. 

Unfortunately, we forgot to remove their related resolvers, causing AppSync to crash. This PR fixes just that.

## Changes

- Remove stale appsync resolveers

## Testing

- App can be deployed

## Notes

This wasn't caught since the GraphQL queries were removed during PR feedback in which case, I personally forgot to re-deploy (since I didn't expect any errors).  What went wrong was optimistically assuming that there would be no side-effects. Guess that's not gonna happen again!
