### PR TITLE
Fix empty managed schema release result

### DIFF
--- a/internal/core/logtypesapi/managed_schemas.go
+++ b/internal/core/logtypesapi/managed_schemas.go
@@ -32,8 +32,8 @@ import (
 type ListManagedSchemaUpdatesInput struct{}
 
 type ListManagedSchemaUpdatesOutput struct {
-	Releases []managedschemas.Release `json:"releases,omitempty" description:"Available release updates"`
-	Error    *APIError                `json:"error,omitempty" description:"An error that occurred while fetching the record"`
+	Releases *[]managedschemas.Release `json:"releases,omitempty" description:"Available release updates"`
+	Error    *APIError                 `json:"error,omitempty" description:"An error that occurred while fetching the record"`
 }
 
 // nolint:lll
@@ -47,8 +47,11 @@ func (api *LogTypesAPI) ListManagedSchemaUpdates(ctx context.Context, _ *ListMan
 	if err != nil {
 		return nil, err
 	}
+	if releases == nil {
+		releases = []managedschemas.Release{}
+	}
 	return &ListManagedSchemaUpdatesOutput{
-		Releases: releases,
+		Releases: &releases,
 	}, nil
 }
 


### PR DESCRIPTION
## Background

There's was a small bug where the reply of `ListManagedSchemaUpdates` would be `{}` if there were no updates available.
The field should be kept as `omitempty` because we want it to be missing when there is an API error to report.
To work around `omitempty` behavior where empty slices are omitted, the value was changed to be a pointer to a slice.

## Changes

- Changes the `Releases` field of `ListManagedSchemaUpdatesOutput` to `*[]managedschemas.Release` to get the correct behavior in the API response

## Testing

- mage test:go
