### PR TITLE
String join the role arns list to fix root stack

### DIFF
--- a/deployments/root.yml
+++ b/deployments/root.yml
@@ -348,7 +348,7 @@ Resources:
         LayerVersionArns: !Join [',', !Ref LayerVersionArns]
         ProcessedDataBucket: !GetAtt Bootstrap.Outputs.ProcessedDataBucket
         ProcessedDataTopicArn: !GetAtt Bootstrap.Outputs.ProcessedDataTopicArn
-        PythonAssumableRoleArns: !Ref PythonAssumableRoleArns
+        PythonAssumableRoleArns: !Join [',', !Ref PythonAssumableRoleArns]
         PythonLayerVersionArn: !GetAtt BootstrapGateway.Outputs.PythonLayerVersionArn
         PythonManagedPolicyArn: !Ref PythonManagedPolicyArn
         SqsKeyId: !GetAtt Bootstrap.Outputs.QueueEncryptionKeyId
@@ -439,7 +439,7 @@ Resources:
         LogProcessorLambdaSQSReadBatchSize: !Ref LogProcessorLambdaSQSReadBatchSize
         ProcessedDataBucket: !GetAtt Bootstrap.Outputs.ProcessedDataBucket
         ProcessedDataTopicArn: !GetAtt Bootstrap.Outputs.ProcessedDataTopicArn
-        PythonAssumableRoleArns: !Ref PythonAssumableRoleArns
+        PythonAssumableRoleArns: !Join [',', !Ref PythonAssumableRoleArns]
         PythonLayerVersionArn: !GetAtt BootstrapGateway.Outputs.PythonLayerVersionArn
         PythonManagedPolicyArn: !Ref PythonManagedPolicyArn
         SqsKeyId: !GetAtt Bootstrap.Outputs.QueueEncryptionKeyId


### PR DESCRIPTION
## Background

#2647 introduced a new root stack parameter which is a CommaDelimitedList. That broke root-stack deployment (`mage master:deploy`)

> 18:04:58	ERROR	[deploy]	stack panther: AWS::CloudFormation::Stack LogAnalysis CREATE_FAILED: Value of property Parameters must be an object with String (or simple type) properties
18:04:59	ERROR	[deploy]	stack panther: AWS::CloudFormation::Stack CloudSecurity CREATE_FAILED: Value of property Parameters must be an object with String (or simple type) properties
Error: UPDATE_ROLLBACK_IN_PROGRESS

The CommaDelimitedList is a very awkward type in CloudFormation: it is passed as a string, but referenced as a list. When you pass it to another stack, then, you have to flatten it back to a string.

## Changes

- Flatten `AssumableRoleArns` to a string before passing to cloud-security and log-analysis stacks

## Testing

- `mage master:deploy` (in progress)
