### PR TITLE
[FE] Move sources to `Integrations` menu entry

### DIFF
--- a/web/src/components/Navigation/Navigation.test.tsx
+++ b/web/src/components/Navigation/Navigation.test.tsx
@@ -52,13 +52,17 @@ describe('Navigation', () => {
     // Expand
     fireEvent.click(getByText('Log Analysis'));
     expect(getByText('Overview')).toBeInTheDocument();
-    expect(getByText('Sources')).toBeInTheDocument();
 
-    expect(getByText('Cloud Security')).toBeInTheDocument();
-
+    // Expand
     fireEvent.click(getByText('Cloud Security'));
     expect(getByText('Resources')).toBeInTheDocument();
     expect(getByText('Settings')).toBeInTheDocument();
+
+    // Expand
+    fireEvent.click(getByText('Integrations'));
+    expect(getByText('Log Sources')).toBeInTheDocument();
+    expect(getByText('Cloud Accounts')).toBeInTheDocument();
+    expect(getByText('Alert Destinations')).toBeInTheDocument();
 
     fireEvent.click(getByText('Settings'));
     expect(getByText('General')).toBeInTheDocument();

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -32,10 +32,12 @@ import {
   ComplianceNavigation,
   LogAnalysisNavigation,
   AnalysisNavigationLinks,
+  IntegrationsNavigation,
 } from './SecondaryNavigations';
 
 const COMPLIANCE_NAV_KEY = 'compliance';
 const LOG_ANALYSIS_NAV_KEY = 'logAnalysis';
+const INTEGRATIONS_NAV_KEY = 'integrations';
 const SETTINGS_NAV_KEY = 'settings';
 
 export type NavigationLinks = {
@@ -44,7 +46,11 @@ export type NavigationLinks = {
   label: string;
 };
 
-type NavKeys = typeof COMPLIANCE_NAV_KEY | typeof LOG_ANALYSIS_NAV_KEY | typeof SETTINGS_NAV_KEY;
+type NavKeys =
+  | typeof COMPLIANCE_NAV_KEY
+  | typeof LOG_ANALYSIS_NAV_KEY
+  | typeof SETTINGS_NAV_KEY
+  | typeof INTEGRATIONS_NAV_KEY;
 
 const Navigation = () => {
   const {
@@ -62,12 +68,16 @@ const Navigation = () => {
       pathname.includes(navLinks.to)
     );
     const isSettingsPage = pathname.includes(urls.settings.home());
+    const isIntegrationsPage = pathname.includes(urls.integrations.home());
 
     if (isCompliancePage) {
       return COMPLIANCE_NAV_KEY;
     }
     if (isUnderAnalysisNav) {
       return LOG_ANALYSIS_NAV_KEY;
+    }
+    if (isIntegrationsPage) {
+      return INTEGRATIONS_NAV_KEY;
     }
     if (isSettingsPage) {
       return SETTINGS_NAV_KEY;
@@ -83,6 +93,7 @@ const Navigation = () => {
 
   const isComplianceNavigationActive = secondaryNav === COMPLIANCE_NAV_KEY;
   const isLogAnalysisNavigationActive = secondaryNav === LOG_ANALYSIS_NAV_KEY;
+  const isIntegrationsNavigationActive = secondaryNav === INTEGRATIONS_NAV_KEY;
   const isSettingsNavigationActive = secondaryNav === SETTINGS_NAV_KEY;
 
   return (
@@ -146,6 +157,18 @@ const Navigation = () => {
               }
             >
               <ComplianceNavigation />
+            </NavGroup>
+          </Box>
+          <Box as="li" mb={2}>
+            <NavGroup
+              active={isIntegrationsNavigationActive}
+              icon="integrations"
+              label="Integrations"
+              onSelect={() =>
+                setSecondaryNav(isIntegrationsNavigationActive ? null : INTEGRATIONS_NAV_KEY)
+              }
+            >
+              <IntegrationsNavigation />
             </NavGroup>
           </Box>
           <Box as="li" mb={2}>

--- a/web/src/components/Navigation/SecondaryNavigations/ComplianceNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/ComplianceNavigation.tsx
@@ -38,12 +38,6 @@ const ComplianceNavigation: React.FC = () => {
           to={urls.compliance.resources.list()}
           label="Resources"
         />
-        <NavLink
-          isSecondary
-          icon="infra-source"
-          to={urls.compliance.sources.list()}
-          label="Sources"
-        />
       </FadeInTrail>
     </Flex>
   );

--- a/web/src/components/Navigation/SecondaryNavigations/IntegrationsNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/IntegrationsNavigation.tsx
@@ -17,24 +17,36 @@
  */
 
 import React from 'react';
-import { Box, Flex, Heading, Text } from 'pouncejs';
-import BlankCanvasImg from 'Assets/illustrations/blank-canvas.svg';
+import { Flex } from 'pouncejs';
+import FadeInTrail from 'Components/utils/FadeInTrail';
 import urls from 'Source/urls';
-import LinkButton from 'Components/buttons/LinkButton';
+import NavLink from '../NavLink';
 
-const ListResourcesPageEmptyDataFallback: React.FC = () => {
+const IntegrationsNavigation: React.FC = () => {
   return (
-    <Flex justify="center" align="center" direction="column">
-      <Box my={10}>
-        <img alt="Black Canvas Illustration" src={BlankCanvasImg} width="auto" height={300} />
-      </Box>
-      <Heading mb={6}>No resources found</Heading>
-      <Text color="gray-300" textAlign="center" mb={8}>
-        You don{"'"}t have any resources connected to your Panther account
-      </Text>
-      <LinkButton to={urls.integrations.cloudAccounts.create()}>Get started</LinkButton>
+    <Flex direction="column" as="ul">
+      <FadeInTrail as="li">
+        <NavLink
+          isSecondary
+          icon="log-source"
+          to={urls.integrations.logSources.list()}
+          label="Log Sources"
+        />
+        <NavLink
+          isSecondary
+          icon="cloud-security"
+          to={urls.integrations.cloudAccounts.list()}
+          label="Cloud Accounts"
+        />
+        <NavLink
+          isSecondary
+          icon="output"
+          to={urls.integrations.destinations.list()}
+          label="Alert Destinations"
+        />
+      </FadeInTrail>
     </Flex>
   );
 };
 
-export default ListResourcesPageEmptyDataFallback;
+export default React.memo(IntegrationsNavigation);

--- a/web/src/components/Navigation/SecondaryNavigations/LogAnalysisNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/LogAnalysisNavigation.tsx
@@ -35,11 +35,6 @@ export const analysisNavigationsLinks: NavigationLinks[] = [
     label: 'Overview',
   },
   {
-    to: urls.logAnalysis.sources.list(),
-    icon: 'log-source',
-    label: 'Sources',
-  },
-  {
     to: urls.logAnalysis.customLogs.list(),
     icon: 'source-code',
     label: 'Custom Schemas',

--- a/web/src/components/Navigation/SecondaryNavigations/SettingsNavigation.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/SettingsNavigation.tsx
@@ -30,12 +30,6 @@ const SettingsNavigation: React.FC = () => {
         <NavLink isSecondary icon="organization" to={urls.settings.users()} label="Users" />
         <NavLink
           isSecondary
-          icon="output"
-          to={urls.settings.destinations.list()}
-          label="Destinations"
-        />
-        <NavLink
-          isSecondary
           icon="source-code"
           to={urls.settings.globalPythonModules.list()}
           label="Global Modules"

--- a/web/src/components/Navigation/SecondaryNavigations/index.tsx
+++ b/web/src/components/Navigation/SecondaryNavigations/index.tsx
@@ -18,5 +18,6 @@
 
 export { default as ComplianceNavigation } from './ComplianceNavigation';
 export { default as LogAnalysisNavigation } from './LogAnalysisNavigation';
+export { default as IntegrationsNavigation } from './IntegrationsNavigation';
 export { default as SettingsNavigation } from './SettingsNavigation';
 export { analysisNavigationsLinks as AnalysisNavigationLinks } from './LogAnalysisNavigation';

--- a/web/src/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/web/src/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Navigation renders with active links 1`] = `
-.panther-48 {
+.panther-54 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,7 +15,7 @@ exports[`Navigation renders with active links 1`] = `
   background-color: #141c2a;
 }
 
-.panther-47 {
+.panther-53 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -40,7 +40,7 @@ exports[`Navigation renders with active links 1`] = `
   display: block;
 }
 
-.panther-41 {
+.panther-47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -204,11 +204,11 @@ exports[`Navigation renders with active links 1`] = `
   margin-left: auto;
 }
 
-.panther-35 {
+.panther-41 {
   margin-top: auto;
 }
 
-.panther-34 {
+.panther-40 {
   -webkit-transition: color 0.1s ease-out;
   transition: color 0.1s ease-out;
   font-weight: 500;
@@ -217,20 +217,20 @@ exports[`Navigation renders with active links 1`] = `
   color: #7fd3ff;
 }
 
-.panther-34:hover {
+.panther-40:hover {
   color: #ace2ff;
 }
 
-.panther-34:focus {
+.panther-40:focus {
   color: #ace2ff;
 }
 
-.panther-34:active,
-.panther-34[data-active=true] {
+.panther-40:active,
+.panther-40[data-active=true] {
   color: #11a5f3;
 }
 
-.panther-33 {
+.panther-39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -249,18 +249,18 @@ exports[`Navigation renders with active links 1`] = `
   color: #f6f6f6;
 }
 
-.panther-33:hover {
+.panther-39:hover {
   color: #f6f6f6;
   background-color: #1d2a3f;
 }
 
-.panther-46 {
+.panther-52 {
   padding: 16px;
   background-color: #0f1623;
   margin-top: 16px;
 }
 
-.panther-45 {
+.panther-51 {
   width: 100%;
   cursor: pointer;
   color: #f6f6f6;
@@ -271,7 +271,7 @@ exports[`Navigation renders with active links 1`] = `
   transition: all 0.1s linear;
 }
 
-.panther-44 {
+.panther-50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -282,11 +282,11 @@ exports[`Navigation renders with active links 1`] = `
   align-items: center;
 }
 
-.panther-44>*:not(:last-child) {
+.panther-50>*:not(:last-child) {
   margin-right: 8px;
 }
 
-.panther-42 {
+.panther-48 {
   width: 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -312,11 +312,11 @@ exports[`Navigation renders with active links 1`] = `
   flex-shrink: 0;
 }
 
-.panther-42:hover {
+.panther-48:hover {
   background-color: #7268a6;
 }
 
-.panther-43 {
+.panther-49 {
   font-weight: 700;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -328,11 +328,11 @@ exports[`Navigation renders with active links 1`] = `
     id="main-header"
   />
   <aside
-    class="panther-48"
+    class="panther-54"
   >
     <nav
       aria-label="Main"
-      class="panther-47"
+      class="panther-53"
     >
       <a
         class="panther-1"
@@ -347,7 +347,7 @@ exports[`Navigation renders with active links 1`] = `
         />
       </a>
       <ul
-        class="panther-41"
+        class="panther-47"
       >
         <hr
           aria-orientation="horizontal"
@@ -515,6 +515,47 @@ exports[`Navigation renders with active links 1`] = `
                 viewBox="0 0 24 24"
               >
                 <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M22.392 16.342v2l-.005.2a4 4 0 01-3.995 3.8H7.437v-2h10.955l.149-.006a2 2 0 001.85-1.994v-2h2zM4.608 7.547h2v1.668a2 2 0 001.856 1.99l.15.005 8.01-.02-1.91-1.911 1.414-1.415 4.243 4.243-4.243 4.243-1.414-1.415 1.745-1.746-1.36.004v.038l-9.486-.025-.149.005a2 2 0 00-1.85 1.833l-.006.157v.667l-2 .001v-.673l.006-.2a4.001 4.001 0 013.543-3.765 3.96 3.96 0 01-.544-1.811l-.005-.2V7.547zm13.784-5.889a4 4 0 013.995 3.8l.005.2v2h-2v-2a2 2 0 00-1.851-1.994l-.15-.006H7.438v-2h10.955z"
+                  fill="#FFF"
+                />
+              </svg>
+              <div
+                class="panther-4"
+              >
+                Integrations
+              </div>
+              <svg
+                class="panther-15"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7.41 8.58997L12 13.17L16.59 8.58997L18 9.99997L12 16L6 9.99997L7.41 8.58997Z"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="panther-7"
+        >
+          <div
+            class="panther-17"
+          >
+            <button
+              class="panther-16"
+              type="button"
+            >
+              <svg
+                class="panther-3"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
                   d="M14.077 1c.674 0 1.253.468 1.393 1.102l.022.13.324 2.298.198.1c.149.078.295.162.44.25l.214.135.189.128 2.137-.87a1.44 1.44 0 011.604.423l.076.103.067.112 2.084 3.667a1.458 1.458 0 01-.257 1.733l-.105.092-1.795 1.427.014.192.01.219.003.217-.003.218-.01.219-.014.19 1.799 1.431c.474.38.643 1.009.458 1.583l-.05.13-.06.13-2.063 3.627a1.419 1.419 0 01-1.659.692l-.128-.045-2.112-.862-.205.14c-.143.092-.287.18-.432.263l-.219.12-.18.09-.322 2.285a1.423 1.423 0 01-1.154 1.223l-.13.019-.134.006H9.93a1.425 1.425 0 01-1.393-1.103l-.022-.129-.325-2.3-.197-.098a8.351 8.351 0 01-.44-.25l-.215-.136-.189-.129-2.136.873a1.44 1.44 0 01-1.604-.424l-.076-.103-.067-.112-2.084-3.667a1.458 1.458 0 01.257-1.733l.105-.093 1.794-1.428-.019-.302-.004-.11-.003-.215.003-.215.01-.22.013-.193L1.54 10.4a1.443 1.443 0 01-.46-1.597l.048-.12.065-.125 2.062-3.627a1.419 1.419 0 011.658-.692l.129.044 2.11.862.207-.139c.143-.092.287-.18.432-.263l.219-.12.18-.091.322-2.284a1.423 1.423 0 011.154-1.224l.13-.018L9.93 1h4.147zm-.352 1.833h-3.444l-.418 2.965L9.381 6a6.707 6.707 0 00-1.29.727l-.259.189-.417.318-2.727-1.114-1.739 3.06 2.325 1.848-.063.51a7.521 7.521 0 00-.066.921c0 .218.015.45.043.716l.086.715-2.326 1.85 1.74 3.058 2.734-1.116.42.328c.405.317.827.58 1.27.79l.269.119.482.2.418 2.965h3.444l.419-2.964.482-.201a6.707 6.707 0 001.29-.727l.259-.19.417-.317 2.726 1.113 1.74-3.059-2.325-1.849.063-.51c.044-.362.065-.642.065-.92 0-.224-.013-.448-.041-.714l-.024-.208-.063-.51 2.325-1.85-1.739-3.058-2.734 1.117-.42-.328a6.719 6.719 0 00-1.27-.79L14.626 6l-.482-.2-.419-2.966zm-1.724 5.5A3.67 3.67 0 0115.668 12 3.67 3.67 0 0112 15.667 3.67 3.67 0 018.335 12 3.67 3.67 0 0112 8.333zm0 1.834c-1.01 0-1.833.823-1.833 1.833s.823 1.833 1.833 1.833 1.834-.823 1.834-1.833-.824-1.833-1.834-1.833z"
                 />
               </svg>
@@ -536,16 +577,16 @@ exports[`Navigation renders with active links 1`] = `
           </div>
         </li>
         <li
-          class="panther-35"
+          class="panther-41"
         >
           <a
-            class="panther-34"
+            class="panther-40"
             href="https://docs.runpanther.io/v/release-1.2"
             rel="noopener noreferrer"
             target="_blank"
           >
             <div
-              class="panther-33"
+              class="panther-39"
             >
               <svg
                 class="panther-3"
@@ -593,24 +634,24 @@ exports[`Navigation renders with active links 1`] = `
         </li>
       </ul>
       <div
-        class="panther-46"
+        class="panther-52"
       >
         <button
           aria-describedby="1"
           aria-label="Toggle User Menu"
-          class="panther-45"
+          class="panther-51"
           type="button"
         >
           <div
-            class="panther-44"
+            class="panther-50"
           >
             <div
-              class="panther-42"
+              class="panther-48"
             >
               TT
             </div>
             <div
-              class="panther-43"
+              class="panther-49"
             >
               T. TestSurname
             </div>

--- a/web/src/components/RelatedDestinations/RelatedDestinations.tsx
+++ b/web/src/components/RelatedDestinations/RelatedDestinations.tsx
@@ -80,7 +80,7 @@ const RelatedDestinations: React.FC<RelatedDestinationsSectionProps> = ({
   // If component is verbose, we should render all destinations as row with the name of destination displayed
   if (verbose) {
     return (
-      <RRLink to={urls.settings.destinations.list()}>
+      <RRLink to={urls.integrations.destinations.list()}>
         <Flex inline direction="column" spacing={2}>
           <LimitItemDisplay limit={limit}>
             {sortedDestinations.map(destination => (

--- a/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
+++ b/web/src/components/forms/BaseDestinationForm/BaseDestinationForm.tsx
@@ -139,7 +139,7 @@ function BaseDestinationForm<AdditionalValues extends Partial<DestinationConfigI
                 variantColor="darkgray"
                 icon="close-outline"
                 aria-label="Cancel destination editing"
-                to={urls.settings.destinations.list()}
+                to={urls.integrations.destinations.list()}
               >
                 Cancel
               </LinkButton>

--- a/web/src/components/forms/PolicyForm/PolicyFormCoreSection/PolicyFormCoreSection.tsx
+++ b/web/src/components/forms/PolicyForm/PolicyFormCoreSection/PolicyFormCoreSection.tsx
@@ -67,7 +67,7 @@ const PolicyFormCoreSection: React.FC = () => {
       return (
         <FormHelperText id="outputIds-description" mt={2} mr={1}>
           You have not configured any destinations, create one
-          <Link ml={1} as={RRLink} to={urls.settings.destinations.create()}>
+          <Link ml={1} as={RRLink} to={urls.integrations.destinations.create()}>
             here
           </Link>
         </FormHelperText>

--- a/web/src/components/forms/RuleForm/RuleFormCoreSection/RuleFormCoreSection.tsx
+++ b/web/src/components/forms/RuleForm/RuleFormCoreSection/RuleFormCoreSection.tsx
@@ -83,7 +83,7 @@ const RuleFormCoreSection: React.FC = () => {
       return (
         <FormHelperText id="outputIds-description" mt={2} mr={1}>
           You have not configured any destinations, create one
-          <Link ml={1} as={RRLink} to={urls.settings.destinations.create()}>
+          <Link ml={1} as={RRLink} to={urls.integrations.destinations.create()}>
             here
           </Link>
         </FormHelperText>

--- a/web/src/components/wizards/ComplianceSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/ComplianceSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -146,7 +146,7 @@ const ValidationPanel: React.FC = () => {
         />
         <WizardPanel.Actions>
           <Flex direction="column" spacing={4}>
-            <LinkButton to={urls.compliance.sources.list()}>Finish Setup</LinkButton>
+            <LinkButton to={urls.integrations.cloudAccounts.list()}>Finish Setup</LinkButton>
             {!initialValues.integrationId && (
               <Link
                 as={AbstractButton}

--- a/web/src/components/wizards/S3LogSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/S3LogSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -187,7 +187,7 @@ const ValidationPanel: React.FC = () => {
         />
         <WizardPanel.Actions>
           <Flex direction="column" spacing={4}>
-            <LinkButton to={urls.logAnalysis.sources.list()}>Finish Setup</LinkButton>
+            <LinkButton to={urls.integrations.logSources.list()}>Finish Setup</LinkButton>
             {!initialValues.integrationId && (
               <Link
                 as={AbstractButton}

--- a/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
+++ b/web/src/components/wizards/SqsSourceWizard/ValidationPanel/ValidationPanel.tsx
@@ -92,7 +92,7 @@ const ValidationPanel: React.FC = () => {
           </AbstractButton>
           <WizardPanel.Actions>
             <Flex direction="column" spacing={4}>
-              <LinkButton to={urls.logAnalysis.sources.list()}>Finish Setup</LinkButton>
+              <LinkButton to={urls.integrations.logSources.list()}>Finish Setup</LinkButton>
               {!initialValues.integrationId && (
                 <Link
                   as={AbstractButton}

--- a/web/src/components/wizards/common/DestinationTestPanel/DestinationTestPanel.tsx
+++ b/web/src/components/wizards/common/DestinationTestPanel/DestinationTestPanel.tsx
@@ -124,12 +124,12 @@ const DestinationTestPanel: React.FC = () => {
             If you don{"'"}t feel like it right now, you can always change the configuration later
           </Text>
           <LinkButton
-            to={urls.settings.destinations.edit(destination.outputId)}
+            to={urls.integrations.destinations.edit(destination.outputId)}
             onClick={goToPrevStep}
           >
             Back to Configuration
           </LinkButton>
-          <Link as={RRLink} variant="discreet" to={urls.settings.destinations.list()}>
+          <Link as={RRLink} variant="discreet" to={urls.integrations.destinations.list()}>
             Skip Testing
           </Link>
         </Flex>
@@ -153,7 +153,7 @@ const DestinationTestPanel: React.FC = () => {
             src={NotificationStatus}
           />
           <Text>Signed, sealed, and delivered. You are good to go!</Text>
-          <LinkButton to={urls.settings.destinations.list()}>Finish Setup</LinkButton>
+          <LinkButton to={urls.integrations.destinations.list()}>Finish Setup</LinkButton>
           <Link as={AbstractButton} variant="discreet" onClick={reset}>
             Add Another
           </Link>
@@ -176,7 +176,7 @@ const DestinationTestPanel: React.FC = () => {
             Send Test Alert
           </Button>
         </Box>
-        <Link as={RRLink} variant="discreet" to={urls.settings.destinations.list()}>
+        <Link as={RRLink} variant="discreet" to={urls.integrations.destinations.list()}>
           Finish Setup
         </Link>
       </Flex>

--- a/web/src/components/wizards/common/DestinationTestPanel/__snapshots__/DestinationTestPanel.test.tsx.snap
+++ b/web/src/components/wizards/common/DestinationTestPanel/__snapshots__/DestinationTestPanel.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`DestinationTestPanel should show a success message for successful test-
               </div>
               <a
                 class="panther-11"
-                href="/settings/destinations/"
+                href="/integrations/destinations/"
               >
                 Finish Setup
               </a>
@@ -554,7 +554,7 @@ exports[`DestinationTestPanel should show a success message for successful test-
               </p>
               <a
                 class="panther-10"
-                href="/settings/destinations/"
+                href="/integrations/destinations/"
               >
                 <span
                   class="panther-9"
@@ -921,7 +921,7 @@ exports[`DestinationTestPanel should show error details for a failing test-alert
               </p>
               <a
                 class="panther-21"
-                href="/settings/destinations/8c0eb672-b7bb-4ef0-9d96-a2bc1abe94d7/edit/"
+                href="/integrations/destinations/8c0eb672-b7bb-4ef0-9d96-a2bc1abe94d7/edit/"
               >
                 <span
                   class="panther-20"
@@ -932,7 +932,7 @@ exports[`DestinationTestPanel should show error details for a failing test-alert
               </a>
               <a
                 class="panther-22"
-                href="/settings/destinations/"
+                href="/integrations/destinations/"
               >
                 Skip Testing
               </a>

--- a/web/src/pages/ComplianceOverview/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ComplianceOverview/EmptyDataFallback/EmptyDataFallback.tsx
@@ -33,7 +33,7 @@ const ComplianceEmptyDataFallback: React.FC = () => (
         You don{"'"}t seem to have any Cloud Security sources connected to our system. <br />
         When you do, a high level overview of your system{"'"}s health will appear here.
       </Text>
-      <LinkButton to={urls.compliance.sources.create()}>Add your first source</LinkButton>
+      <LinkButton to={urls.integrations.cloudAccounts.create()}>Add your first source</LinkButton>
     </Flex>
   </FadeIn>
 );

--- a/web/src/pages/CreateDestination/CreateDestination.test.tsx
+++ b/web/src/pages/CreateDestination/CreateDestination.test.tsx
@@ -137,7 +137,10 @@ describe('CreateDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a Github destination', async () => {
@@ -187,7 +190,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a Jira destination', async () => {
@@ -253,7 +259,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a PagerDuty destination', async () => {
@@ -302,7 +311,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a SQS destination', async () => {
@@ -350,7 +362,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a SNS destination', async () => {
@@ -400,7 +415,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a Webhook destination', async () => {
@@ -448,7 +466,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a Teams destination', async () => {
@@ -496,7 +517,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a Opsgenie destination', async () => {
@@ -544,7 +568,10 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can create a Asana destination', async () => {
@@ -601,6 +628,9 @@ describe('CreateDestination', () => {
     fireEvent.click(getByText('Add Destination'));
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 });

--- a/web/src/pages/EditComplianceSource/ΕditComplianceSource.test.tsx
+++ b/web/src/pages/EditComplianceSource/ΕditComplianceSource.test.tsx
@@ -75,10 +75,10 @@ describe('EditComplianceSource', () => {
       }),
     ];
     const { getByText, getByLabelText, getByAltText, findByText } = render(
-      <Route path={urls.compliance.sources.edit(':id')}>
+      <Route path={urls.integrations.cloudAccounts.edit(':id')}>
         <EditComplianceSource />
       </Route>,
-      { mocks, initialRoute: urls.compliance.sources.edit(complianceSource.integrationId) }
+      { mocks, initialRoute: urls.integrations.cloudAccounts.edit(complianceSource.integrationId) }
     );
 
     const nameField = getByLabelText('Name') as HTMLInputElement;
@@ -163,10 +163,10 @@ describe('EditComplianceSource', () => {
       findByText,
       queryByText,
     } = render(
-      <Route path={urls.compliance.sources.edit(':id')}>
+      <Route path={urls.integrations.cloudAccounts.edit(':id')}>
         <EditComplianceSource />
       </Route>,
-      { mocks, initialRoute: urls.compliance.sources.edit(complianceSource.integrationId) }
+      { mocks, initialRoute: urls.integrations.cloudAccounts.edit(complianceSource.integrationId) }
     );
 
     const nameField = getByLabelText('Name') as HTMLInputElement;

--- a/web/src/pages/EditDestination/EditDestination.test.tsx
+++ b/web/src/pages/EditDestination/EditDestination.test.tsx
@@ -109,7 +109,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit Github destination', async () => {
@@ -159,7 +162,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit Jira destination', async () => {
@@ -215,7 +221,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit PagerDuty destination', async () => {
@@ -266,7 +275,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit SQS destination', async () => {
@@ -316,7 +328,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit SNS destination', async () => {
@@ -367,7 +382,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit Custom Webhook destination', async () => {
@@ -417,7 +435,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit MS Teams destination', async () => {
@@ -467,7 +488,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit Opsgenie destination', async () => {
@@ -523,7 +547,10 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 
   it('can successfully edit Asana destination', async () => {
@@ -574,6 +601,9 @@ describe('EditDestination', () => {
 
     // Expect success screen with proper redirect link
     expect(await findByText('Everything looks good!'));
-    expect(getByText('Finish Setup')).toHaveAttribute('href', urls.settings.destinations.list());
+    expect(getByText('Finish Setup')).toHaveAttribute(
+      'href',
+      urls.integrations.destinations.list()
+    );
   });
 });

--- a/web/src/pages/EditS3LogSource/ΕditS3LogSource.test.tsx
+++ b/web/src/pages/EditS3LogSource/ΕditS3LogSource.test.tsx
@@ -97,12 +97,12 @@ describe('EditS3LogSource', () => {
       }),
     ];
     const { getByText, getByLabelText, getByAltText, findByText, queryByText } = render(
-      <Route path={urls.logAnalysis.sources.edit(':id', ':type')}>
+      <Route path={urls.integrations.logSources.edit(':id', ':type')}>
         <EditS3LogSource />
       </Route>,
       {
         mocks,
-        initialRoute: urls.logAnalysis.sources.edit(logSource.integrationId, 's3'),
+        initialRoute: urls.integrations.logSources.edit(logSource.integrationId, 's3'),
       }
     );
 
@@ -204,12 +204,12 @@ describe('EditS3LogSource', () => {
       getAllByLabelText,
       queryByText,
     } = render(
-      <Route path={urls.logAnalysis.sources.edit(':id', ':type')}>
+      <Route path={urls.integrations.logSources.edit(':id', ':type')}>
         <EditS3LogSource />
       </Route>,
       {
         mocks,
-        initialRoute: urls.logAnalysis.sources.edit(logSource.integrationId, 's3'),
+        initialRoute: urls.integrations.logSources.edit(logSource.integrationId, 's3'),
       }
     );
 
@@ -300,12 +300,12 @@ describe('EditS3LogSource', () => {
       getByAriaLabel,
       queryByText,
     } = render(
-      <Route path={urls.logAnalysis.sources.edit(':id', ':type')}>
+      <Route path={urls.integrations.logSources.edit(':id', ':type')}>
         <EditS3LogSource />
       </Route>,
       {
         mocks,
-        initialRoute: urls.logAnalysis.sources.edit(logSource.integrationId, 's3'),
+        initialRoute: urls.integrations.logSources.edit(logSource.integrationId, 's3'),
       }
     );
 
@@ -392,12 +392,12 @@ describe('EditS3LogSource', () => {
       }),
     ];
     const { getByText, getByLabelText, getByAltText, findByText } = render(
-      <Route path={urls.logAnalysis.sources.edit(':id', ':type')}>
+      <Route path={urls.integrations.logSources.edit(':id', ':type')}>
         <EditS3LogSource />
       </Route>,
       {
         mocks,
-        initialRoute: urls.logAnalysis.sources.edit(logSource.integrationId, 's3'),
+        initialRoute: urls.integrations.logSources.edit(logSource.integrationId, 's3'),
       }
     );
 

--- a/web/src/pages/EditSqsLogSource/ΕditSqsLogSource.test.tsx
+++ b/web/src/pages/EditSqsLogSource/ΕditSqsLogSource.test.tsx
@@ -87,12 +87,12 @@ describe('EditSqsLogSource', () => {
       }),
     ];
     const { getByText, getByLabelText, findByText } = render(
-      <Route path={urls.logAnalysis.sources.edit(':id', ':type')}>
+      <Route path={urls.integrations.logSources.edit(':id', ':type')}>
         <EditSqsLogSource />
       </Route>,
       {
         mocks,
-        initialRoute: urls.logAnalysis.sources.edit(logSource.integrationId, 'sqs'),
+        initialRoute: urls.integrations.logSources.edit(logSource.integrationId, 'sqs'),
       }
     );
 

--- a/web/src/pages/Landing/Landing.tsx
+++ b/web/src/pages/Landing/Landing.tsx
@@ -71,7 +71,11 @@ const LandingPage: React.FC = () => {
                 Connect AWS accounts, scan resources and detect misconfigurations
               </Text>
               <Box width={225}>
-                <LinkButton to={urls.compliance.sources.create()} fullWidth variantColor="teal">
+                <LinkButton
+                  to={urls.integrations.cloudAccounts.create()}
+                  fullWidth
+                  variantColor="teal"
+                >
                   Onboard an AWS account
                 </LinkButton>
               </Box>
@@ -85,7 +89,11 @@ const LandingPage: React.FC = () => {
                 Connect your log buckets and analyze data with rules
               </Text>
               <Box width={225}>
-                <LinkButton to={urls.logAnalysis.sources.create()} fullWidth variantColor="teal">
+                <LinkButton
+                  to={urls.integrations.logSources.create()}
+                  fullWidth
+                  variantColor="teal"
+                >
                   Connect S3 Buckets
                 </LinkButton>
               </Box>
@@ -104,7 +112,7 @@ const LandingPage: React.FC = () => {
                 Add destinations so Panther can notify you of policy and rule findings
               </Text>
               <Box width={225}>
-                <LinkButton to={urls.settings.destinations.list()} fullWidth variantColor="red">
+                <LinkButton to={urls.integrations.destinations.list()} fullWidth variantColor="red">
                   Setup Destinations
                 </LinkButton>
               </Box>

--- a/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCard.tsx
+++ b/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCard.tsx
@@ -52,7 +52,7 @@ const ComplianceSourceCard: React.FC<ComplianceSourceCardProps> = ({ source }) =
         <GenericItemCard.Header>
           <GenericItemCard.Heading>
             {!isCreatedByPanther ? (
-              <Link as={RRLink} to={urls.compliance.sources.edit(source.integrationId)}>
+              <Link as={RRLink} to={urls.integrations.cloudAccounts.edit(source.integrationId)}>
                 {source.integrationLabel}
               </Link>
             ) : (

--- a/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCardOptions.tsx
+++ b/web/src/pages/ListComplianceSources/ComplianceSourceCard/ComplianceSourceCardOptions.tsx
@@ -36,7 +36,7 @@ const ComplianceSourceCardOptions: React.FC<ComplianceSourceCardOptionsProps> = 
     <Dropdown>
       <DropdownButton as={GenericItemCard.OptionsButton} />
       <DropdownMenu>
-        <DropdownLink as={RRLink} to={urls.compliance.sources.edit(source.integrationId)}>
+        <DropdownLink as={RRLink} to={urls.integrations.cloudAccounts.edit(source.integrationId)}>
           Edit
         </DropdownLink>
         <DropdownItem

--- a/web/src/pages/ListComplianceSources/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListComplianceSources/EmptyDataFallback/EmptyDataFallback.tsx
@@ -30,7 +30,7 @@ const EmptyDataFallback: React.FC = () => (
     <Text color="gray-300" textAlign="center" mb={8}>
       You don{"'"}t seem to have any Cloud Security sources connected to our system.
     </Text>
-    <LinkButton to="to={urls.compliance.sources.create()}">Connect an account</LinkButton>
+    <LinkButton to="to={urls.integrations.cloudAccounts.create()}">Connect an account</LinkButton>
   </Flex>
 );
 

--- a/web/src/pages/ListComplianceSources/ListComplianceSources.tsx
+++ b/web/src/pages/ListComplianceSources/ListComplianceSources.tsx
@@ -58,7 +58,7 @@ const ListComplianceSources = () => {
       <Panel
         title="Connected Accounts"
         actions={
-          <LinkButton to={urls.compliance.sources.create()} icon="add">
+          <LinkButton to={urls.integrations.cloudAccounts.create()} icon="add">
             Add Account
           </LinkButton>
         }

--- a/web/src/pages/ListDestinations/DestinationCards/DestinationCard.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/DestinationCard.tsx
@@ -39,7 +39,7 @@ const DestinationCard: React.FC<DestinationCardProps> = ({ destination, logo, ch
       <GenericItemCard.Body>
         <GenericItemCard.Header>
           <GenericItemCard.Heading>
-            <Link as={RRLink} to={urls.settings.destinations.edit(destination.outputId)}>
+            <Link as={RRLink} to={urls.integrations.destinations.edit(destination.outputId)}>
               {destination.displayName}
             </Link>
           </GenericItemCard.Heading>

--- a/web/src/pages/ListDestinations/DestinationCards/DestinationCardOptions.tsx
+++ b/web/src/pages/ListDestinations/DestinationCards/DestinationCardOptions.tsx
@@ -94,7 +94,7 @@ const DestinationCardOptions: React.FC<DestinationCardOptionsProps> = ({ destina
       <DropdownButton as={GenericItemCard.OptionsButton} />
       <DropdownMenu>
         <DropdownItem onSelect={handleTestAlertClick}>Send Test Alert</DropdownItem>
-        <DropdownLink as={RRLink} to={urls.settings.destinations.edit(destination.outputId)}>
+        <DropdownLink as={RRLink} to={urls.integrations.destinations.edit(destination.outputId)}>
           Edit
         </DropdownLink>
         <DropdownItem

--- a/web/src/pages/ListDestinations/DestinationCards/__tests__/__snapshots__/DestinationCard.test.tsx.snap
+++ b/web/src/pages/ListDestinations/DestinationCards/__tests__/__snapshots__/DestinationCard.test.tsx.snap
@@ -271,7 +271,7 @@ exports[`Generic Destination Card should match snapshot 1`] = `
             >
               <a
                 class="panther-1"
-                href="/settings/destinations/8c0eb672-b7bb-4ef0-9d96-a2bc1abe94d7/edit/"
+                href="/integrations/destinations/8c0eb672-b7bb-4ef0-9d96-a2bc1abe94d7/edit/"
               >
                 Accountability
               </a>

--- a/web/src/pages/ListDestinations/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListDestinations/EmptyDataFallback/EmptyDataFallback.tsx
@@ -33,7 +33,7 @@ const DestinationsPageEmptyDataFallback: React.FC = () => {
         You don{"'"}t seem to have any destinations setup yet. <br />
         Adding destinations will help you get notified when irregularities occur.
       </Text>
-      <LinkButton to={urls.settings.destinations.create()} icon="add">
+      <LinkButton to={urls.integrations.destinations.create()} icon="add">
         Add your first Destination
       </LinkButton>
     </Flex>

--- a/web/src/pages/ListDestinations/ListDestinations.test.tsx
+++ b/web/src/pages/ListDestinations/ListDestinations.test.tsx
@@ -89,7 +89,7 @@ describe('ListDestinations', () => {
       const editButton = await findByText('Edit');
       expect(editButton.parentElement).toHaveAttribute(
         'href',
-        urls.settings.destinations.edit(destinations[index].outputId)
+        urls.integrations.destinations.edit(destinations[index].outputId)
       );
 
       // close menu

--- a/web/src/pages/ListDestinations/ListDestinations.tsx
+++ b/web/src/pages/ListDestinations/ListDestinations.tsx
@@ -59,7 +59,7 @@ const ListDestinations = () => {
         <Panel
           title="Destinations"
           actions={
-            <LinkButton to={urls.settings.destinations.create()} icon="add">
+            <LinkButton to={urls.integrations.destinations.create()} icon="add">
               Add Destination
             </LinkButton>
           }

--- a/web/src/pages/ListLogSources/EmptyDataFallback/EmptyDataFallback.tsx
+++ b/web/src/pages/ListLogSources/EmptyDataFallback/EmptyDataFallback.tsx
@@ -31,7 +31,7 @@ const EmptyDataFallback: React.FC = () => (
     <Text color="gray-300" textAlign="center" mb={8}>
       You don{"'"}t seem to have any Log sources connected to our system. <br />
     </Text>
-    <LinkButton to={urls.logAnalysis.sources.create()}>Onboard your logs</LinkButton>
+    <LinkButton to={urls.integrations.logSources.create()}>Onboard your logs</LinkButton>
   </Flex>
 );
 

--- a/web/src/pages/ListLogSources/ListLogSources.tsx
+++ b/web/src/pages/ListLogSources/ListLogSources.tsx
@@ -62,7 +62,7 @@ const ListLogSources = () => {
       <Panel
         title="Log Sources"
         actions={
-          <LinkButton to={urls.logAnalysis.sources.create()} icon="add">
+          <LinkButton to={urls.integrations.logSources.create()} icon="add">
             Add Source
           </LinkButton>
         }

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
@@ -84,7 +84,7 @@ const LogSourceCard: React.FC<LogSourceCardProps> = ({ source, children, logo })
             {!isCreatedByPanther ? (
               <Link
                 as={RRLink}
-                to={urls.logAnalysis.sources.edit(source.integrationId, sourceType)}
+                to={urls.integrations.logSources.edit(source.integrationId, sourceType)}
               >
                 {source.integrationLabel}
               </Link>

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
@@ -40,7 +40,7 @@ const LogSourceCardOptions: React.FC<LogSourceCardOptionsProps> = ({ source }) =
   switch (source.integrationType) {
     case LogIntegrationsEnum.sqs:
       castedSource = source as SqsLogSourceIntegration;
-      logSourceEditUrl = urls.logAnalysis.sources.edit(source.integrationId, 'sqs');
+      logSourceEditUrl = urls.integrations.logSources.edit(source.integrationId, 'sqs');
       break;
     case LogIntegrationsEnum.s3:
     default:
@@ -49,7 +49,7 @@ const LogSourceCardOptions: React.FC<LogSourceCardOptionsProps> = ({ source }) =
       if (castedSource.managedS3Resources?.topicARN) {
         description += `. The SNS topic created by Panther will also be kept (${castedSource.managedS3Resources.topicARN})`;
       }
-      logSourceEditUrl = urls.logAnalysis.sources.edit(source.integrationId, 's3');
+      logSourceEditUrl = urls.integrations.logSources.edit(source.integrationId, 's3');
   }
 
   return (

--- a/web/src/pages/LogSourceOnboarding/LogSourceOnboarding.tsx
+++ b/web/src/pages/LogSourceOnboarding/LogSourceOnboarding.tsx
@@ -103,7 +103,7 @@ const LogSourceOnboarding: React.FC = () => {
                   logo={config.logo}
                   title={config.title}
                   disabled={config.disabled}
-                  to={`${urls.logAnalysis.sources.create(config.type)}`}
+                  to={`${urls.integrations.logSources.create(config.type)}`}
                 />
               ))}
             </SimpleGrid>

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -126,21 +126,6 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
                   path={urls.compliance.resources.details(':id')}
                   component={ResourceDetailsPage}
                 />
-                <Route
-                  exact
-                  path={urls.compliance.sources.list()}
-                  component={ListComplianceSourcesPage}
-                />
-                <Route
-                  exact
-                  path={urls.compliance.sources.create()}
-                  component={CreateComplianceSourcePage}
-                />
-                <Route
-                  exact
-                  path={urls.compliance.sources.edit(':id')}
-                  component={EditComplianceSourcePage}
-                />
                 {/* ******************* LOG ANALYSIS ***************************** */}
                 <Redirect exact from={urls.logAnalysis.home()} to={urls.logAnalysis.overview()} />
                 <Redirect
@@ -163,31 +148,6 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
                 />
                 <Route
                   exact
-                  path={urls.logAnalysis.sources.list()}
-                  component={ListLogSourcesPage}
-                />
-                <Route
-                  exact
-                  path={urls.logAnalysis.sources.create(':type')}
-                  component={CreateLogSourcePage}
-                />
-                <Route
-                  exact
-                  path={urls.logAnalysis.sources.create()}
-                  component={LogSourceOnboarding}
-                />
-                <Route
-                  exact
-                  path={urls.logAnalysis.sources.edit(':id', 's3')}
-                  component={EditS3LogSourcePage}
-                />
-                <Route
-                  exact
-                  path={urls.logAnalysis.sources.edit(':id', 'sqs')}
-                  component={EditSqsLogSource}
-                />
-                <Route
-                  exact
                   path={urls.logAnalysis.dataModels.list()}
                   component={ListDataModelsPage}
                 />
@@ -206,12 +166,73 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
                   from={urls.logAnalysis.dataModels.details(':id')}
                   to={urls.logAnalysis.dataModels.edit(':id')}
                 />
+                <Route exact path={urls.packs.list()} component={ListPacksPage} />
+                {/* ******************* INTEGRATIONS ***************************** */}
                 <Redirect
                   exact
-                  from={`${urls.logAnalysis.sources.list()}:type`}
-                  to={urls.logAnalysis.sources.list()}
+                  from={urls.integrations.home()}
+                  to={urls.integrations.logSources.list()}
                 />
-                <Route exact path={urls.packs.list()} component={ListPacksPage} />
+                <Redirect
+                  exact
+                  from={`${urls.integrations.logSources.list()}:type`}
+                  to={urls.integrations.logSources.list()}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.logSources.list()}
+                  component={ListLogSourcesPage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.logSources.create(':type')}
+                  component={CreateLogSourcePage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.logSources.create()}
+                  component={LogSourceOnboarding}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.logSources.edit(':id', 's3')}
+                  component={EditS3LogSourcePage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.logSources.edit(':id', 'sqs')}
+                  component={EditSqsLogSource}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.cloudAccounts.list()}
+                  component={ListComplianceSourcesPage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.cloudAccounts.create()}
+                  component={CreateComplianceSourcePage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.cloudAccounts.edit(':id')}
+                  component={EditComplianceSourcePage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.destinations.create()}
+                  component={CreateDestinationPage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.destinations.edit(':id')}
+                  component={EditDestinationPage}
+                />
+                <Route
+                  exact
+                  path={urls.integrations.destinations.list()}
+                  component={ListDestinationsPage}
+                />
                 {/* ******************* SETTINGS ***************************** */}
                 <Redirect exact from={urls.settings.home()} to={urls.settings.general()} />
                 <Route exact path={urls.settings.general()} component={GeneralSettingsPage} />
@@ -238,21 +259,6 @@ const PrimaryPageLayout: React.FunctionComponent = () => {
                   to={urls.settings.globalPythonModules.edit(':id')}
                 />
                 <Route exact path={urls.settings.users()} component={UsersPage} />
-                <Route
-                  exact
-                  path={urls.settings.destinations.create()}
-                  component={CreateDestinationPage}
-                />
-                <Route
-                  exact
-                  path={urls.settings.destinations.edit(':id')}
-                  component={EditDestinationPage}
-                />
-                <Route
-                  exact
-                  path={urls.settings.destinations.list()}
-                  component={ListDestinationsPage}
-                />
                 <Route
                   exact
                   path={urls.logAnalysis.customLogs.create()}

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -54,12 +54,6 @@ const urls = {
       details: (id: ResourceDetails['id']) => `${urls.compliance.resources.list()}${urlEncode(id)}/`, // prettier-ignore
       edit: (id: ResourceDetails['id']) => `${urls.compliance.resources.details(id)}edit/`,
     },
-    sources: {
-      list: () => `${urls.compliance.home()}sources/`,
-      create: () => `${urls.compliance.sources.list()}new/`,
-      edit: (id: ComplianceIntegration['integrationId']) =>
-        `${urls.compliance.sources.list()}${id}/edit/`,
-    },
   },
   logAnalysis: {
     home: () => '/log-analysis/',
@@ -80,12 +74,6 @@ const urls = {
       list: () => `${urls.logAnalysis.home()}alerts/`,
       details: (id: AlertDetails['alertId']) => `${urls.logAnalysis.alerts.list()}${urlEncode(id)}/` // prettier-ignore
     },
-    sources: {
-      list: () => `${urls.logAnalysis.home()}sources/`,
-      create: (type?: string) => `${urls.logAnalysis.sources.list()}new/${type || ''}`,
-      edit: (id: LogIntegration['integrationId'], type: string) =>
-        `${urls.logAnalysis.sources.list()}${type}/${id}/edit/`,
-    },
     customLogs: {
       list: () => `${urls.logAnalysis.home()}custom-logs/`,
       details: (logType: CustomLogRecord['logType']) =>
@@ -100,6 +88,27 @@ const urls = {
     list: () => urls.packs.home(),
     details: (id: Pack['id']) => `${urls.packs.home()}${urlEncode(id)}/`,
   },
+  integrations: {
+    home: () => `/integrations/`,
+    logSources: {
+      list: () => `${urls.integrations.home()}log-sources/`,
+      create: (type?: string) => `${urls.integrations.logSources.list()}new/${type || ''}`,
+      edit: (id: LogIntegration['integrationId'], type: string) =>
+        `${urls.integrations.logSources.list()}${type}/${id}/edit/`,
+    },
+    cloudAccounts: {
+      list: () => `${urls.integrations.home()}cloud-accounts/`,
+      create: () => `${urls.integrations.cloudAccounts.list()}new/`,
+      edit: (id: ComplianceIntegration['integrationId']) =>
+        `${urls.integrations.cloudAccounts.list()}${id}/edit/`,
+    },
+    destinations: {
+      list: () => `${urls.integrations.home()}destinations/`,
+      create: () => `${urls.integrations.destinations.list()}new/`,
+      edit: (id: Destination['outputId']) =>
+        `${urls.integrations.destinations.list()}${urlEncode(id)}/edit/`,
+    },
+  },
   settings: {
     home: () => '/settings/',
     general: () => `${urls.settings.home()}general/`,
@@ -111,12 +120,6 @@ const urls = {
     },
     bulkUploader: () => `${urls.settings.home()}bulk-uploader/`,
     users: () => `${urls.settings.home()}users/`,
-    destinations: {
-      list: () => `${urls.settings.home()}destinations/`,
-      create: () => `${urls.settings.destinations.list()}new/`,
-      edit: (id: Destination['outputId']) =>
-        `${urls.settings.destinations.list()}${urlEncode(id)}/edit/`,
-    },
   },
   account: {
     auth: {


### PR DESCRIPTION
## Background

In a process of improving our navigation menu for newcomers, we proposed to move all of the available "connectors" in a new menu entry named `Integrations` which will host all the 3rd-party services that Panther can connect to. 

This PR implements just that

## Screenshots

<img width="1639" alt="Screen Shot 2021-02-15 at 5 48 06 PM" src="https://user-images.githubusercontent.com/10436045/107967603-fed3f700-6fb5-11eb-80aa-24cebf05ad9d.png">



## Changes

- Add new collapsable menu entry named `Integrations`
- Move all CS and LA sources under Integrations
- Move & rename Destinations entry under Integrations

## Testing

`npm run test`
- How did you test your change?
