### PR TITLE
The log processing role must be now provided by users

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -199,6 +199,7 @@ input GetS3LogIntegrationTemplateInput {
   s3Bucket: String!
   kmsKey: String
   managedBucketNotifications: Boolean!
+  roleARN: String!
 }
 
 input ListAlertsInput {
@@ -761,6 +762,7 @@ input AddS3LogIntegrationInput {
   kmsKey: String
   s3PrefixLogTypes: [S3PrefixLogTypesInput!]!
   managedBucketNotifications: Boolean!
+  roleARN: String!
 }
 
 input SqsLogConfigInput {
@@ -789,6 +791,7 @@ input UpdateS3LogIntegrationInput {
   s3Bucket: String
   kmsKey: String
   s3PrefixLogTypes: [S3PrefixLogTypesInput!]
+  roleARN: String!
 }
 
 input UpdateSqsLogIntegrationInput {

--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -59,9 +59,10 @@ type CheckIntegrationInput struct {
 	EnableRemediation *bool `json:"enableRemediation"`
 
 	// Checks for log analysis integrations
-	S3Bucket         string           `json:"s3Bucket"`
-	S3PrefixLogTypes S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty"`
-	KmsKey           string           `json:"kmsKey"`
+	S3Bucket             string           `json:"s3Bucket"`
+	S3PrefixLogTypes     S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty"`
+	KmsKey               string           `json:"kmsKey"`
+	LogProcessingRoleARN string           `json:"roleARN"` // arn validation missing, FE handles the healthcheck response
 
 	// Checks for Sqs configuration
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
@@ -104,6 +105,8 @@ type PutIntegrationSettings struct {
 	S3PrefixLogTypes           S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty" validate:"omitempty,min=1"`
 	KmsKey                     string           `json:"kmsKey" validate:"omitempty,kmsKeyArn"`
 	ManagedBucketNotifications bool             `json:"managedBucketNotifications"`
+	// The AWS IAM role Panther can use to read objects from the user's S3 bucket.
+	LogProcessingRoleARN string `json:"roleARN" validate:"omitempty,iamARN"`
 
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 }
@@ -131,6 +134,7 @@ type UpdateIntegrationSettingsInput struct {
 	S3Bucket                string           `json:"s3Bucket" validate:"omitempty,min=1"`
 	S3PrefixLogTypes        S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty" validate:"omitempty,min=1"`
 	KmsKey                  string           `json:"kmsKey" validate:"omitempty,kmsKeyArn"`
+	LogProcessingRoleARN    string           `json:"roleARN" validate:"omitempty,iamARN"`
 
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 }

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -69,10 +69,10 @@ type SourceIntegrationMetadata struct {
 	ResourceRegexIgnoreList []string `json:"resourceRegexIgnoreList,omitempty"`
 
 	// fields specific for an s3 integration (plus AWSAccountID, StackName)
-	S3Bucket          string           `json:"s3Bucket,omitempty"`
-	S3PrefixLogTypes  S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty"`
-	KmsKey            string           `json:"kmsKey,omitempty"`
-	LogProcessingRole string           `json:"logProcessingRole,omitempty"`
+	S3Bucket             string           `json:"s3Bucket,omitempty"`
+	S3PrefixLogTypes     S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty"`
+	KmsKey               string           `json:"kmsKey,omitempty"`
+	LogProcessingRoleARN string           `json:"roleARN,omitempty"`
 	// Whether Panther should configure the user's bucket notifications.
 	ManagedBucketNotifications bool `json:"managedBucketNotifications"`
 	// The resources that Panther created. This may be partial if an error occurred
@@ -156,7 +156,7 @@ func (s *SourceIntegration) RequiredLogTypes() (logTypes []string) {
 func (s *SourceIntegration) RequiredLogProcessingRole() string {
 	switch typ := s.IntegrationType; typ {
 	case IntegrationTypeAWS3, IntegrationTypeAWSScan:
-		return s.LogProcessingRole
+		return s.LogProcessingRoleARN
 	case IntegrationTypeSqs:
 		return s.SqsConfig.LogProcessingRole
 	default:

--- a/api/lambda/source/models/validator.go
+++ b/api/lambda/source/models/validator.go
@@ -43,6 +43,9 @@ func Validator() (*validator.Validate, error) {
 	if err := result.RegisterValidation("kmsKeyArn", validateKmsKeyArn); err != nil {
 		return nil, err
 	}
+	if err := result.RegisterValidation("iamARN", validateIAMARN); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -65,4 +68,13 @@ func validateKmsKeyArn(fl validator.FieldLevel) bool {
 		return false
 	}
 	return true
+}
+
+func validateIAMARN(fl validator.FieldLevel) bool {
+	value := fl.Field().String()
+	a, err := arn.Parse(value)
+	if err != nil {
+		return false
+	}
+	return a.Service == "iam" && strings.HasPrefix(a.Resource, "role")
 }

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -40,10 +40,9 @@ import (
 )
 
 const (
-	auditRoleFormat         = "arn:aws:iam::%s:role/PantherAuditRole-%s"
-	logProcessingRoleFormat = "arn:aws:iam::%s:role/PantherLogProcessingRole-%s"
-	cweRoleFormat           = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole-%s"
-	remediationRoleFormat   = "arn:aws:iam::%s:role/PantherRemediationRole-%s"
+	auditRoleFormat       = "arn:aws:iam::%s:role/PantherAuditRole-%s"
+	cweRoleFormat         = "arn:aws:iam::%s:role/PantherCloudFormationStackSetExecutionRole-%s"
+	remediationRoleFormat = "arn:aws:iam::%s:role/PantherRemediationRole-%s"
 )
 
 var (
@@ -90,7 +89,7 @@ func (api *API) checkAwsS3Integration(input *models.CheckIntegrationInput) *mode
 		IntegrationType: input.IntegrationType,
 	}
 	var roleCreds *credentials.Credentials
-	logProcessingRole := generateLogProcessingRoleArn(input.AWSAccountID, input.IntegrationLabel)
+	logProcessingRole := input.LogProcessingRoleARN
 	roleCreds, out.ProcessingRoleStatus = api.getCredentialsWithStatus(logProcessingRole)
 
 	if !out.ProcessingRoleStatus.Healthy {

--- a/internal/core/source_api/api/get_integration_template.go
+++ b/internal/core/source_api/api/get_integration_template.go
@@ -166,11 +166,6 @@ func getStackName(integrationType string, label string) string {
 	return fmt.Sprintf(LogAnalysisStackNameTemplate, normalizedLabel(label))
 }
 
-// Generates the ARN of the log processing role
-func generateLogProcessingRoleArn(awsAccountID string, label string) string {
-	return fmt.Sprintf(logProcessingRoleFormat, awsAccountID, normalizedLabel(label))
-}
-
 func normalizedLabel(label string) string {
 	sanitized := strings.ReplaceAll(label, " ", "-")
 	return strings.ToLower(sanitized)

--- a/internal/core/source_api/api/list_integrations.go
+++ b/internal/core/source_api/api/list_integrations.go
@@ -52,7 +52,7 @@ func (api *API) ListIntegrations(
 		if integ.IntegrationType == models.IntegrationTypeAWSScan {
 			if integ.S3Bucket == "" {
 				integ.S3Bucket = api.Config.InputDataBucketName
-				integ.LogProcessingRole = api.Config.InputDataRoleArn
+				integ.LogProcessingRoleARN = api.Config.InputDataRoleArn
 			}
 		}
 		result = append(result, integ)

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -142,15 +142,16 @@ func (api *API) validateIntegration(input *models.PutIntegrationInput) error {
 		return nil
 	}
 	reason, passing, err := api.EvaluateIntegrationFunc(&models.CheckIntegrationInput{
-		AWSAccountID:      input.AWSAccountID,
-		IntegrationType:   input.IntegrationType,
-		IntegrationLabel:  input.IntegrationLabel,
-		EnableCWESetup:    input.CWEEnabled,
-		EnableRemediation: input.RemediationEnabled,
-		S3Bucket:          input.S3Bucket,
-		S3PrefixLogTypes:  input.S3PrefixLogTypes,
-		KmsKey:            input.KmsKey,
-		SqsConfig:         input.SqsConfig,
+		AWSAccountID:         input.AWSAccountID,
+		IntegrationType:      input.IntegrationType,
+		IntegrationLabel:     input.IntegrationLabel,
+		EnableCWESetup:       input.CWEEnabled,
+		EnableRemediation:    input.RemediationEnabled,
+		S3Bucket:             input.S3Bucket,
+		S3PrefixLogTypes:     input.S3PrefixLogTypes,
+		KmsKey:               input.KmsKey,
+		LogProcessingRoleARN: input.LogProcessingRoleARN,
+		SqsConfig:            input.SqsConfig,
 	})
 	if err != nil {
 		return putIntegrationInternalError
@@ -290,7 +291,7 @@ func (api *API) generateNewIntegration(input *models.PutIntegrationInput) *model
 	case models.IntegrationTypeAWSScan:
 		metadata.AWSAccountID = input.AWSAccountID
 		metadata.CWEEnabled = input.CWEEnabled
-		metadata.LogProcessingRole = api.Config.InputDataRoleArn
+		metadata.LogProcessingRoleARN = api.Config.InputDataRoleArn
 		metadata.RemediationEnabled = input.RemediationEnabled
 		metadata.ScanIntervalMins = input.ScanIntervalMins
 		metadata.StackName = getStackName(input.IntegrationType, input.IntegrationLabel)
@@ -304,9 +305,8 @@ func (api *API) generateNewIntegration(input *models.PutIntegrationInput) *model
 		metadata.S3Bucket = input.S3Bucket
 		metadata.S3PrefixLogTypes = input.S3PrefixLogTypes
 		metadata.KmsKey = input.KmsKey
-		metadata.S3PrefixLogTypes = input.S3PrefixLogTypes
 		metadata.StackName = getStackName(input.IntegrationType, input.IntegrationLabel)
-		metadata.LogProcessingRole = generateLogProcessingRoleArn(input.AWSAccountID, input.IntegrationLabel)
+		metadata.LogProcessingRoleARN = input.LogProcessingRoleARN
 		metadata.ManagedBucketNotifications = input.ManagedBucketNotifications
 	case models.IntegrationTypeSqs:
 		metadata.SqsConfig = &models.SqsConfig{

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -101,13 +101,14 @@ func (api *API) checkSource(existingItem *ddb.Integration, input *models.UpdateI
 		IntegrationType: existingItem.IntegrationType,
 
 		// From update existingItem request
-		IntegrationLabel:  input.IntegrationLabel,
-		EnableCWESetup:    input.CWEEnabled,
-		EnableRemediation: input.RemediationEnabled,
-		S3Bucket:          input.S3Bucket,
-		S3PrefixLogTypes:  input.S3PrefixLogTypes,
-		KmsKey:            input.KmsKey,
-		SqsConfig:         input.SqsConfig,
+		IntegrationLabel:     input.IntegrationLabel,
+		EnableCWESetup:       input.CWEEnabled,
+		EnableRemediation:    input.RemediationEnabled,
+		S3Bucket:             input.S3Bucket,
+		S3PrefixLogTypes:     input.S3PrefixLogTypes,
+		KmsKey:               input.KmsKey,
+		LogProcessingRoleARN: input.LogProcessingRoleARN,
+		SqsConfig:            input.SqsConfig,
 	})
 	if err != nil {
 		return err
@@ -196,8 +197,8 @@ func updateIntegrationDBItem(item *ddb.Integration, input *models.UpdateIntegrat
 		if input.IntegrationLabel != "" {
 			item.IntegrationLabel = input.IntegrationLabel
 			item.StackName = getStackName(models.IntegrationTypeAWS3, input.IntegrationLabel)
-			item.LogProcessingRole = generateLogProcessingRoleArn(item.AWSAccountID, input.IntegrationLabel)
 		}
+		item.LogProcessingRoleARN = input.LogProcessingRoleARN
 		item.S3Bucket = input.S3Bucket
 		item.KmsKey = input.KmsKey
 		item.S3PrefixLogTypes = input.S3PrefixLogTypes

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -44,7 +44,7 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		item.S3PrefixLogTypes = input.S3PrefixLogTypes
 		item.KmsKey = input.KmsKey
 		item.StackName = input.StackName
-		item.LogProcessingRole = generateLogProcessingRoleArn(input.AWSAccountID, input.IntegrationLabel)
+		item.LogProcessingRoleARN = input.LogProcessingRoleARN
 		item.ManagedBucketNotifications = input.ManagedBucketNotifications
 		item.ManagedS3Resources = input.ManagedS3Resources
 	case models.IntegrationTypeAWSScan:
@@ -54,7 +54,7 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		item.LastScanErrorMessage = input.LastScanErrorMessage
 		item.LastScanEndTime = input.LastScanEndTime
 		item.LastScanStartTime = input.LastScanStartTime
-		item.LogProcessingRole = input.LogProcessingRole
+		item.LogProcessingRoleARN = input.LogProcessingRoleARN
 		item.RemediationEnabled = input.RemediationEnabled
 		item.S3Bucket = input.S3Bucket
 		item.ScanIntervalMins = input.ScanIntervalMins
@@ -99,7 +99,7 @@ func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 		}
 		integration.KmsKey = item.KmsKey
 		integration.StackName = item.StackName
-		integration.LogProcessingRole = item.LogProcessingRole
+		integration.LogProcessingRoleARN = item.LogProcessingRoleARN
 		integration.ManagedBucketNotifications = item.ManagedBucketNotifications
 		integration.ManagedS3Resources = item.ManagedS3Resources
 	case models.IntegrationTypeAWSScan:
@@ -109,7 +109,7 @@ func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
 		integration.ScanIntervalMins = item.ScanIntervalMins
 		integration.ScanStatus = item.ScanStatus
 		integration.S3Bucket = item.S3Bucket
-		integration.LogProcessingRole = item.LogProcessingRole
+		integration.LogProcessingRoleARN = item.LogProcessingRoleARN
 		integration.EventStatus = item.EventStatus
 		integration.LastScanStartTime = item.LastScanStartTime
 		integration.LastScanEndTime = item.LastScanEndTime

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -57,7 +57,7 @@ type Integration struct {
 	LogTypes                   []string                  `json:"logTypes" dynamodbav:",stringset"`
 	KmsKey                     string                    `json:"kmsKey,omitempty"`
 	StackName                  string                    `json:"stackName,omitempty"`
-	LogProcessingRole          string                    `json:"logProcessingRole,omitempty"`
+	LogProcessingRoleARN       string                    `json:"logProcessingRole,omitempty"`
 	ManagedBucketNotifications bool                      `json:"managedBucketNotifications,omitempty"`
 	ManagedS3Resources         models.ManagedS3Resources `json:"managedS3Resources,omitempty"`
 

--- a/internal/core/source_api/main/integration_test.go
+++ b/internal/core/source_api/main/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -62,9 +63,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration(t *testing.T) {
-	//if !integrationTest {
+	// if !integrationTest {
 	//	t.Skip()
-	//}
+	// }
 	// TODO This integration test currently fails since it tries to do healthcheck when adding integration.
 	// This causes all subsequent tests to fail
 	// See https://github.com/panther-labs/panther/issues/394
@@ -346,4 +347,68 @@ func TestIntegration_TestAPI_UpdateStatus_FailsIfIntegrationNotExists(t *testing
 	err := testAPI.UpdateStatus(&input)
 
 	require.Error(t, err)
+}
+
+func TestIntegration_PutUpdateIntegration_S3(t *testing.T) {
+	t.Parallel()
+	testutils.IntegrationTest(t)
+
+	sess = session.Must(session.NewSession())
+	c := lambda.New(sess)
+
+	// Create
+	input := models.LambdaInput{
+		PutIntegration: &models.PutIntegrationInput{
+			PutIntegrationSettings: models.PutIntegrationSettings{
+				IntegrationLabel:     "source-" + uuid.New().String()[:6],
+				IntegrationType:      models.IntegrationTypeAWS3,
+				UserID:               uuid.New().String(),
+				AWSAccountID:         "555555555555",
+				S3Bucket:             "some-bucket-" + uuid.New().String()[:6],
+				S3PrefixLogTypes:     models.S3PrefixLogtypes{{S3Prefix: "", LogTypes: []string{"Custom.LogType"}}},
+				LogProcessingRoleARN: "arn:aws:iam::region:role/user-provided-role",
+			},
+		},
+	}
+
+	var output models.SourceIntegration
+	err := genericapi.Invoke(c, functionName, input, &output)
+
+	require.NoError(t, err)
+	require.Equal(t, input.PutIntegration.IntegrationLabel, output.IntegrationLabel)
+	require.Equal(t, input.PutIntegration.LogProcessingRoleARN, output.LogProcessingRoleARN)
+	require.Equal(t, input.PutIntegration.S3PrefixLogTypes, output.S3PrefixLogTypes)
+
+	// defer cleanup
+	defer func() {
+		err := deleteIntegration(c, output.IntegrationID)
+		require.NoError(t, err)
+	}()
+
+	// Update
+	upd := models.LambdaInput{
+		UpdateIntegrationSettings: &models.UpdateIntegrationSettingsInput{
+			IntegrationID:        output.IntegrationID,
+			IntegrationLabel:     "source-" + uuid.New().String()[:6],
+			S3Bucket:             "some-bucket-" + uuid.New().String()[:6],
+			S3PrefixLogTypes:     models.S3PrefixLogtypes{{S3Prefix: "prefix", LogTypes: []string{"Custom.LogType2"}}},
+			LogProcessingRoleARN: "arn:aws:iam::region:role/user-provided-role-2",
+		},
+	}
+
+	err = genericapi.Invoke(c, functionName, upd, &output)
+
+	require.NoError(t, err)
+	require.Equal(t, upd.UpdateIntegrationSettings.IntegrationLabel, output.IntegrationLabel)
+	require.Equal(t, upd.UpdateIntegrationSettings.LogProcessingRoleARN, output.LogProcessingRoleARN)
+	require.Equal(t, upd.UpdateIntegrationSettings.S3PrefixLogTypes, output.S3PrefixLogTypes)
+}
+
+func deleteIntegration(c *lambda.Lambda, id string) error {
+	deleteInput := models.LambdaInput{
+		DeleteIntegration: &models.DeleteIntegrationInput{
+			IntegrationID: id,
+		},
+	}
+	return genericapi.Invoke(c, functionName, deleteInput, nil)
 }

--- a/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_client_cache_test.go
@@ -40,12 +40,12 @@ import (
 var (
 	integration = &models.SourceIntegration{
 		SourceIntegrationMetadata: models.SourceIntegrationMetadata{
-			AWSAccountID:      "1234567890123",
-			S3Bucket:          "test-bucket",
-			S3PrefixLogTypes:  models.S3PrefixLogtypes{{S3Prefix: "prefix", LogTypes: []string{"Log.TestType"}}},
-			IntegrationType:   models.IntegrationTypeAWS3,
-			LogProcessingRole: "arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix",
-			IntegrationID:     "3e4b1734-e678-4581-b291-4b8a176219e9",
+			AWSAccountID:         "1234567890123",
+			S3Bucket:             "test-bucket",
+			S3PrefixLogTypes:     models.S3PrefixLogtypes{{S3Prefix: "prefix", LogTypes: []string{"Log.TestType"}}},
+			IntegrationType:      models.IntegrationTypeAWS3,
+			LogProcessingRoleARN: "arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix",
+			IntegrationID:        "3e4b1734-e678-4581-b291-4b8a176219e9",
 		},
 	}
 )
@@ -154,12 +154,12 @@ func TestGetS3ClientSourceNoPrefix(t *testing.T) {
 
 	integration = &models.SourceIntegration{
 		SourceIntegrationMetadata: models.SourceIntegrationMetadata{
-			AWSAccountID:      "1234567890123",
-			S3Bucket:          "test-bucket",
-			LogProcessingRole: "arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix",
-			IntegrationType:   models.IntegrationTypeAWS3,
-			IntegrationID:     "189cddfa-6fd5-419e-8b0e-668105b67dc0",
-			S3PrefixLogTypes:  models.S3PrefixLogtypes{{S3Prefix: "", LogTypes: []string{}}},
+			AWSAccountID:         "1234567890123",
+			S3Bucket:             "test-bucket",
+			LogProcessingRoleARN: "arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix",
+			IntegrationType:      models.IntegrationTypeAWS3,
+			IntegrationID:        "189cddfa-6fd5-419e-8b0e-668105b67dc0",
+			S3PrefixLogTypes:     models.S3PrefixLogtypes{{S3Prefix: "", LogTypes: []string{}}},
 		},
 	}
 

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -128,11 +128,11 @@ func TestHandleUnsupportedFileType(t *testing.T) {
 
 	integration = &models.SourceIntegration{
 		SourceIntegrationMetadata: models.SourceIntegrationMetadata{
-			AWSAccountID:      "1234567890123",
-			S3Bucket:          "mybucket",
-			IntegrationType:   models.IntegrationTypeAWS3,
-			LogProcessingRole: "arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix",
-			IntegrationID:     "3e4b1734-e678-4581-b291-4b8a17621999",
+			AWSAccountID:         "1234567890123",
+			S3Bucket:             "mybucket",
+			IntegrationType:      models.IntegrationTypeAWS3,
+			LogProcessingRoleARN: "arn:aws:iam::123456789012:role/PantherLogProcessingRole-suffix",
+			IntegrationID:        "3e4b1734-e678-4581-b291-4b8a17621999",
 		},
 	}
 

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -119,6 +119,7 @@ export type AddS3LogIntegrationInput = {
   kmsKey?: Maybe<Scalars['String']>;
   s3PrefixLogTypes: Array<S3PrefixLogTypesInput>;
   managedBucketNotifications: Scalars['Boolean'];
+  roleARN: Scalars['String'];
 };
 
 export type AddSqsLogIntegrationInput = {
@@ -551,6 +552,7 @@ export type GetS3LogIntegrationTemplateInput = {
   s3Bucket: Scalars['String'];
   kmsKey?: Maybe<Scalars['String']>;
   managedBucketNotifications: Scalars['Boolean'];
+  roleARN: Scalars['String'];
 };
 
 export type GithubConfig = {
@@ -1621,6 +1623,7 @@ export type UpdateS3LogIntegrationInput = {
   s3Bucket?: Maybe<Scalars['String']>;
   kmsKey?: Maybe<Scalars['String']>;
   s3PrefixLogTypes?: Maybe<Array<S3PrefixLogTypesInput>>;
+  roleARN: Scalars['String'];
 };
 
 export type UpdateSqsLogIntegrationInput = {

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -303,6 +303,7 @@ export const buildAddS3LogIntegrationInput = (
       's3PrefixLogTypes' in overrides ? overrides.s3PrefixLogTypes : [buildS3PrefixLogTypesInput()],
     managedBucketNotifications:
       'managedBucketNotifications' in overrides ? overrides.managedBucketNotifications : false,
+    roleARN: 'roleARN' in overrides ? overrides.roleARN : 'networks',
   };
 };
 
@@ -906,6 +907,7 @@ export const buildGetS3LogIntegrationTemplateInput = (
     kmsKey: 'kmsKey' in overrides ? overrides.kmsKey : 'Books',
     managedBucketNotifications:
       'managedBucketNotifications' in overrides ? overrides.managedBucketNotifications : false,
+    roleARN: 'roleARN' in overrides ? overrides.roleARN : 'e-business',
   };
 };
 
@@ -1976,6 +1978,7 @@ export const buildUpdateS3LogIntegrationInput = (
     kmsKey: 'kmsKey' in overrides ? overrides.kmsKey : 'deposit',
     s3PrefixLogTypes:
       's3PrefixLogTypes' in overrides ? overrides.s3PrefixLogTypes : [buildS3PrefixLogTypesInput()],
+    roleARN: 'roleARN' in overrides ? overrides.roleARN : 'UIC-Franc',
   };
 };
 


### PR DESCRIPTION
## Background

Users must specify the log processing role that Panther will use for reading s3 files

## Changes

- Rename `LogProcessingRole` to `LogProcessingRoleARN`
- Added `roleARN` fied in GraphQL models. It is a required field now for creating/updating an s3 integration

## Testing

- integration tests

