### PR TITLE
Rule Engine: case-insensitive lookup for event fields

### DIFF
--- a/internal/log_analysis/rules_engine/src/enriched_event.py
+++ b/internal/log_analysis/rules_engine/src/enriched_event.py
@@ -18,10 +18,10 @@ from collections.abc import Mapping
 from typing import Any, Optional
 
 from .data_model import DataModel
-from .immutable import ImmutableDict, json_encoder
+from .immutable import ImmutableCaseInsensitiveDict, json_encoder
 
 
-class PantherEvent(ImmutableDict):  # pylint: disable=R0901
+class PantherEvent(ImmutableCaseInsensitiveDict):  # pylint: disable=R0901
     """Panther enriched event with unified data model (udm) access."""
 
     def __init__(self, event: Mapping, data_model: Optional[DataModel]):

--- a/internal/log_analysis/rules_engine/tests/test_engine.py
+++ b/internal/log_analysis/rules_engine/tests/test_engine.py
@@ -294,13 +294,13 @@ class TestEngine(TestCase):
                 rule_version='version',
                 log_type='log',
                 dedup='TypeError',
-                error_message='\'ImmutableDict\' object does not support item assignment: rule_id_1.py, '
+                error_message='\'ImmutableCaseInsensitiveDict\' object does not support item assignment: rule_id_1.py, '
                 'line 2, in rule    event["key"]["nested_key"] = "not_value"',
                 event={'key': {
                     'nested_key': 'value'
                 }},
                 dedup_period_mins=60,
-                title='TypeError("\'ImmutableDict\' object does not support item assignment")'
+                title='TypeError("\'ImmutableCaseInsensitiveDict\' object does not support item assignment")'
             )
         ]
 

--- a/internal/log_analysis/rules_engine/tests/test_enriched_event.py
+++ b/internal/log_analysis/rules_engine/tests/test_enriched_event.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 
 from ..src.data_model import DataModel
 from ..src.enriched_event import PantherEvent
-from ..src.immutable import ImmutableList, ImmutableDict
+from ..src.immutable import ImmutableList, ImmutableCaseInsensitiveDict
 
 
 class TestEnrichedEvent(TestCase):
@@ -195,12 +195,12 @@ class TestEnrichedEvent(TestCase):
         with self.assertRaises(TypeError):
             # pylint: disable=E1137
             enriched_event['dst'] = 1  # type: ignore
-        self.assertIsInstance(enriched_event['dst'], ImmutableDict)
+        self.assertIsInstance(enriched_event['dst'], ImmutableCaseInsensitiveDict)
         with self.assertRaises(TypeError):
             # pylint: disable=E1137
             enriched_event['dst']['ip'] = 1
         self.assertIsInstance(enriched_event['extra'], ImmutableList)
-        self.assertIsInstance(enriched_event['extra'][0], ImmutableDict)
+        self.assertIsInstance(enriched_event['extra'][0], ImmutableCaseInsensitiveDict)
 
     def test_assignment_not_allowed_on_udm_access(self) -> None:
         event = {'dst_ip': '1.1.1.1', 'dst_port': '2222', 'extra': {'timestamp': 1, 'array': [1, 2]}}
@@ -218,8 +218,8 @@ class TestEnrichedEvent(TestCase):
             }
         )
         enriched_event = PantherEvent(event, data_model)
-        self.assertEqual(ImmutableDict(event['extra']), enriched_event.udm('extra_fields'))
-        self.assertIsInstance(enriched_event.udm('extra_fields'), ImmutableDict)
+        self.assertEqual(ImmutableCaseInsensitiveDict(event['extra']), enriched_event.udm('extra_fields'))
+        self.assertIsInstance(enriched_event.udm('extra_fields'), ImmutableCaseInsensitiveDict)
         self.assertIsInstance(enriched_event.udm('extra_fields')['array'], ImmutableList)
         with self.assertRaises(TypeError):
             enriched_event.udm('extra_fields')['timestamp'] = 10
@@ -228,4 +228,4 @@ class TestEnrichedEvent(TestCase):
         event = {'headers': [{'User-Agent': 'Chrome', 'Host': 'google.com'}]}
         enriched_event = PantherEvent(event, None)
         self.assertIsInstance(enriched_event['headers'], ImmutableList)
-        self.assertIsInstance(enriched_event['headers'][0], ImmutableDict)
+        self.assertIsInstance(enriched_event['headers'][0], ImmutableCaseInsensitiveDict)


### PR DESCRIPTION
## Background

Apart from making it easier for rule authors to write fields without recalling the exact case-sensitive field name, changes in case should not affect rules. In addition, Athena columns are lowercase.  

`PantherEvent` and its nested objects will now allow case-insensitive lookup.

> Unit tests (via `panther_analysis_tool`) will require using all-lowercase field names for the time being.

## Changes

- Define a mapping from lowercase key name to the original key name.
- Perform a case-sensitive search initially and fall back to case-insensitive lookup through the case-insensitive key mapping. 
- Note that the original field names will still be available.

## Testing

- `mage test:python`
- End-to-end test:
  - Deploy this branch.
  - Edit `/detections/rules/GCP.GCS.IAMChanges/edit/?section=functions`
     ```python
      def rule(event):
          return (event['resource'].get('type') == 'gcs_bucket' and
              event['protopayload'].get('methodname')
            == 'storage.setIamPermissions')
    ```
  - Run tests, still passing.