### PR TITLE
Display the Panther-created SNS topic when an s3 source is deleted

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -731,8 +731,7 @@ type S3LogIntegration {
 }
 
 type ManagedS3Resources {
-  topicARN: String
-  topicConfigurationIds: [String!]
+  topicARN: String!
 }
 
 type SqsLogSourceIntegration {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -731,7 +731,7 @@ type S3LogIntegration {
 }
 
 type ManagedS3Resources {
-  topicARN: String!
+  topicARN: String
 }
 
 type SqsLogSourceIntegration {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -727,6 +727,12 @@ type S3LogIntegration {
   notificationsConfigurationSucceeded: Boolean!
   health: S3LogIntegrationHealth!
   stackName: String!
+  managedS3Resources: ManagedS3Resources
+}
+
+type ManagedS3Resources {
+  topicARN: String
+  topicConfigurationIds: [String!]
 }
 
 type SqsLogSourceIntegration {

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -96,7 +96,7 @@ func (api *API) PutIntegration(input *models.PutIntegrationInput) (newIntegratio
 }
 
 func (api *API) handleManagedBucketNotifications(source *models.SourceIntegration) {
-	err := ManageBucketNotifications(api.AwsSession, api.Config.AccountID, api.Config.AWSPartition, source)
+	err := ManageBucketNotifications(api.AwsSession, api.Config.AccountID, api.Config.AWSPartition, api.Config.LogProcessorQueueArn, source)
 	source.NotificationsConfigurationSucceeded = err == nil
 	if err != nil {
 		zap.L().Error("failed to manage bucket notifications", zap.Error(err))

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -821,6 +821,11 @@ export type LongSeriesData = {
   series: Array<LongSeries>;
 };
 
+export type ManagedS3Resources = {
+  __typename?: 'ManagedS3Resources';
+  topicARN: Scalars['String'];
+};
+
 export enum MessageActionEnum {
   Resend = 'RESEND',
   Suppress = 'SUPPRESS',
@@ -1364,6 +1369,7 @@ export type S3LogIntegration = {
   notificationsConfigurationSucceeded: Scalars['Boolean'];
   health: S3LogIntegrationHealth;
   stackName: Scalars['String'];
+  managedS3Resources?: Maybe<ManagedS3Resources>;
 };
 
 export type S3LogIntegrationHealth = {
@@ -1824,6 +1830,7 @@ export type ResolversTypes = {
   S3LogIntegration: ResolverTypeWrapper<S3LogIntegration>;
   S3PrefixLogTypes: ResolverTypeWrapper<S3PrefixLogTypes>;
   S3LogIntegrationHealth: ResolverTypeWrapper<S3LogIntegrationHealth>;
+  ManagedS3Resources: ResolverTypeWrapper<ManagedS3Resources>;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   SqsLogSourceIntegration: ResolverTypeWrapper<SqsLogSourceIntegration>;
   SqsConfig: ResolverTypeWrapper<SqsConfig>;
@@ -2014,6 +2021,7 @@ export type ResolversParentTypes = {
   S3LogIntegration: S3LogIntegration;
   S3PrefixLogTypes: S3PrefixLogTypes;
   S3LogIntegrationHealth: S3LogIntegrationHealth;
+  ManagedS3Resources: ManagedS3Resources;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   SqsLogSourceIntegration: SqsLogSourceIntegration;
   SqsConfig: SqsConfig;
@@ -2753,6 +2761,14 @@ export type LongSeriesDataResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
+export type ManagedS3ResourcesResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ManagedS3Resources'] = ResolversParentTypes['ManagedS3Resources']
+> = {
+  topicARN?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
 export type MsTeamsConfigResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['MsTeamsConfig'] = ResolversParentTypes['MsTeamsConfig']
@@ -3375,6 +3391,11 @@ export type S3LogIntegrationResolvers<
   >;
   health?: Resolver<ResolversTypes['S3LogIntegrationHealth'], ParentType, ContextType>;
   stackName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  managedS3Resources?: Resolver<
+    Maybe<ResolversTypes['ManagedS3Resources']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -3708,6 +3729,7 @@ export type Resolvers<ContextType = any> = {
   Long?: GraphQLScalarType;
   LongSeries?: LongSeriesResolvers<ContextType>;
   LongSeriesData?: LongSeriesDataResolvers<ContextType>;
+  ManagedS3Resources?: ManagedS3ResourcesResolvers<ContextType>;
   MsTeamsConfig?: MsTeamsConfigResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OpsgenieConfig?: OpsgenieConfigResolvers<ContextType>;

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -823,7 +823,7 @@ export type LongSeriesData = {
 
 export type ManagedS3Resources = {
   __typename?: 'ManagedS3Resources';
-  topicARN: Scalars['String'];
+  topicARN?: Maybe<Scalars['String']>;
 };
 
 export enum MessageActionEnum {
@@ -2765,7 +2765,7 @@ export type ManagedS3ResourcesResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['ManagedS3Resources'] = ResolversParentTypes['ManagedS3Resources']
 > = {
-  topicARN?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  topicARN?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -100,6 +100,7 @@ import {
   LogAnalysisMetricsResponse,
   LongSeries,
   LongSeriesData,
+  ManagedS3Resources,
   ModifyGlobalPythonModuleInput,
   MsTeamsConfig,
   MsTeamsConfigInput,
@@ -1231,6 +1232,15 @@ export const buildLongSeriesData = (overrides: Partial<LongSeriesData> = {}): Lo
   };
 };
 
+export const buildManagedS3Resources = (
+  overrides: Partial<ManagedS3Resources> = {}
+): ManagedS3Resources => {
+  return {
+    __typename: 'ManagedS3Resources',
+    topicARN: 'topicARN' in overrides ? overrides.topicARN : 'Horizontal',
+  };
+};
+
 export const buildModifyGlobalPythonModuleInput = (
   overrides: Partial<ModifyGlobalPythonModuleInput> = {}
 ): ModifyGlobalPythonModuleInput => {
@@ -1564,6 +1574,8 @@ export const buildS3LogIntegration = (
         : true,
     health: 'health' in overrides ? overrides.health : buildS3LogIntegrationHealth(),
     stackName: 'stackName' in overrides ? overrides.stackName : 'River',
+    managedS3Resources:
+      'managedS3Resources' in overrides ? overrides.managedS3Resources : buildManagedS3Resources(),
   };
 };
 

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -44,6 +44,7 @@ export type S3LogIntegrationDetails = Pick<
     kmsKeyStatus: IntegrationItemHealthDetails;
     getObjectStatus?: Types.Maybe<IntegrationItemHealthDetails>;
   };
+  managedS3Resources?: Types.Maybe<Pick<Types.ManagedS3Resources, 'topicARN'>>;
 };
 
 export const S3LogIntegrationDetails = gql`
@@ -77,6 +78,9 @@ export const S3LogIntegrationDetails = gql`
       getObjectStatus {
         ...IntegrationItemHealthDetails
       }
+    }
+    managedS3Resources {
+      topicARN
     }
   }
   ${IntegrationItemHealthDetails}

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
@@ -29,4 +29,7 @@ fragment S3LogIntegrationDetails on S3LogIntegration {
       ...IntegrationItemHealthDetails
     }
   }
+  managedS3Resources {
+    topicARN
+  }
 }

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
@@ -46,6 +46,9 @@ const LogSourceCardOptions: React.FC<LogSourceCardOptionsProps> = ({ source }) =
     default:
       castedSource = source as S3LogIntegration;
       description = `Deleting this source will not delete the associated Cloudformation stack. You will need to manually delete the stack ${castedSource.stackName} from the AWS Account ${castedSource.awsAccountId}`;
+      if (castedSource.managedS3Resources?.topicARN) {
+        description += `. The SNS topic created by Panther will also be kept (${castedSource.managedS3Resources.topicARN})`;
+      }
       logSourceEditUrl = urls.logAnalysis.sources.edit(source.integrationId, 's3');
   }
 


### PR DESCRIPTION
## Background

If user opted for Panther-managed bucket notifications, Panther may also create an SNS topic on the user's AWS account.
When user deletes the source, Panther does not delete the topic (it may be re-used). This PR

## Changes

-  Display the Panther-created SNS topic when an s3 source is deleted
- A small backend refactoring (get Panther queue ARN from api Config)  (by @giorgosp)

## Testing

- Manually

## Screenshot
<img width="864" alt="Screenshot 2021-02-15 at 10 52 27" src="https://user-images.githubusercontent.com/3627869/107924981-7a18b700-6f7c-11eb-8ef8-7c65574a94ac.png">
