### PR TITLE
Minor cleanup for new pkg code

### DIFF
--- a/deployments/cloud_security.yml
+++ b/deployments/cloud_security.yml
@@ -130,7 +130,7 @@ Resources:
       # * Failure of this sqs queue will impact delivery of alerts to output destinations.
       # * Failed events will go into the `panther-alert-processor-queue-dlq`. When the system has recovered they should be re-queued to the `panther-alert-processor-queue` using the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       KmsMasterKeyId: !Ref SqsKeyId
       VisibilityTimeout: !FindInMap [Functions, AlertProcessor, Timeout]
       RedrivePolicy:
@@ -155,7 +155,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-alert-processor-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       VisibilityTimeout: 60
 
   AlertProcessorDLQAlarms:
@@ -364,7 +364,7 @@ Resources:
   EventQueue:
     Type: AWS::SQS::Queue
     Properties:
-      MessageRetentionPeriod: '86400' # 24 hours
+      MessageRetentionPeriod: 86400 # 24 hours
       QueueName: panther-aws-events-queue
       # <cfndoc>
       # This sqs q receives CloudTrail events delivered by CloudWatch events
@@ -394,7 +394,7 @@ Resources:
   EventDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       QueueName: panther-aws-events-queue-dlq
       # <cfndoc>
       # This is the dead letter queue for the `panther-aws-events-queue`.
@@ -732,7 +732,7 @@ Resources:
       # * Failure of this sqs queue will impact the remediation of policy violations.
       # * Failed events will go into the `panther-remediation-queue`. When the system has recovered they should be re-queued to the `panther-remediation-queue-dlq` using the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       KmsMasterKeyId: !Ref SqsKeyId
       VisibilityTimeout: !FindInMap [Functions, RemediationProcessor, Timeout]
       RedrivePolicy:
@@ -757,7 +757,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-remediation-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       VisibilityTimeout: 60
 
   RemediationDLQAlarms:
@@ -1044,7 +1044,7 @@ Resources:
   ResourcesDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       QueueName: panther-resources-queue-dlq
       # <cfndoc>
       # The dead letter queue for the `panther-resources-queue`.
@@ -1253,7 +1253,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-snapshot-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       VisibilityTimeout: 60
 
   SnapshotDLQAlarms:

--- a/deployments/core.yml
+++ b/deployments/core.yml
@@ -594,7 +594,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-alerts-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       VisibilityTimeout: 60
 
   AlertDLQAlarms:
@@ -872,7 +872,7 @@ Resources:
       # * Failure of this sqs queue will prevent users from updating the globals layer.
       # * Failed events will go into the `panther-layer-manager-queue-dlq`. When the system has recovered, one event should be re-queued to the `panther-layer-manager-queue` using the Panther tool `requeue` and the rest should be purged.
       # </cfndoc>
-      MessageRetentionPeriod: '86400' # 24 hours
+      MessageRetentionPeriod: 86400 # 24 hours
       KmsMasterKeyId: !Ref SqsKeyId
       VisibilityTimeout: !FindInMap [Functions, LayerManager, Timeout]
       RedrivePolicy:
@@ -897,7 +897,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-layer-manager-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
       VisibilityTimeout: 60
 
   LayerDLQAlarms:

--- a/deployments/log_analysis.yml
+++ b/deployments/log_analysis.yml
@@ -419,7 +419,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-input-data-notifications-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
 
   LogProcessorDLQAlarms:
     Type: Custom::SQSAlarms
@@ -628,7 +628,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-datacatalog-updater-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
 
   UpdaterDLQAlarms:
     Type: Custom::SQSAlarms
@@ -826,7 +826,7 @@ Resources:
       # When the system has recovered they should be re-queued to the `panther-rules-engine-queue` using
       # the Panther tool `requeue`.
       # </cfndoc>
-      MessageRetentionPeriod: '1209600' # Max duration - 14 days
+      MessageRetentionPeriod: 1209600 # Max duration - 14 days
 
   RulesEngineDLQAlarms:
     Type: Custom::SQSAlarms

--- a/deployments/web_server.yml
+++ b/deployments/web_server.yml
@@ -155,7 +155,7 @@ Resources:
         - Type: redirect
           RedirectConfig:
             Protocol: HTTPS
-            Port: 443
+            Port: '443'
             Host: '#{host}'
             Path: '/#{path}'
             Query: '#{query}'

--- a/tools/mage/deploy/template.go
+++ b/tools/mage/deploy/template.go
@@ -50,15 +50,11 @@ func Stack(
 ) (map[string]string, error) {
 
 	// 1) Generate packaged template, packaging assets in S3 and ECR
-	packagedTemplate := templatePath
-	if packager != nil {
-		packager.Log.Debugf("packaging %s to s3 bucket %s and ecr registry %s",
-			templatePath, packager.Bucket, packager.EcrRegistry)
-		var err error
-		packagedTemplate, err = packager.Template(templatePath)
-		if err != nil {
-			return nil, err
-		}
+	packager.Log.Debugf("packaging %s to s3 bucket %s and ecr registry %s",
+		templatePath, packager.Bucket, packager.EcrRegistry)
+	packagedTemplate, err := packager.Template(templatePath)
+	if err != nil {
+		return nil, err
 	}
 
 	// 2) If the stack already exists, wait for it to reach a steady state.

--- a/tools/mage/deploy/template.go
+++ b/tools/mage/deploy/template.go
@@ -50,7 +50,6 @@ func Stack(
 ) (map[string]string, error) {
 
 	// 1) Generate packaged template, packaging assets in S3 and ECR
-	// 1) Generate packaged template, packaging assets in S3 and ECR
 	packagedTemplate := templatePath
 	if packager != nil {
 		packager.Log.Debugf("packaging %s to s3 bucket %s and ecr registry %s",

--- a/tools/mage/deploy/template.go
+++ b/tools/mage/deploy/template.go
@@ -50,11 +50,16 @@ func Stack(
 ) (map[string]string, error) {
 
 	// 1) Generate packaged template, packaging assets in S3 and ECR
-	packager.Log.Debugf("packaging %s to s3 bucket %s and ecr registry %s",
-		templatePath, packager.Bucket, packager.EcrRegistry)
-	packagedTemplate, err := packager.Template(templatePath)
-	if err != nil {
-		return nil, err
+	// 1) Generate packaged template, packaging assets in S3 and ECR
+	packagedTemplate := templatePath
+	if packager != nil {
+		packager.Log.Debugf("packaging %s to s3 bucket %s and ecr registry %s",
+			templatePath, packager.Bucket, packager.EcrRegistry)
+		var err error
+		packagedTemplate, err = packager.Template(templatePath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// 2) If the stack already exists, wait for it to reach a steady state.

--- a/tools/mage/test/cfn.go
+++ b/tools/mage/test/cfn.go
@@ -70,20 +70,7 @@ func testCfnLint() error {
 		return nil
 	})
 
-	// cfn-lint will complain:
-	//   E3012 Property Resources/SnapshotDLQ/Properties/MessageRetentionPeriod should be of type Integer
-	//
-	// But if we keep them integers, yaml marshaling converts large integers to scientific notation,
-	// which CFN does not understand. So we force string values to serialize them correctly.
-	args := []string{
-		"-x", "E3012:strict=false",
-		// cfn-lint complains: E3002 Invalid Property Resources/WebApplicationServer/Properties/NetworkConfiguration/AwsvpcConfiguration
-		//deployments/web_server.yml:208:9 .
-		// nolint:lll
-		// However this property is valid: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-networkconfiguration.html#cfn-ecs-service-networkconfiguration-awsvpcconfiguration
-		"-i", "E3002",
-		"-i", "W3002", // warns about templates which require packaging; ours all do
-		"--"}
+	args := []string{"-i", "W3002", "--"}  // warns about templates which require packaging; ours all do
 	args = append(args, templates...)
 	if err := sh.RunV(util.PipPath("cfn-lint"), args...); err != nil {
 		return err

--- a/tools/mage/test/cfn.go
+++ b/tools/mage/test/cfn.go
@@ -70,7 +70,7 @@ func testCfnLint() error {
 		return nil
 	})
 
-	args := []string{"-i", "W3002", "--"}  // warns about templates which require packaging; ours all do
+	args := []string{"-i", "W3002", "--"} // warns about templates which require packaging; ours all do
 	args = append(args, templates...)
 	if err := sh.RunV(util.PipPath("cfn-lint"), args...); err != nil {
 		return err


### PR DESCRIPTION
## Background

#2524 was a large PR which replaced the `mage` packaging logic. As devs have started using it, there were a few small fixes needed

## Changes

- The YAML v3 library uses 4 spaces for indentation by default, who knows why. I've lowered it to 2 spaces when writing packaged templates: it takes quite a bit less space and it is easier to see deeply nested CFN settings in the web console
- The `bootstrap` stack still needs to be "packaged" to strip comments or else it will be too large (in enterprise) to deploy directly. This stack cannot have S3 packaging in the old deployment model because it is itself the stack which creates the S3 buckets
- The problem with large numbers being written in scientific notation appears to be resolved in the YAML v3 parser. I've removed all the YAML quotes around large numbers added in #2524
- When deploying individual Lambda functions, we no longer have to strip the `out/bin` prefix from the source paths, because #2524 changed the path in the templates to the source rather than the compiled binary

## Testing

Fresh deploy: `AWS_REGION=us-west-1 mage deploy`
