### PR TITLE
Misc fixes and feedback on pack api

### DIFF
--- a/internal/core/analysis_api/handlers/dynamo.go
+++ b/internal/core/analysis_api/handlers/dynamo.go
@@ -113,6 +113,12 @@ func (r *tableItem) addExtraFields() {
 	r.LowerTags = lowerSet(r.Tags)
 }
 
+// Add extra internal filtering fields before serializing to Dynamo
+func (r *packTableItem) addExtraFields() {
+	r.LowerDisplayName = strings.ToLower(r.DisplayName)
+	r.LowerID = strings.ToLower(r.ID)
+}
+
 // Sort string sets before converting to an external Rule/Policy/Detection model.
 func (r *tableItem) normalize() {
 	sortCaseInsensitive(r.OutputIDs)
@@ -430,6 +436,7 @@ func dynamoPut(policy *tableItem) error {
 
 // Write a single pack to Dynamo.
 func dynamoPutPack(pack *packTableItem) error {
+	pack.addExtraFields()
 	body, err := dynamodbattribute.MarshalMap(pack)
 	if err != nil {
 		zap.L().Error("dynamodbattribute.MarshalMap failed", zap.Error(err))

--- a/internal/core/analysis_api/handlers/update_pack.go
+++ b/internal/core/analysis_api/handlers/update_pack.go
@@ -50,11 +50,11 @@ func (API) PatchPack(input *models.PatchPackInput) *events.APIGatewayProxyRespon
 	// Note: currently only support `enabled` and `enabledRelease` updates from the `patch` operation
 	// But you cannot update version and enabled status in same request
 	if input.VersionID != 0 && input.VersionID != oldItem.PackVersion.ID {
+		// we are updating the version
 		return updateVersion(input, oldItem)
 	}
 	// we are updating the enabled status
 	return updatePackEnabledStatus(input, oldItem)
-	// we are updating the version
 }
 
 // updatePackEnabledStatus will update the enabled status of the pack and the detections in it

--- a/internal/core/analysis_api/handlers/update_pack.go
+++ b/internal/core/analysis_api/handlers/update_pack.go
@@ -49,18 +49,12 @@ func (API) PatchPack(input *models.PatchPackInput) *events.APIGatewayProxyRespon
 	}
 	// Note: currently only support `enabled` and `enabledRelease` updates from the `patch` operation
 	// But you cannot update version and enabled status in same request
-	if input.Enabled != oldItem.Enabled && input.VersionID != 0 && input.VersionID != oldItem.PackVersion.ID {
-		return &events.APIGatewayProxyResponse{
-			Body:       fmt.Sprintf("Cannot update version and enabled status at the same time (%s)", input.ID),
-			StatusCode: http.StatusNotFound,
-		}
+	if input.VersionID != 0 && input.VersionID != oldItem.PackVersion.ID {
+		return updateVersion(input, oldItem)
 	}
-	if input.VersionID == 0 || input.Enabled != oldItem.Enabled {
-		// we are updating the enabled status
-		return updatePackEnabledStatus(input, oldItem)
-	}
+	// we are updating the enabled status
+	return updatePackEnabledStatus(input, oldItem)
 	// we are updating the version
-	return updateVersion(input, oldItem)
 }
 
 // updatePackEnabledStatus will update the enabled status of the pack and the detections in it

--- a/internal/core/analysis_api/handlers/update_pack_test.go
+++ b/internal/core/analysis_api/handlers/update_pack_test.go
@@ -80,182 +80,6 @@ func TestIsDetectionInMultipleEnabledPacks(t *testing.T) {
 	assert.True(t, result)
 }
 
-func TestSetupUpdatePacksVersions(t *testing.T) {
-	// This tests setting up pack items when there is
-	// no change needed (packs already have knowledge of all releases)
-	// as well as when a new release is available, but there aren't any
-	// new or removed packs
-	detectionsAtVersion := allDetections
-	newVersion := models.Version{ID: 2222, SemVer: "v1.2.0"}
-	availableVersions := []models.Version{
-		{ID: 1111, SemVer: "v1.1.0"},
-		{ID: 2222, SemVer: "v1.2.0"},
-	}
-	packOne := &packTableItem{
-		ID:                "pack.id.1",
-		AvailableVersions: availableVersions,
-		PackDefinition: models.PackDefinition{
-			IDs: []string{ruleDetectionID},
-		},
-		PackTypes: map[models.DetectionType]int{
-			models.TypeRule: 1,
-		}}
-	packTwo := &packTableItem{
-		ID:                "pack.id.2",
-		AvailableVersions: availableVersions,
-		PackDefinition: models.PackDefinition{
-			IDs: []string{ruleDetectionID},
-		},
-		PackTypes: map[models.DetectionType]int{
-			models.TypeRule: 1,
-		}}
-	packThree := &packTableItem{
-		ID:                "pack.id.3",
-		AvailableVersions: availableVersions,
-		PackDefinition: models.PackDefinition{
-			IDs: []string{ruleDetectionID},
-		},
-		PackTypes: map[models.DetectionType]int{
-			models.TypeRule: 1,
-		},
-	}
-	packsAtVersion := map[string]*packTableItem{
-		"pack.id.1": packOne,
-		"pack.id.2": packTwo,
-		"pack.id.3": packThree,
-	}
-	// Test: no changed needed
-	oldPacks := []*packTableItem{
-		packOne,
-		packTwo,
-		packThree,
-	}
-	newPackItems := setupUpdatePacksVersions(newVersion, oldPacks, packsAtVersion, detectionsAtVersion)
-	assert.Equal(t, 0, len(newPackItems))
-	// Test: no packs added/removed, releases updated
-	newVersion = models.Version{ID: 3333, SemVer: "v1.3.0"}
-	newPackItems = setupUpdatePacksVersions(newVersion, oldPacks, packsAtVersion, detectionsAtVersion)
-	for _, newPackItem := range newPackItems {
-		assert.True(t, newPackItem.UpdateAvailable)
-		assert.Equal(t, 3, len(newPackItem.AvailableVersions))
-	}
-}
-
-func TestSetupPacksVersionsAddPack(t *testing.T) {
-	// This tests setting up pack items when
-	// a new pack is added in a release. It should be auto-disable
-	// and the AvailableReleases should only include the
-	// new release version
-	detectionsAtVersion := allDetections
-	newVersion := models.Version{ID: 3333, SemVer: "v1.3.0"}
-	availableVersions := []models.Version{
-		{ID: 1111, SemVer: "v1.1.0"},
-		{ID: 2222, SemVer: "v1.2.0"},
-	}
-	// Test: New pack added
-	packOne := &packTableItem{
-		ID:                "pack.id.1",
-		AvailableVersions: availableVersions,
-		PackDefinition: models.PackDefinition{
-			IDs: []string{ruleDetectionID},
-		},
-		PackTypes: map[models.DetectionType]int{
-			models.TypeRule: 1,
-		}}
-	packTwo := &packTableItem{
-		ID:                "pack.id.2",
-		AvailableVersions: availableVersions,
-		PackDefinition: models.PackDefinition{
-			IDs: []string{ruleDetectionID},
-		},
-		PackTypes: map[models.DetectionType]int{
-			models.TypeRule: 1,
-		}}
-	// packThree is the "new" pack added
-	packThree := &packTableItem{
-		ID: "pack.id.3",
-		PackDefinition: models.PackDefinition{
-			IDs: []string{ruleDetectionID, policyDetectionID},
-		},
-		PackTypes: map[models.DetectionType]int{
-			models.TypeRule:   1,
-			models.TypePolicy: 1,
-		},
-	}
-	oldPacks := []*packTableItem{
-		packOne,
-		packTwo, // no packThree in the oldPacks
-	}
-	packsAtVersion := map[string]*packTableItem{
-		"pack.id.1": packOne,
-		"pack.id.2": packTwo,
-		"pack.id.3": packThree, // "new" packs has all three items
-	}
-	newPackItems := setupUpdatePacksVersions(newVersion, oldPacks, packsAtVersion, detectionsAtVersion)
-	assert.Equal(t, 3, len(newPackItems)) // ensure all three items have updates
-	for _, newPackItem := range newPackItems {
-		// validate the newly added pack is disabled and
-		// has the current field values
-		if newPackItem.ID == "pack.id.3" {
-			assert.False(t, newPackItem.UpdateAvailable) // while this is a new pack, the newest version has been installed (but disabled)
-			assert.False(t, newPackItem.Enabled)
-			assert.Equal(t, 1, len(newPackItem.AvailableVersions))
-			assert.Equal(t, newVersion.ID, newPackItem.PackVersion.ID)
-			assert.Equal(t, newVersion.SemVer, newPackItem.PackVersion.SemVer)
-			assert.Equal(t, packThree.PackTypes, newPackItem.PackTypes) // ensure the detection types are reflected
-		} else {
-			assert.True(t, newPackItem.UpdateAvailable)
-			// the existing packs should have 3 available versions
-			assert.Equal(t, 3, len(newPackItem.AvailableVersions))
-			assert.Equal(t, 1, len(newPackItem.PackTypes)) // ensure the detection types haven't changed for these packs
-			assert.Equal(t, packOne.PackTypes, newPackItem.PackTypes)
-		}
-	}
-}
-
-func TestSetupPacksVersionsRemovePack(t *testing.T) {
-	// This tests setting up the new pack items
-	// when a pack is removed from a release, in which case
-	// the removed pack does not get the new release in its
-	// AvailableRelease
-	detectionsAtVersion := allDetections
-	newVersion := models.Version{ID: 3333, SemVer: "v1.3.0"}
-	availableVersions := []models.Version{
-		{ID: 1111, SemVer: "v1.1.0"},
-		{ID: 2222, SemVer: "v1.2.0"},
-	}
-	// Test: pack removed
-	packOne := &packTableItem{
-		ID:                "pack.id.1",
-		AvailableVersions: availableVersions,
-	}
-	packTwo := &packTableItem{
-		ID:                "pack.id.2",
-		AvailableVersions: availableVersions,
-	}
-	packThree := &packTableItem{
-		ID:                "pack.id.3",
-		AvailableVersions: availableVersions, // will be "removed" in latest release
-	}
-	oldPacks := []*packTableItem{
-		packOne,
-		packTwo,
-		packThree,
-	}
-	packsAtVersion := map[string]*packTableItem{
-		"pack.id.1": packOne,
-		"pack.id.2": packTwo, // packThree "removed" from latest release
-	}
-	newPackItems := setupUpdatePacksVersions(newVersion, oldPacks, packsAtVersion, detectionsAtVersion)
-	assert.Equal(t, 2, len(newPackItems)) // only two packs should be updated
-	for _, newPackItem := range newPackItems {
-		assert.True(t, newPackItem.UpdateAvailable)
-		// validate the removed pack isn't returned from the function (no changes needed)
-		assert.NotEqual(t, packThree.ID, newPackItem.ID)
-		assert.Equal(t, 3, len(newPackItem.AvailableVersions))
-	}
-}
-
 func TestSetupUpdatePackToVersion(t *testing.T) {
 	// This tests setting up the updated items for
 	// updating a pack to a speicific version
@@ -280,37 +104,12 @@ func TestSetupUpdatePackToVersion(t *testing.T) {
 			models.TypeRule: 1,
 		},
 	}
-	input := &models.PatchPackInput{
-		VersionID: newVersion.ID,
-		ID:        "pack.id.1",
-		Enabled:   false,
-	}
 	packOne := oldPackOne
-	// Test: success, no update to enabled status
-	item := setupUpdatePackToVersion(input, newVersion, oldPackOne, packOne, detectionsAtVersion)
+	// Test: success
+	item := setupUpdatePackToVersion(newVersion, oldPackOne, packOne, detectionsAtVersion)
 	assert.Equal(t, newVersion, item.PackVersion)
 	assert.False(t, item.Enabled)
-	// Test: success, update enabled status
-	input = &models.PatchPackInput{
-		VersionID: newVersion.ID,
-		ID:        "pack.id.1",
-		Enabled:   true,
-	}
-	packOne = &packTableItem{
-		ID:                "pack.id.1",
-		AvailableVersions: availableVersions,
-		Enabled:           false,
-		Description:       "new description",
-	}
-	item = setupUpdatePackToVersion(input, newVersion, oldPackOne, packOne, detectionsAtVersion)
-	assert.Equal(t, newVersion, item.PackVersion)
-	assert.True(t, item.Enabled)
 	// Test: success, update detection type in pack
-	input = &models.PatchPackInput{
-		VersionID: newVersion.ID,
-		ID:        "pack.id.1",
-		Enabled:   true,
-	}
 	packOne = &packTableItem{
 		ID:                "pack.id.1",
 		AvailableVersions: availableVersions,
@@ -323,9 +122,9 @@ func TestSetupUpdatePackToVersion(t *testing.T) {
 			models.TypePolicy: 1,
 		},
 	}
-	item = setupUpdatePackToVersion(input, newVersion, oldPackOne, packOne, detectionsAtVersion)
+	item = setupUpdatePackToVersion(newVersion, oldPackOne, packOne, detectionsAtVersion)
 	assert.Equal(t, newVersion, item.PackVersion)
-	assert.True(t, item.Enabled)
+	assert.False(t, item.Enabled)
 	assert.Equal(t, packOne.PackDefinition, item.PackDefinition)
 	assert.Equal(t, packOne.PackTypes, item.PackTypes)
 }
@@ -340,11 +139,6 @@ func TestSetupUpdatePackToVersionOnDowngrade(t *testing.T) {
 		newVersion,
 		{ID: 2222, SemVer: "v1.2.0"},
 	}
-	input := &models.PatchPackInput{
-		VersionID: newVersion.ID,
-		ID:        "pack.id.1",
-		Enabled:   true,
-	}
 	oldPackOne := &packTableItem{
 		ID:                "pack.id.1",
 		AvailableVersions: availableVersions,
@@ -357,9 +151,9 @@ func TestSetupUpdatePackToVersionOnDowngrade(t *testing.T) {
 		Enabled:           false,
 		Description:       "original description",
 	}
-	item := setupUpdatePackToVersion(input, newVersion, oldPackOne, packOne, detectionsAtVersion)
+	item := setupUpdatePackToVersion(newVersion, oldPackOne, packOne, detectionsAtVersion)
 	assert.Equal(t, newVersion, item.PackVersion)
-	assert.True(t, item.Enabled)
+	assert.False(t, item.Enabled)
 	assert.Equal(t, 2, len(item.AvailableVersions)) // ensure even though we are downgrading, the available versions stays the same
 	assert.True(t, item.UpdateAvailable)            // since we are downgrading, the update available flag should still be set
 }

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -335,8 +335,6 @@ func TestIntegrationAPI(t *testing.T) {
 		t.Run("SaveRuleInvalidTestInputJson", saveRuleInvalidTestInputJSON)
 
 		t.Run("TestFailCreatePolicyInvalidResourceType", testFailCreatePolicyInvalidResourceType)
-
-		t.Run("PollAnalysisPacks", pollPacks)
 	})
 	if t.Failed() {
 		return
@@ -350,7 +348,6 @@ func TestIntegrationAPI(t *testing.T) {
 		t.Run("GetRuleWrongType", getRuleWrongType)
 		t.Run("GetGlobal", getGlobal)
 		t.Run("GetDataModel", getDataModel)
-		t.Run("GetPack", getPack)
 	})
 
 	// NOTE! This will mutate the original policy above!
@@ -385,7 +382,6 @@ func TestIntegrationAPI(t *testing.T) {
 		t.Run("ListDetectionsComplianceProjection", listDetectionsComplianceProjection)
 		t.Run("ListDetectionsAnalysisTypeFilter", listDetectionsAnalysisTypeFilter)
 		t.Run("ListDetectionsComplianceFilter", listDetectionsComplianceFilter)
-		t.Run("ListPacks", listPacks)
 	})
 
 	t.Run("Modify", func(t *testing.T) {
@@ -410,7 +406,15 @@ func TestIntegrationAPI(t *testing.T) {
 
 	// This has to run after the other detection changes since it will
 	// add/remove/update detections
+	t.Run("PollPack", func(t *testing.T) {
+		t.Run("PollAnalysisPacks", pollPacks)
+	})
+	t.Run("ListPacks", func(t *testing.T) {
+		t.Run("GetPack", getPack)
+		t.Run("ListPacks", listPacks)
+	})
 	t.Run("Patch", func(t *testing.T) {
+		t.Run("ListPacks", listPacks)
 		t.Run("PatchPack", patchPack)
 		t.Run("EnumeratePack", enumeratePack)
 	})
@@ -3094,24 +3098,6 @@ func enumeratePack(t *testing.T) {
 	}
 	_, err = apiClient.Invoke(&input, &result)
 	assert.Error(t, err)
-	// First, have to enable to pack to get the detections in
-	var modifyResult models.Pack
-	modifyInput := models.LambdaInput{
-		PatchPack: &models.PatchPackInput{
-			ID:        packOriginalReleaseStandardSet.ID,
-			Enabled:   true,
-			VersionID: packOriginalReleaseStandardSet.PackVersion.ID,
-			UserID:    userID,
-		},
-	}
-	statusCode, err = apiClient.Invoke(&modifyInput, &modifyResult)
-	// update appropriate fields to compare
-	packOriginalReleaseStandardSet.Enabled = true
-	packOriginalReleaseStandardSet.LastModified = modifyResult.LastModified
-	packOriginalReleaseStandardSet.LastModifiedBy = userID
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Equal(t, *packOriginalReleaseStandardSet, modifyResult)
 	// success: multi types
 	input = models.LambdaInput{
 		EnumeratePack: &models.EnumeratePackInput{
@@ -3149,10 +3135,9 @@ func patchPack(t *testing.T) {
 	// enable pack
 	input = models.LambdaInput{
 		PatchPack: &models.PatchPackInput{
-			ID:        packOriginalRelease.ID,
-			Enabled:   true,
-			VersionID: packOriginalRelease.PackVersion.ID,
-			UserID:    userID,
+			ID:      packOriginalRelease.ID,
+			Enabled: true,
+			UserID:  userID,
 		},
 	}
 	packOriginalRelease.Enabled = true

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -3113,9 +3113,26 @@ func enumeratePack(t *testing.T) {
 }
 
 func patchPack(t *testing.T) {
-	// disable pack
+	// enable pack
 	var result models.Pack
 	input := models.LambdaInput{
+		PatchPack: &models.PatchPackInput{
+			ID:      packOriginalRelease.ID,
+			Enabled: true,
+			UserID:  userID,
+		},
+	}
+	packOriginalRelease.LastModifiedBy = userID
+	packOriginalRelease.Enabled = true
+	statusCode, err := apiClient.Invoke(&input, &result)
+	packOriginalRelease.LastModified = result.LastModified
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, *packOriginalRelease, result)
+	// TODO: lookup detection in pack and ensure enabled:true
+
+	// disable pack
+	input = models.LambdaInput{
 		PatchPack: &models.PatchPackInput{
 			ID:        packOriginalRelease.ID,
 			Enabled:   false,
@@ -3123,30 +3140,13 @@ func patchPack(t *testing.T) {
 			UserID:    userID,
 		},
 	}
-	packOriginalRelease.LastModifiedBy = userID
 	packOriginalRelease.Enabled = false
-	statusCode, err := apiClient.Invoke(&input, &result)
-	packOriginalRelease.LastModified = result.LastModified
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Equal(t, *packOriginalRelease, result)
-	// TODO: lookup detection in pack and ensure enabled: false
-
-	// enable pack
-	input = models.LambdaInput{
-		PatchPack: &models.PatchPackInput{
-			ID:      packOriginalRelease.ID,
-			Enabled: true,
-			UserID:  userID,
-		},
-	}
-	packOriginalRelease.Enabled = true
 	statusCode, err = apiClient.Invoke(&input, &result)
 	packOriginalRelease.LastModified = result.LastModified
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, *packOriginalRelease, result)
-	// TODO: lookup detection in pack and ensure enabled:true
+	// TODO: lookup detection in pack and ensure enabled: false
 
 	/*TODO
 	// upgrade to newer well known version (v1.15.0) TODO

--- a/internal/core/analysis_api/main/integration_test.go
+++ b/internal/core/analysis_api/main/integration_test.go
@@ -49,7 +49,7 @@ import (
 const (
 	tableName           = "panther-analysis"
 	packTableName       = "panther-analysis-packs"
-	analysesRoot        = "./test_analyses"
+	analysesRoot        = "./bulk_test_resources/test_analyses"
 	analysesZipLocation = "./bulk_upload.zip"
 
 	bulkTestDataDirPath              = "./bulk_test_resources"
@@ -129,7 +129,7 @@ var (
 		Description: "Example LogType Schema",
 		Enabled:     true,
 		ID:          "DataModelTypeAnalysis",
-		LogTypes:    []string{"Custom.Log.1"},
+		LogTypes:    []string{"Crowdstrike.DNSRequest"},
 		Mappings: []models.DataModelMapping{
 			{
 				Name: "source_ip",
@@ -142,7 +142,7 @@ var (
 		Description: "Example LogType Schema",
 		Enabled:     true,
 		ID:          "SecondDataModelTypeAnalysis",
-		LogTypes:    []string{"Custom.Log.2"},
+		LogTypes:    []string{"Crowdstrike.NetworkConnect"},
 		Mappings: []models.DataModelMapping{
 			{
 				Name: "source_ip",
@@ -155,7 +155,7 @@ var (
 		Description: "Example LogType Schema",
 		Enabled:     false,
 		ID:          "ThirdDataModelTypeAnalysis",
-		LogTypes:    []string{"Custom.Log.2"},
+		LogTypes:    []string{"Crowdstrike.NetworkConnect"},
 		Mappings: []models.DataModelMapping{
 			{
 				Name: "source_ip",
@@ -1321,7 +1321,7 @@ func createDataModel(t *testing.T) {
 			Description: "Example LogType Schema",
 			Enabled:     true,
 			ID:          "AnotherDataModelTypeAnalysis",
-			LogTypes:    []string{"Custom.Log.1"},
+			LogTypes:    []string{"Crowdstrike.DNSRequest"},
 			Mappings:    []models.DataModelMapping{},
 		},
 	}
@@ -2992,6 +2992,27 @@ func pollPacks(t *testing.T) {
 		Packs: []models.Pack{
 			*packOriginalReleaseStandardSet,
 			*packOriginalRelease,
+		},
+	}
+	assert.Equal(t, expected, result)
+	assert.NoError(t, err)
+	// test name contains filter
+	input = models.LambdaInput{
+		ListPacks: &models.ListPacksInput{
+			NameContains: "standard",
+		},
+	}
+	statusCode, err = apiClient.Invoke(&input, &result)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	expected = models.ListPacksOutput{
+		Paging: models.Paging{
+			ThisPage:   1,
+			TotalItems: 1,
+			TotalPages: 1,
+		},
+		Packs: []models.Pack{
+			*packOriginalReleaseStandardSet,
 		},
 	}
 	assert.Equal(t, expected, result)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -126,7 +126,7 @@ func (c *Client) GetReleaseTagName(cxt context.Context, githubConfig Config, ver
 	if err != nil {
 		return "", err
 	}
-	return *release.TagName, nil
+	return aws.StringValue(release.TagName), nil
 }
 
 func downloadGithubAsset(cxt context.Context, client *Client, owner string,


### PR DESCRIPTION
## Background

A few issues/items arose in testing:
1. `nameContains` filter wasn't working: added missing ddb columns for lowerid and lowername
2.  Added some guardrails around values returned from github api
3.  `PatchPack`: update and enabled should not be allowed in a single operation.  
4. `PollPack` will now add but _disable_ new detections in a pack

## Changes

- `nameContains` : added missing ddb columns for lowerid and lowername
- wrapped values in `aws.StringValue` and `aws.BoolValue`
- `PatchPack`: Separate out the enabled status update and the version update into two separate operations. This simplified some of the detection update logic
- `PollPack`: will now add but _disable_ new detections in a pack (vs not adding them at all)

## Testing

- `mage test:integration`
- `mage test:go`
- manual testing:

<details>

<summary> if a user disables a pack, it disables all the detections in the pack unless those detections are in another enabled pack. </summary>

Initial state:

```
- Sample.Pack.ID.Two: 
    - detections: AWS.CloudTrail.Created
    - enabled: true
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: true
- AWS.CloudTrail.Created: enabled
- AWS.Console.LoginFailed: enabled
- AWS.LoginWithoutMFA: enabled
```
-> disable `sample.pack.id`

new state:

```
- Sample.Pack.ID.Two: 
    - detections: AWS.CloudTrail.Created
    - enabled: true
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: false
- AWS.CloudTrail.Created: enabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
```

-> disable `sample.pack.id.two`

new state:

```
- Sample.Pack.ID.Two: 
    - detections: AWS.CloudTrail.Created
    - enabled: false
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: false
- AWS.CloudTrail.Created: disabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
```

</details>

<details>

<summary> if a user enables a pack, it enables all the detection in the pack </summary>

Initial State:

```
- AWS.CloudTrail.Created: disabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: false
```

-> enabled `sample.pack.id`

new state:

```
- AWS.CloudTrail.Created: enabled
- AWS.Console.LoginFailed: enabled
- AWS.LoginWithoutMFA: enabled
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: true
```

</details>

<details>

<summary> if a user disables all the detections in a pack one by one (outside of the pack management) - the pack should still be enabled and receive updates </summary>

Initial State:
```
- AWS.CloudTrail.Created: disabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: true
```

-> update `sample.pack.id` version

New state:

```
- AWS.CloudTrail.Created: disabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: true
```

</details>

<details>

<summary> User enables pack, User sees one rule in the pack they don't like, User disables rule they don't like, User gets updates to pack, rule stays disabled. </summary>

Initial state:

```
- AWS.CloudTrail.Created: enabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: true
```

-> update `sample.pack.id`

New State:

```
- AWS.CloudTrail.Created: enabled
- AWS.Console.LoginFailed: disabled
- AWS.LoginWithoutMFA: disabled
- Sample.Pack.ID: 
    - detections: AWS.CloudTrail.Created, AWS.Console.LoginFailed, AWS.LoginWithoutMFA
    - enabled: true
```

</details>
