### PR TITLE
Add healthcheck for bucket notifications configuration

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -305,6 +305,7 @@ type S3LogIntegrationHealth {
   s3BucketStatus: IntegrationItemHealthStatus!
   kmsKeyStatus: IntegrationItemHealthStatus!
   getObjectStatus: IntegrationItemHealthStatus # can be null for sources created in Panther<1.16
+  bucketNotificationsStatus: IntegrationItemHealthStatus
 }
 
 type SqsLogIntegrationHealth {

--- a/api/lambda/source/models/api.go
+++ b/api/lambda/source/models/api.go
@@ -58,10 +58,11 @@ type CheckIntegrationInput struct {
 	EnableCWESetup    *bool `json:"enableCWESetup"`
 	EnableRemediation *bool `json:"enableRemediation"`
 
-	// Checks for log analysis integrations
-	S3Bucket         string           `json:"s3Bucket"`
-	S3PrefixLogTypes S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty"`
-	KmsKey           string           `json:"kmsKey"`
+	// Checks for s3 integrations
+	S3Bucket                   string           `json:"s3Bucket"`
+	S3PrefixLogTypes           S3PrefixLogtypes `json:"s3PrefixLogTypes,omitempty"`
+	KmsKey                     string           `json:"kmsKey"`
+	ManagedBucketNotifications bool             `json:"managedBucketNotifications"`
 
 	// Checks for Sqs configuration
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -195,6 +195,10 @@ type SourceIntegrationHealth struct {
 	KMSKeyStatus         SourceIntegrationItemStatus `json:"kmsKeyStatus,omitempty"`
 	// GetObject check is not available to sources created in Panther<1.16
 	GetObjectStatus *SourceIntegrationItemStatus `json:"getObjectStatus,omitempty"`
+	// BucketNotificationsStatus is the result of checking the bucket's notifications configuration.
+	// It is populated only the log processing role has the s3:GetBucketNotification permission. This is
+	// added to our provided CFN template if user opts for Panther-managed bucket notifications.
+	BucketNotificationsStatus *SourceIntegrationItemStatus `json:"bucketNotificationsStatus,omitempty"`
 
 	// Checks for Sqs integrations
 	SqsStatus SourceIntegrationItemStatus `json:"sqsStatus"`

--- a/deployments/appsync.yml
+++ b/deployments/appsync.yml
@@ -607,6 +607,7 @@ Resources:
         $util.qr($input.put("s3Bucket", $ctx.source.s3Bucket))
         $util.qr($input.put("s3PrefixLogTypes", $ctx.source.s3PrefixLogTypes))
         $util.qr($input.put("kmsKey", $ctx.source.kmsKey))
+        $util.qr($input.put("managedBucketNotifications", $ctx.source.managedBucketNotifications))
         $util.qr($input.put("pantherVersion", $ctx.source.pantherVersion))
         {
           "version" : "2017-02-28",

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -20,6 +20,7 @@ package api
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,6 +38,7 @@ import (
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
 	"github.com/panther-labs/panther/pkg/genericapi"
+	"github.com/panther-labs/panther/pkg/stringset"
 )
 
 const (
@@ -105,12 +107,89 @@ func (api *API) checkAwsS3Integration(input *models.CheckIntegrationInput) *mode
 		Credentials: roleCreds,
 		Region:      bucketRegion,
 	})
-	h, skipped := checkGetObject(s3Client, input)
+	getObjectCheck, skipped := checkGetObject(s3Client, input)
 	if !skipped {
-		out.GetObjectStatus = &h
+		out.GetObjectStatus = &getObjectCheck
 	}
 
+	notificationsCheck, skipped := checkBucketNotifications(s3Client, input, api.Config, bucketRegion)
+	if !skipped {
+		out.BucketNotificationsStatus = &notificationsCheck
+	}
 	return out
+}
+
+func checkBucketNotifications(s3Client s3iface.S3API, input *models.CheckIntegrationInput, config Config, bucketRegion *string) (
+	h models.SourceIntegrationItemStatus, skipped bool) {
+
+	if !input.ManagedBucketNotifications {
+		return models.SourceIntegrationItemStatus{}, true
+	}
+
+	out, err := s3Client.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+		Bucket:              &input.S3Bucket,
+		ExpectedBucketOwner: &input.AWSAccountID,
+	})
+	if err != nil {
+		return models.SourceIntegrationItemStatus{
+			Healthy:      false,
+			Message:      "Failed to get bucket notifications",
+			ErrorMessage: err.Error(),
+		}, false
+	}
+
+	topicARN := arn.ARN{
+		Partition: config.AWSPartition, // Note: Assume the onboarded bucket is in the same AWS partition as Panther
+		Service:   "sns",
+		Region:    *bucketRegion,
+		AccountID: input.AWSAccountID,
+		Resource:  "panther-notifications-topic",
+	}.String()
+	// an SNS notification should exist for each one of the prefixes
+	prefixes := reduceNoPrefixStrings(input.S3PrefixLogTypes.S3Prefixes())
+	var notFound []string // keep the prefixes which we didn't find notifications for
+	for _, p := range prefixes {
+		// search the prefix in the configurations
+		ok := false
+		for _, c := range out.TopicConfigurations {
+			zap.S().Warn("topic arn", topicARN, aws.StringValue(c.TopicArn))
+			if topicARN != aws.StringValue(c.TopicArn) {
+				continue
+			}
+			if !stringset.Contains(aws.StringValueSlice(c.Events), "s3:ObjectCreated:*") {
+				continue
+			}
+			if c.Filter == nil || c.Filter.Key == nil {
+				continue
+			}
+
+			// Check filter rules. The prefix should be equal to p. Missing prefix is also fine if p is empty.
+			// Note we can't validate the suffix. User may have added a suffix to further break down which log files
+			// reach Panther.
+			rulePrefix := ""
+			for _, r := range c.Filter.Key.FilterRules {
+				if strings.ToLower(aws.StringValue(r.Name)) == "prefix" {
+					rulePrefix = aws.StringValue(r.Value)
+				}
+			}
+			ok = rulePrefix == p
+		}
+		if !ok {
+			notFound = append(notFound, p) // checked all topic configs, couldn't find the prefix
+		}
+	}
+
+	if len(notFound) == 0 {
+		return models.SourceIntegrationItemStatus{
+			Healthy: true,
+			Message: "Bucket notifications are configured",
+		}, false
+	}
+	return models.SourceIntegrationItemStatus{
+		Healthy:      false,
+		Message:      "Bucket notifications are not properly configured",
+		ErrorMessage: fmt.Sprintf("Notifications are not configured for these prefixes: %+q", notFound),
+	}, false
 }
 
 // This function checks if the IAM identity of the s3Client has permissions to

--- a/internal/core/source_api/api/managed_bucket_notifications.go
+++ b/internal/core/source_api/api/managed_bucket_notifications.go
@@ -59,7 +59,7 @@ func ManageBucketNotifications(
 	managed := &source.ManagedS3Resources
 
 	stsSess := pantherSess.Copy(&aws.Config{
-		MaxRetries:  aws.Int(5),
+		MaxRetries:          aws.Int(5),
 		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 		Credentials:         stscreds.NewCredentials(pantherSess, source.RequiredLogProcessingRole()),
 	})

--- a/internal/core/source_api/api/managed_bucket_notifications.go
+++ b/internal/core/source_api/api/managed_bucket_notifications.go
@@ -58,13 +58,11 @@ func ManageBucketNotifications(
 
 	managed := &source.ManagedS3Resources
 
-	stsSess, err := session.NewSession(&aws.Config{
+	stsSess := pantherSess.Copy(&aws.Config{
 		MaxRetries:  aws.Int(5),
-		Credentials: stscreds.NewCredentials(pantherSess, source.RequiredLogProcessingRole()),
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
+		Credentials:         stscreds.NewCredentials(pantherSess, source.RequiredLogProcessingRole()),
 	})
-	if err != nil {
-		return errors.Wrap(err, "failed to create sts session")
-	}
 
 	bucketRegion, err := getBucketLocation(stsSess, source.S3Bucket)
 	if err != nil {
@@ -128,9 +126,10 @@ func RemoveBucketNotifications(pantherSess *session.Session, source *models.Sour
 		return nil
 	}
 
-	stsSess := session.Must(session.NewSession(&aws.Config{
-		Credentials: stscreds.NewCredentials(pantherSess, source.RequiredLogProcessingRole()),
-	}))
+	stsSess := pantherSess.Copy(&aws.Config{
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
+		Credentials:         stscreds.NewCredentials(pantherSess, source.RequiredLogProcessingRole()),
+	})
 
 	bucketRegion, err := getBucketLocation(stsSess, source.S3Bucket)
 	if err != nil {

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -1378,6 +1378,7 @@ export type S3LogIntegrationHealth = {
   s3BucketStatus: IntegrationItemHealthStatus;
   kmsKeyStatus: IntegrationItemHealthStatus;
   getObjectStatus?: Maybe<IntegrationItemHealthStatus>;
+  bucketNotificationsStatus?: Maybe<IntegrationItemHealthStatus>;
 };
 
 export type S3PrefixLogTypes = {
@@ -3411,6 +3412,11 @@ export type S3LogIntegrationHealthResolvers<
   s3BucketStatus?: Resolver<ResolversTypes['IntegrationItemHealthStatus'], ParentType, ContextType>;
   kmsKeyStatus?: Resolver<ResolversTypes['IntegrationItemHealthStatus'], ParentType, ContextType>;
   getObjectStatus?: Resolver<
+    Maybe<ResolversTypes['IntegrationItemHealthStatus']>,
+    ParentType,
+    ContextType
+  >;
+  bucketNotificationsStatus?: Resolver<
     Maybe<ResolversTypes['IntegrationItemHealthStatus']>,
     ParentType,
     ContextType

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -1596,6 +1596,10 @@ export const buildS3LogIntegrationHealth = (
       'getObjectStatus' in overrides
         ? overrides.getObjectStatus
         : buildIntegrationItemHealthStatus(),
+    bucketNotificationsStatus:
+      'bucketNotificationsStatus' in overrides
+        ? overrides.bucketNotificationsStatus
+        : buildIntegrationItemHealthStatus(),
   };
 };
 

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -43,6 +43,7 @@ export type S3LogIntegrationDetails = Pick<
     s3BucketStatus: IntegrationItemHealthDetails;
     kmsKeyStatus: IntegrationItemHealthDetails;
     getObjectStatus?: Types.Maybe<IntegrationItemHealthDetails>;
+    bucketNotificationsStatus?: Types.Maybe<IntegrationItemHealthDetails>;
   };
   managedS3Resources?: Types.Maybe<Pick<Types.ManagedS3Resources, 'topicARN'>>;
 };
@@ -76,6 +77,9 @@ export const S3LogIntegrationDetails = gql`
         ...IntegrationItemHealthDetails
       }
       getObjectStatus {
+        ...IntegrationItemHealthDetails
+      }
+      bucketNotificationsStatus {
         ...IntegrationItemHealthDetails
       }
     }

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
@@ -28,6 +28,9 @@ fragment S3LogIntegrationDetails on S3LogIntegration {
     getObjectStatus {
       ...IntegrationItemHealthDetails
     }
+    bucketNotificationsStatus {
+      ...IntegrationItemHealthDetails
+    }
   }
   managedS3Resources {
     topicARN

--- a/web/src/pages/CreateLogSource/CreateS3LogSource/CreateS3LogSource.test.tsx
+++ b/web/src/pages/CreateLogSource/CreateS3LogSource/CreateS3LogSource.test.tsx
@@ -50,6 +50,7 @@ const healthyS3 = buildS3LogIntegration({
     processingRoleStatus: buildIntegrationItemHealthStatus({ healthy: true }),
     s3BucketStatus: buildIntegrationItemHealthStatus({ healthy: true }),
     getObjectStatus: buildIntegrationItemHealthStatus({ healthy: true }),
+    bucketNotificationsStatus: buildIntegrationItemHealthStatus({ healthy: true }),
   }),
 });
 describe('CreateS3LogSource', () => {

--- a/web/src/pages/EditS3LogSource/ΕditS3LogSource.test.tsx
+++ b/web/src/pages/EditS3LogSource/ΕditS3LogSource.test.tsx
@@ -51,6 +51,7 @@ const healthyS3 = buildS3LogIntegration({
     processingRoleStatus: buildIntegrationItemHealthStatus({ healthy: true }),
     s3BucketStatus: buildIntegrationItemHealthStatus({ healthy: true }),
     getObjectStatus: buildIntegrationItemHealthStatus({ healthy: true }),
+    bucketNotificationsStatus: buildIntegrationItemHealthStatus({ healthy: true }),
   }),
 });
 

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCard.tsx
@@ -61,6 +61,9 @@ const LogSourceCard: React.FC<LogSourceCardProps> = ({ source, children, logo })
         if (sourceHealth.getObjectStatus) {
           checks.push(sourceHealth.getObjectStatus);
         }
+        if (sourceHealth.bucketNotificationsStatus) {
+          checks.push(sourceHealth.bucketNotificationsStatus);
+        }
         return checks;
       }
       default:


### PR DESCRIPTION
## Background

Add healthcheck for bucket notifications configuration

## Changes

- Add a check that checks the bucket notifications are configured properly for the prefixes the user filled in the onboarded s3 source.
- The healthcheck is only run if user has enabled Panther-managed
bucket notifications

## Testing

- Manual QA:
    - Test with empty prefix in the source, multiple prefixes and overlapping prefixes in the source 
    - Test source with Panther-managed notifications, healthcheck is displayed
    - Test source with manual notification configuration, healthcheck is not displayed
