### PR TITLE
[FE][Feat] Allow any type of item in Selection.Context

### DIFF
--- a/web/src/components/cards/AlertCard/PolicyAlertCard/PolicyAlertCard.tsx
+++ b/web/src/components/cards/AlertCard/PolicyAlertCard/PolicyAlertCard.tsx
@@ -60,7 +60,7 @@ const PolicyAlertCard: React.FC<PolicyAlertCardProps> = ({
       <Flex align="start" pr={2}>
         {selectionEnabled && (
           <Box transform="translate3d(0,-8px,0)">
-            <SelectCheckbox selectionId={alert.alertId} />
+            <SelectCheckbox selectionItem={alert.alertId} />
           </Box>
         )}
       </Flex>

--- a/web/src/components/cards/AlertCard/RuleAlertCard/RuleAlertCard.tsx
+++ b/web/src/components/cards/AlertCard/RuleAlertCard/RuleAlertCard.tsx
@@ -54,7 +54,7 @@ const RuleAlertCard: React.FC<RuleAlertCardProps> = ({
       <Flex align="start" pr={2}>
         {selectionEnabled && (
           <Box transform="translate3d(0,-8px,0)">
-            <SelectCheckbox selectionId={alert.alertId} />
+            <SelectCheckbox selectionItem={alert.alertId} />
           </Box>
         )}
       </Flex>

--- a/web/src/components/utils/SelectContext/SelectAllCheckbox.tsx
+++ b/web/src/components/utils/SelectContext/SelectAllCheckbox.tsx
@@ -20,15 +20,12 @@ import React from 'react';
 import { useSelect } from 'Components/utils/SelectContext/SelectContext';
 import { Checkbox } from 'pouncejs';
 
-interface SelectAllCheckboxProps {
-  selectionIds: string[];
+interface SelectAllCheckboxProps<T> {
+  selectionItems: T[];
 }
 
-const SelectAllCheckboxComponent: React.FC<SelectAllCheckboxProps> = ({
-  selectionIds,
-  ...rest
-}) => {
-  const { selection, resetSelection, selectAll } = useSelect();
+function SelectAllCheckboxComponent<T>({ selectionItems, ...rest }: SelectAllCheckboxProps<T>) {
+  const { selection, resetSelection, selectAll } = useSelect<T>();
   return (
     <Checkbox
       checked={!!selection.length}
@@ -36,13 +33,13 @@ const SelectAllCheckboxComponent: React.FC<SelectAllCheckboxProps> = ({
         if (selection.length) {
           resetSelection();
         } else {
-          selectAll(selectionIds);
+          selectAll(selectionItems);
         }
       }}
       aria-label={selection.length ? 'unselect all' : 'select all'}
       {...rest}
     />
   );
-};
+}
 
-export const SelectAllCheckbox = React.memo(SelectAllCheckboxComponent);
+export default React.memo(SelectAllCheckboxComponent);

--- a/web/src/components/utils/SelectContext/SelectCheckbox.tsx
+++ b/web/src/components/utils/SelectContext/SelectCheckbox.tsx
@@ -20,21 +20,22 @@ import React from 'react';
 import { Checkbox } from 'pouncejs';
 import { useSelect } from './SelectContext';
 
-interface SelectCheckboxProps {
-  selectionId: string;
+interface SelectCheckboxProps<T> {
+  selectionItem: T;
 }
 
-const SelectCheckboxComponent: React.FC<SelectCheckboxProps> = ({ selectionId, ...rest }) => {
-  const { checkIfSelected, toggleItem } = useSelect();
-  const isSelected = checkIfSelected(selectionId);
+function SelectCheckboxComponent<T>({ selectionItem, ...rest }: SelectCheckboxProps<T>) {
+  const { checkIfSelected, toggleItem } = useSelect<T>();
+  const isSelected = checkIfSelected(selectionItem);
+
   return (
     <Checkbox
       checked={isSelected}
-      aria-label={isSelected ? `unselect ${selectionId}` : `select ${selectionId}`}
-      onChange={() => toggleItem(selectionId)}
+      aria-label={isSelected ? 'unselect item' : 'select item'}
+      onChange={() => toggleItem(selectionItem)}
       {...rest}
     />
   );
-};
+}
 
-export const SelectCheckbox = React.memo(SelectCheckboxComponent);
+export default React.memo(SelectCheckboxComponent);

--- a/web/src/components/utils/SelectContext/SelectContext.test.tsx
+++ b/web/src/components/utils/SelectContext/SelectContext.test.tsx
@@ -18,19 +18,20 @@
 import React from 'react';
 import { Text } from 'pouncejs';
 import { fireClickAndMouseEvents, render } from 'test-utils';
-import { SelectProvider, useSelect } from 'Components/utils/SelectContext/SelectContext';
-import { SelectCheckbox } from 'Components/utils/SelectContext/SelectCheckbox';
-import { SelectAllCheckbox } from 'Components/utils/SelectContext/SelectAllCheckbox';
+import { SelectProvider, useSelect, SelectCheckbox, SelectAllCheckbox } from './index';
 
-const TestingComponent: React.FC<{ items: string[] }> = ({ items }) => {
-  const { checkIfSelected } = useSelect();
+const items = [{ id: 'a' }, { id: 'b' }];
+type Item = typeof items[0];
+
+const TestingComponent: React.FC<{ items: Item[] }> = ({ items: itms }) => {
+  const { checkIfSelected } = useSelect<Item>();
   return (
     <React.Fragment>
-      {items.map(id => (
-        <React.Fragment key={id}>
-          <SelectCheckbox selectionId={id} />
+      {itms.map(item => (
+        <React.Fragment key={item.id}>
+          <SelectCheckbox selectionItem={item} />
           <Text>
-            {id} is {checkIfSelected(id) ? 'selected' : 'unselected'}
+            {item.id} is {checkIfSelected(item) ? 'selected' : 'unselected'}
           </Text>
         </React.Fragment>
       ))}
@@ -40,47 +41,46 @@ const TestingComponent: React.FC<{ items: string[] }> = ({ items }) => {
 
 describe('Select Context tests', () => {
   it('should select & unselect items', async () => {
-    const items = ['a', 'b', 'c'];
-    const [itemA, itemB] = items;
-
-    const { getByText, getByAriaLabel } = render(
+    const { getByText, getAllByAriaLabel } = render(
       <SelectProvider>
         <TestingComponent items={items} />
       </SelectProvider>
     );
-    items.forEach(id => {
-      expect(getByText(`${id} is unselected`));
+    const [checkboxA, checkboxB] = getAllByAriaLabel(`select item`);
+
+    items.forEach(item => {
+      expect(getByText(`${item.id} is unselected`));
     });
 
-    const checkboxB = getByAriaLabel(`select ${itemB}`);
+    await fireClickAndMouseEvents(checkboxA);
+    expect(getByText(`${items[0].id} is selected`));
+    expect(getByText(`${items[1].id} is unselected`));
+
     await fireClickAndMouseEvents(checkboxB);
-    expect(getByText(`${itemB} is selected`));
-    expect(getByText(`${itemA} is unselected`));
-    const uncheckboxB = getByAriaLabel(`unselect ${itemB}`);
-    await fireClickAndMouseEvents(uncheckboxB);
-    expect(getByText(`${itemB} is unselected`));
+    expect(getByText(`${items[0].id} is selected`));
+    expect(getByText(`${items[1].id} is selected`));
   });
 
   it('should select all & deselect all items', async () => {
-    const items = ['a', 'b', 'c'];
     const { getByText, getByAriaLabel } = render(
       <SelectProvider>
-        <SelectAllCheckbox selectionIds={items} />
+        <SelectAllCheckbox selectionItems={items} />
         <TestingComponent items={items} />
       </SelectProvider>
     );
-    items.forEach(id => {
-      expect(getByText(`${id} is unselected`));
+
+    items.forEach(item => {
+      expect(getByText(`${item.id} is unselected`));
     });
-    const selectAll = getByAriaLabel(`select all`);
-    await fireClickAndMouseEvents(selectAll);
-    items.forEach(id => {
-      expect(getByText(`${id} is selected`));
+
+    await fireClickAndMouseEvents(getByAriaLabel(`select all`));
+    items.forEach(item => {
+      expect(getByText(`${item.id} is selected`));
     });
-    const deselectAll = getByAriaLabel(`unselect all`);
-    await fireClickAndMouseEvents(deselectAll);
-    items.forEach(id => {
-      expect(getByText(`${id} is unselected`));
+
+    await fireClickAndMouseEvents(getByAriaLabel('unselect all'));
+    items.forEach(item => {
+      expect(getByText(`${item.id} is unselected`));
     });
   });
 });

--- a/web/src/components/utils/SelectContext/index.tsx
+++ b/web/src/components/utils/SelectContext/index.tsx
@@ -17,5 +17,5 @@
  */
 
 export * from './SelectContext';
-export * from './SelectCheckbox';
-export * from './SelectAllCheckbox';
+export { default as SelectCheckbox } from './SelectCheckbox';
+export { default as SelectAllCheckbox } from './SelectAllCheckbox';

--- a/web/src/pages/ListAlerts/ListAlerts.test.tsx
+++ b/web/src/pages/ListAlerts/ListAlerts.test.tsx
@@ -122,7 +122,7 @@ describe('ListAlerts', () => {
       getAllByLabelText,
       getByText,
       findByAriaLabel,
-      getByAriaLabel,
+      getAllByAriaLabel,
       findAllByText,
       queryByAriaLabel,
       queryAllByText,
@@ -136,24 +136,23 @@ describe('ListAlerts', () => {
     alertSummaries.forEach(alertSummary => {
       expect(getByText(alertSummary.title)).toBeInTheDocument();
     });
-    alertSummaries.forEach(alertSummary => {
-      expect(getByAriaLabel(`select ${alertSummary.alertId}`)).toBeInTheDocument();
-    });
 
     // Single select all of 3 Alerts
-    const checkboxForAlert1 = getByAriaLabel(`select ${alertSummaries[0].alertId}`);
+    const [checkboxForAlert1, checkboxForAlert2, checkboxForAlert3] = getAllByAriaLabel(
+      `select item`
+    );
+
     fireClickAndMouseEvents(checkboxForAlert1);
     expect(getByText('1 Selected')).toBeInTheDocument();
-    const checkboxForAlert2 = getByAriaLabel(`select ${alertSummaries[1].alertId}`);
+
     fireClickAndMouseEvents(checkboxForAlert2);
     expect(getByText('2 Selected')).toBeInTheDocument();
-    const checkboxForAlert3 = getByAriaLabel(`select ${alertSummaries[2].alertId}`);
+
     fireClickAndMouseEvents(checkboxForAlert3);
     expect(getByText('3 Selected')).toBeInTheDocument();
 
     // Deselect first alert
-    const checkedCheckboxForAlert1 = getByAriaLabel(`unselect ${alertSummaries[0].alertId}`);
-    fireClickAndMouseEvents(checkedCheckboxForAlert1);
+    fireClickAndMouseEvents(checkboxForAlert1);
     expect(getByText('2 Selected')).toBeInTheDocument();
 
     // Expect status field to have Resolved as default
@@ -170,8 +169,7 @@ describe('ListAlerts', () => {
     // Find the alerts with the updated status
     expect(await findAllByText('INVALID')).toHaveLength(2);
     // And expect that the selection has been reset
-    expect(await queryByAriaLabel(`unselect ${alertSummaries[1].alertId}`)).not.toBeInTheDocument();
-    expect(await queryByAriaLabel(`unselect ${alertSummaries[2].alertId}`)).not.toBeInTheDocument();
+    expect(queryByAriaLabel(`unselect item`)).not.toBeInTheDocument();
   });
 
   it('can select all alerts and update their status', async () => {
@@ -225,7 +223,7 @@ describe('ListAlerts', () => {
       getAllByLabelText,
       getByText,
       findByAriaLabel,
-      getByAriaLabel,
+      getAllByAriaLabel,
       findAllByText,
       queryByAriaLabel,
     } = render(<ListAlerts />, {
@@ -239,9 +237,8 @@ describe('ListAlerts', () => {
     alertSummaries.forEach(alertSummary => {
       expect(getByText(alertSummary.title)).toBeInTheDocument();
     });
-    alertSummaries.forEach(alertSummary => {
-      expect(getByAriaLabel(`select ${alertSummary.alertId}`)).toBeInTheDocument();
-    });
+
+    expect(getAllByAriaLabel(`select item`)).toHaveLength(alertSummaries.length);
 
     fireClickAndMouseEvents(selectAllCheckbox);
     expect(getByText('3 Selected')).toBeInTheDocument();
@@ -259,9 +256,7 @@ describe('ListAlerts', () => {
     // Find the alerts with the updated status
     expect(await findAllByText('OPEN')).toHaveLength(alertSummaries.length);
     // And expect that the selection has been reset
-    alertSummaries.forEach(alertSummary => {
-      expect(queryByAriaLabel(`unselect ${alertSummary.alertId}`)).not.toBeInTheDocument();
-    });
+    expect(queryByAriaLabel(`unselect item`)).not.toBeInTheDocument();
   });
 
   it('can correctly boot from URL params', async () => {

--- a/web/src/pages/ListAlerts/ListAlerts.tsx
+++ b/web/src/pages/ListAlerts/ListAlerts.tsx
@@ -130,7 +130,7 @@ const ListAlerts = () => {
       <Panel
         title={
           <Flex align="center" spacing={2} ml={4}>
-            <SelectAllCheckbox selectionIds={alertIds} />
+            <SelectAllCheckbox selectionItems={alertIds} />
             <Text>Alerts</Text>
           </Flex>
         }

--- a/web/src/pages/RuleDetails/RuleAlertsListing/RuleAlertsListing.tsx
+++ b/web/src/pages/RuleDetails/RuleAlertsListing/RuleAlertsListing.tsx
@@ -141,7 +141,7 @@ const RuleAlertsListing: React.FC<RuleAlertsListingProps> = ({ ruleId, type }) =
         <Flex width="100%" pt={6} px={6}>
           <Flex width="100%" spacing={2} justify="space-between">
             <Flex align="center" spacing={2} ml={4}>
-              <SelectAllCheckbox selectionIds={alertIds} />
+              <SelectAllCheckbox selectionItems={alertIds} />
               <Text>Alerts</Text>
             </Flex>
             <Flex justify="flex-end">

--- a/web/src/pages/RuleDetails/RuleDetails.test.tsx
+++ b/web/src/pages/RuleDetails/RuleDetails.test.tsx
@@ -677,6 +677,7 @@ describe('RuleDetails', () => {
       getByText,
       getByTestId,
       getByAriaLabel,
+      getAllByAriaLabel,
       findAllByText,
       queryByAriaLabel,
       getAllByLabelText,
@@ -702,20 +703,18 @@ describe('RuleDetails', () => {
     alertSummaries.forEach(alertSummary => {
       expect(getByText(alertSummary.title)).toBeInTheDocument();
     });
-    alertSummaries.forEach(alertSummary => {
-      expect(getByAriaLabel(`select ${alertSummary.alertId}`)).toBeInTheDocument();
-    });
+
     // Single select all of 2 Alerts
-    const checkboxForAlert1 = getByAriaLabel(`select ${alertSummaries[0].alertId}`);
+    const [checkboxForAlert1, checkboxForAlert2] = getAllByAriaLabel(`select item`);
+
     fireClickAndMouseEvents(checkboxForAlert1);
     expect(getByText('1 Selected')).toBeInTheDocument();
-    const checkboxForAlert2 = getByAriaLabel(`select ${alertSummaries[1].alertId}`);
+
     fireClickAndMouseEvents(checkboxForAlert2);
     expect(getByText('2 Selected')).toBeInTheDocument();
 
     // Deselect first alert
-    const checkedCheckboxForAlert1 = getByAriaLabel(`unselect ${alertSummaries[0].alertId}`);
-    fireClickAndMouseEvents(checkedCheckboxForAlert1);
+    fireClickAndMouseEvents(checkboxForAlert1);
     expect(getByText('1 Selected')).toBeInTheDocument();
 
     // Expect status field to have Resolved as default
@@ -732,16 +731,13 @@ describe('RuleDetails', () => {
     // Find the alerts with the updated status
     expect(await findAllByText('INVALID')).toHaveLength(1);
     // And expect that the selection has been reset
-    expect(await queryByAriaLabel(`unselect ${alertSummaries[0].alertId}`)).not.toBeInTheDocument();
-    expect(await queryByAriaLabel(`unselect ${alertSummaries[1].alertId}`)).not.toBeInTheDocument();
+    expect(await queryByAriaLabel(`unselect item`)).not.toBeInTheDocument();
 
     // Now select all Rule Matches and updated to Open
     const selectAllCheckbox = getByAriaLabel('select all');
     fireClickAndMouseEvents(selectAllCheckbox);
 
-    alertSummaries.forEach(alertSummary => {
-      expect(getByAriaLabel(`unselect ${alertSummary.alertId}`)).toBeInTheDocument();
-    });
+    expect(getAllByAriaLabel(`unselect item`)).toHaveLength(alertSummaries.length);
     // Expect status field to have Resolved as default
 
     fireClickAndMouseEvents(getAllByLabelText('Status')[0]);
@@ -837,6 +833,7 @@ describe('RuleDetails', () => {
       getByText,
       getByTestId,
       getByAriaLabel,
+      getAllByAriaLabel,
       findAllByText,
       queryByAriaLabel,
       getAllByLabelText,
@@ -859,23 +856,22 @@ describe('RuleDetails', () => {
     const loadingListingInterfaceElement = getByTestId('rule-alerts-listing-loading');
     expect(loadingListingInterfaceElement).toBeTruthy();
     await waitForElementToBeRemoved(loadingListingInterfaceElement);
+
     alertSummaries.forEach(alertSummary => {
       expect(getByText(alertSummary.title)).toBeInTheDocument();
     });
-    alertSummaries.forEach(alertSummary => {
-      expect(getByAriaLabel(`select ${alertSummary.alertId}`)).toBeInTheDocument();
-    });
+
     // Single select all of 2 Alerts
-    const checkboxForAlert1 = getByAriaLabel(`select ${alertSummaries[0].alertId}`);
+    const [checkboxForAlert1, checkboxForAlert2] = getAllByAriaLabel(`select item`);
+
     fireClickAndMouseEvents(checkboxForAlert1);
     expect(getByText('1 Selected')).toBeInTheDocument();
-    const checkboxForAlert2 = getByAriaLabel(`select ${alertSummaries[1].alertId}`);
+
     fireClickAndMouseEvents(checkboxForAlert2);
     expect(getByText('2 Selected')).toBeInTheDocument();
 
     // Deselect first alert
-    const checkedCheckboxForAlert1 = getByAriaLabel(`unselect ${alertSummaries[0].alertId}`);
-    fireClickAndMouseEvents(checkedCheckboxForAlert1);
+    fireClickAndMouseEvents(checkboxForAlert1);
     expect(getByText('1 Selected')).toBeInTheDocument();
 
     // Expect status field to have Resolved as default
@@ -892,16 +888,14 @@ describe('RuleDetails', () => {
     // Find the alerts with the updated status
     expect(await findAllByText('INVALID')).toHaveLength(1);
     // And expect that the selection has been reset
-    expect(await queryByAriaLabel(`unselect ${alertSummaries[0].alertId}`)).not.toBeInTheDocument();
-    expect(await queryByAriaLabel(`unselect ${alertSummaries[1].alertId}`)).not.toBeInTheDocument();
+    expect(await queryByAriaLabel(`unselect item`)).not.toBeInTheDocument();
 
     // Now select all Rule Matches and updated to Open
     const selectAllCheckbox = getByAriaLabel('select all');
     fireClickAndMouseEvents(selectAllCheckbox);
 
-    alertSummaries.forEach(alertSummary => {
-      expect(getByAriaLabel(`unselect ${alertSummary.alertId}`)).toBeInTheDocument();
-    });
+    expect(getAllByAriaLabel(`unselect item`)).toHaveLength(alertSummaries.length);
+
     // Expect status field to have Resolved as default
 
     fireClickAndMouseEvents(getAllByLabelText('Status')[0]);


### PR DESCRIPTION
## Background

Currently, when we are using `<SelectionContext>` we expect the developer to pass a list of string identifiers (IDs) to help the context undertand what's selected and what's not selected.

Unfortunately, sometimes we want access to the actual selected object (not just its ID) so that we can show some additional information to the user. With this PR this is now possible, since it extends `SelectionContext` to allow any type to be added to it, opening the door to other work that relates to mass selections.

## Changes

- Add typings to all selection-related entities
- Extend functions to support all types of selected items
- Update tests

## Testing

- `npm run test`

## Notes

The changes here are as minimal as I could make them, trying to introduce as small of a migration as possible.

The purpose of this change is to allow for an easier way to handle single-item  and multi-item deletions. It's currently optionally required by the mass actions on detections & data models
