### PR TITLE
Add default value for PythonManagedPolicyArn

### DIFF
--- a/deployments/root.yml
+++ b/deployments/root.yml
@@ -178,6 +178,7 @@ Parameters:
   PythonManagedPolicyArn:
     Type: String
     Description: Managed IAM policy which will be attached to the Python rules-engine and policy-engine
+    Default: ''
     AllowedPattern: '^(arn:(aws|aws-cn|aws-us-gov):iam::(\d{12}|aws):policy\/\S+)?$'
   SecurityGroupID:
     Type: String


### PR DESCRIPTION
## Background

`mage master:deploy` failed with:

> 17:00:11	INFO	[deploy]	create CloudFormation stack panther
Error: failed to create change set for stack panther: ValidationError: Parameters: [PythonManagedPolicyArn] must have values

https://github.com/panther-labs/panther/pull/2647 added 2 new root stack parameters, but forgot to set an empty default value for one of them

## Changes

- Add default value

## Testing

- `mage master:deploy` (in progress)
