### PR TITLE
bugfix: check for lb type

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
@@ -61,6 +61,37 @@ var (
 			},
 		},
 	}
+	ExampleDescribeNetworkLoadBalancersOutput = &elbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []*elbv2.LoadBalancer{
+			{
+				LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-west-2:111111111111:loadbalancer/app/panther-test/aaaaaaaaaaaaa"),
+				DNSName:               aws.String("internal-panther-test-123456789.us-west-2.elb.amazonaws.com"),
+				CanonicalHostedZoneId: aws.String("AAAAA123"),
+				CreatedTime:           &ExampleTime,
+				LoadBalancerName:      aws.String("panther-test"),
+				Scheme:                aws.String("internal"),
+				VpcId:                 aws.String("vpc-aaaa66666"),
+				State: &elbv2.LoadBalancerState{
+					Code: aws.String("active"),
+				},
+				Type: aws.String("network"),
+				AvailabilityZones: []*elbv2.AvailabilityZone{
+					{
+						ZoneName: aws.String("us-west-2c"),
+						SubnetId: aws.String("subnet-1234eee"),
+					},
+					{
+						ZoneName: aws.String("us-west-2d"),
+						SubnetId: aws.String("subnet-1234fff"),
+					},
+				},
+				SecurityGroups: []*string{
+					aws.String("sg-1234asdf"),
+				},
+				IpAddressType: aws.String("ipv4"),
+			},
+		},
+	}
 	ExampleDescribeLoadBalancersOutputContinue = &elbv2.DescribeLoadBalancersOutput{
 		LoadBalancers: []*elbv2.LoadBalancer{
 			ExampleDescribeLoadBalancersOutput.LoadBalancers[0],

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
@@ -59,9 +59,13 @@ var (
 				},
 				IpAddressType: aws.String("ipv4"),
 			},
+		},
+	}
+	ExampleDescribeNetworkLoadBalancersOutput = &elbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []*elbv2.LoadBalancer{
 			{
-				LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-west-2:111111111111:loadbalancer/app/panther-test/bbbbbbbbbbbb"),
-				DNSName:               aws.String("internal-panther-test-9876543210.us-west-2.elb.amazonaws.com"),
+				LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-west-2:222222222222:loadbalancer/app/panther-test/bbbbbbbbbbbb"),
+				DNSName:               aws.String("internal-panther-test-987654321.us-west-2.elb.amazonaws.com"),
 				CanonicalHostedZoneId: aws.String("BBBB123"),
 				CreatedTime:           &ExampleTime,
 				LoadBalancerName:      aws.String("panther-test"),
@@ -74,11 +78,11 @@ var (
 				AvailabilityZones: []*elbv2.AvailabilityZone{
 					{
 						ZoneName: aws.String("us-west-2c"),
-						SubnetId: aws.String("subnet-1234ddd"),
+						SubnetId: aws.String("subnet-1234eee"),
 					},
 					{
 						ZoneName: aws.String("us-west-2d"),
-						SubnetId: aws.String("subnet-1234ggg"),
+						SubnetId: aws.String("subnet-1234fff"),
 					},
 				},
 				SecurityGroups: []*string{

--- a/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/awstest/elbv2.go
@@ -59,18 +59,14 @@ var (
 				},
 				IpAddressType: aws.String("ipv4"),
 			},
-		},
-	}
-	ExampleDescribeNetworkLoadBalancersOutput = &elbv2.DescribeLoadBalancersOutput{
-		LoadBalancers: []*elbv2.LoadBalancer{
 			{
-				LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-west-2:111111111111:loadbalancer/app/panther-test/aaaaaaaaaaaaa"),
-				DNSName:               aws.String("internal-panther-test-123456789.us-west-2.elb.amazonaws.com"),
-				CanonicalHostedZoneId: aws.String("AAAAA123"),
+				LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-west-2:111111111111:loadbalancer/app/panther-test/bbbbbbbbbbbb"),
+				DNSName:               aws.String("internal-panther-test-9876543210.us-west-2.elb.amazonaws.com"),
+				CanonicalHostedZoneId: aws.String("BBBB123"),
 				CreatedTime:           &ExampleTime,
 				LoadBalancerName:      aws.String("panther-test"),
 				Scheme:                aws.String("internal"),
-				VpcId:                 aws.String("vpc-aaaa66666"),
+				VpcId:                 aws.String("vpc-bbbb66666"),
 				State: &elbv2.LoadBalancerState{
 					Code: aws.String("active"),
 				},
@@ -78,11 +74,11 @@ var (
 				AvailabilityZones: []*elbv2.AvailabilityZone{
 					{
 						ZoneName: aws.String("us-west-2c"),
-						SubnetId: aws.String("subnet-1234eee"),
+						SubnetId: aws.String("subnet-1234ddd"),
 					},
 					{
 						ZoneName: aws.String("us-west-2d"),
-						SubnetId: aws.String("subnet-1234fff"),
+						SubnetId: aws.String("subnet-1234ggg"),
 					},
 				},
 				SecurityGroups: []*string{

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer.go
@@ -265,9 +265,12 @@ func buildElbv2ApplicationLoadBalancerSnapshot(
 		}
 	}
 
-	// Try to find a webACL ID
-	if applicationLoadBalancer.WebAcl, err = getWebACLForResource(wafRegionalSvc, lb.LoadBalancerArn); err != nil {
-		return nil, err
+	// currently, waf is only supported in ALB
+	if *lb.Type == elbv2.LoadBalancerTypeEnumApplication {
+		// Try to find a webACL ID
+		if applicationLoadBalancer.WebAcl, err = getWebACLForResource(wafRegionalSvc, lb.LoadBalancerArn); err != nil {
+			return nil, err
+		}
 	}
 
 	return applicationLoadBalancer, nil

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer.go
@@ -266,7 +266,7 @@ func buildElbv2ApplicationLoadBalancerSnapshot(
 	}
 
 	// currently, waf is only supported in ALB
-	if *lb.Type == elbv2.LoadBalancerTypeEnumApplication {
+	if aws.StringValue(lb.Type) == elbv2.LoadBalancerTypeEnumApplication {
 		// Try to find a webACL ID
 		if applicationLoadBalancer.WebAcl, err = getWebACLForResource(wafRegionalSvc, lb.LoadBalancerArn); err != nil {
 			return nil, err

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
@@ -136,6 +136,22 @@ func TestBuildElbv2ApplicationLoadBalancerSnapshot(t *testing.T) {
 	assert.NotEmpty(t, elbv2Snapshot.Name)
 }
 
+func TestBuildElbv2NetworkLoadBalancerSnapshot(t *testing.T) {
+	mockElbv2Svc := awstest.BuildMockElbv2SvcAll()
+	mockWafRegionalSvc := awstest.BuildMockWafRegionalSvcAll()
+
+	elbv2Snapshot, err := buildElbv2ApplicationLoadBalancerSnapshot(
+		mockElbv2Svc,
+		mockWafRegionalSvc,
+		awstest.ExampleDescribeNetworkLoadBalancersOutput.LoadBalancers[0],
+	)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, elbv2Snapshot.SecurityGroups)
+	assert.Nil(t, elbv2Snapshot.WebAcl)
+	assert.NotEmpty(t, elbv2Snapshot.Name)
+}
+
 func TestBuildElbv2ApplicationLoadBalancerSnapshotError(t *testing.T) {
 	mockElbv2Svc := awstest.BuildMockElbv2SvcAllError()
 	mockWafRegionalSvc := awstest.BuildMockWafRegionalSvcAllError()

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
@@ -143,7 +143,7 @@ func TestBuildElbv2NetworkLoadBalancerSnapshot(t *testing.T) {
 	elbv2Snapshot, err := buildElbv2ApplicationLoadBalancerSnapshot(
 		mockElbv2Svc,
 		mockWafRegionalSvc,
-		awstest.ExampleDescribeNetworkLoadBalancersOutput.LoadBalancers[0],
+		awstest.ExampleDescribeLoadBalancersOutput.LoadBalancers[1],
 	)
 
 	assert.NoError(t, err)

--- a/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/elbv2_application_load_balancer_test.go
@@ -143,7 +143,7 @@ func TestBuildElbv2NetworkLoadBalancerSnapshot(t *testing.T) {
 	elbv2Snapshot, err := buildElbv2ApplicationLoadBalancerSnapshot(
 		mockElbv2Svc,
 		mockWafRegionalSvc,
-		awstest.ExampleDescribeLoadBalancersOutput.LoadBalancers[1],
+		awstest.ExampleDescribeNetworkLoadBalancersOutput.LoadBalancers[0],
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
## Background

Calling `GetWebAclForResource` on network load balancers will raise `WAFInvalidParameterException`. This change will check for for the lb type before calling `GetWebAclForResource`

## Changes

- check for lb type
- added unit test for network type

## Testing

- `mage test:go`
