### PR TITLE
Managed notifications multiple sources same bucket

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -734,7 +734,6 @@ type S3LogIntegration {
   notificationsConfigurationSucceeded: Boolean!
   health: S3LogIntegrationHealth!
   stackName: String!
-  managedS3Resources: ManagedS3Resources
 }
 
 type ManagedS3Resources {

--- a/api/lambda/source/models/integration.go
+++ b/api/lambda/source/models/integration.go
@@ -75,9 +75,6 @@ type SourceIntegrationMetadata struct {
 	LogProcessingRole string           `json:"logProcessingRole,omitempty"`
 	// Whether Panther should configure the user's bucket notifications.
 	ManagedBucketNotifications bool `json:"managedBucketNotifications"`
-	// The resources that Panther created. This may be partial if an error occurred
-	// while creating a resource.
-	ManagedS3Resources ManagedS3Resources `json:"managedS3Resources,omitempty"`
 	// This is only needed for the API response, so that the UI can show a warning message
 	// if Panther couldn't setup bucket notifications. Failing to do so doesn't
 	// block any other source operations like saving to the DB.
@@ -196,7 +193,7 @@ type SourceIntegrationHealth struct {
 	// GetObject check is not available to sources created in Panther<1.16
 	GetObjectStatus *SourceIntegrationItemStatus `json:"getObjectStatus,omitempty"`
 	// BucketNotificationsStatus is the result of checking the bucket's notifications configuration.
-	// It is populated only the log processing role has the s3:GetBucketNotification permission. This is
+	// It is populated only if the log processing role has the s3:GetBucketNotification permission. This is
 	// added to our provided CFN template if user opts for Panther-managed bucket notifications.
 	BucketNotificationsStatus *SourceIntegrationItemStatus `json:"bucketNotificationsStatus,omitempty"`
 

--- a/internal/core/source_api/api/check_integration.go
+++ b/internal/core/source_api/api/check_integration.go
@@ -147,7 +147,7 @@ func checkBucketNotifications(
 		AccountID: input.AWSAccountID,
 		Resource:  "panther-notifications-topic",
 	}.String()
-	// an SNS notification should exist for each one of the prefixes
+	// An SNS notification should exist for each one of the prefixes.
 	prefixes := reduceNoPrefixStrings(input.S3PrefixLogTypes.S3Prefixes())
 	var notFound []string // keep the prefixes which we didn't find notifications for
 	for _, p := range prefixes {
@@ -164,16 +164,14 @@ func checkBucketNotifications(
 				continue
 			}
 
-			// Check filter rules. The prefix should be equal to p. Missing prefix is also fine if p is empty.
-			// Note we can't validate the suffix. User may have added a suffix to further break down which log files
-			// reach Panther.
+			// Check filter rules. The prefix should be an str prefix to p. Missing prefix is also fine if p is empty.
 			rulePrefix := ""
 			for _, r := range c.Filter.Key.FilterRules {
 				if strings.ToLower(aws.StringValue(r.Name)) == "prefix" {
 					rulePrefix = aws.StringValue(r.Value)
 				}
 			}
-			ok = rulePrefix == p
+			ok = strings.HasPrefix(p, rulePrefix)
 			if ok {
 				break
 			}

--- a/internal/core/source_api/api/list_integrations.go
+++ b/internal/core/source_api/api/list_integrations.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/panther-labs/panther/api/lambda/source/models"
+	"github.com/panther-labs/panther/internal/core/source_api/ddb"
 	"github.com/panther-labs/panther/pkg/genericapi"
 )
 
@@ -45,7 +46,7 @@ func (api *API) ListIntegrations(
 			// breaking Panther upgrades. Skip these sources.
 			continue
 		}
-		integ := itemToIntegration(item)
+		integ := ddb.ItemToIntegration(item)
 		// This is required for backwards compatibility
 		// Before https://github.com/panther-labs/panther/issues/2031 , the Compliance sources
 		// didn't have the InputDataBucket and InputDataRoleArn populated

--- a/internal/core/source_api/api/managed_bucket_notifications_test.go
+++ b/internal/core/source_api/api/managed_bucket_notifications_test.go
@@ -32,63 +32,96 @@ var (
 	events = aws.StringSlice([]string{"s3:ObjectCreated:*"})
 )
 
+type sortableTopicConfigs []*s3.TopicConfiguration
+
+func (c sortableTopicConfigs) Len() int           { return len(c) }
+func (c sortableTopicConfigs) Less(i, j int) bool { return *c[i].Id < *c[j].Id }
+func (c sortableTopicConfigs) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+
 func Test_updateTopicConfigs(t *testing.T) {
+	t.Parallel()
+
+	requireEqualSorted := func(t *testing.T, expected, actual []*s3.TopicConfiguration, msgAndArgs ...interface{}) {
+		sort.Sort(sortableTopicConfigs(expected))
+		sort.Sort(sortableTopicConfigs(actual))
+		require.Equal(t, expected, actual, msgAndArgs)
+	}
+
 	t.Run("add to empty configs", func(t *testing.T) {
+		t.Parallel()
 		var bucketTopicConfigs []*s3.TopicConfiguration // bucket hasn't any SNS notifications set up
-		var managedConfigIDs []string                   // Panther hasn't created anything yet
 		prefixes := []string{"prefixa/", "prefixb/"}    // create bucket configs for these prefixes
 
-		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, managedConfigIDs, prefixes, topic)
+		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, prefixes, topic)
 
 		expected := []*s3.TopicConfiguration{
-			topicConfig(events, "prefix", "prefixa/", newManagedConfigIDs[0], topic),
-			topicConfig(events, "prefix", "prefixb/", newManagedConfigIDs[1], topic),
+			topicConfig(newManagedConfigIDs[0], "prefix", "prefixa/", events, topic),
+			topicConfig(newManagedConfigIDs[1], "prefix", "prefixb/", events, topic),
 		}
 
-		require.Equal(t, expected, topicConfigs)
+		requireEqualSorted(t, expected, topicConfigs)
 		require.Len(t, newManagedConfigIDs, 2)
 	})
 
 	t.Run("existing Panther and user configs ", func(t *testing.T) {
+		t.Parallel()
 		bucketTopicConfigs := []*s3.TopicConfiguration{
-			topicConfig(events, "prefix", "userPrefixA/", "id1", topic),
-			topicConfig(events, "prefix", "pantherPrefix/", "id3", topic),
-			topicConfig(events, "prefix", "userPrefixB/", "id2", topic),
+			topicConfig("id1", "prefix", "userPrefixA/", events, topic),
+			topicConfig("panther-managed-123", "prefix", "pantherPrefix/", events, topic),
+			topicConfig("id2", "prefix", "userPrefixB/", events, topic),
 		}
-		managedConfigIDs := []string{"id3"}
 		// Note pantherPrefix from above is missing. These should be the only Panther-managed configs.
 		prefixes := []string{"pantherPrefix1/", "pantherPrefix2/"}
 
-		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, managedConfigIDs, prefixes, topic)
+		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, prefixes, topic)
 
 		expected := []*s3.TopicConfiguration{
-			topicConfig(events, "prefix", "userPrefixA/", "id1", topic),
-			topicConfig(events, "prefix", "userPrefixB/", "id2", topic),
-			topicConfig(events, "prefix", "pantherPrefix1/", newManagedConfigIDs[0], topic),
-			topicConfig(events, "prefix", "pantherPrefix2/", newManagedConfigIDs[1], topic),
+			topicConfig("id1", "prefix", "userPrefixA/", events, topic),
+			topicConfig("id2", "prefix", "userPrefixB/", events, topic),
+			topicConfig(newManagedConfigIDs[0], "prefix", "pantherPrefix1/", events, topic),
+			topicConfig(newManagedConfigIDs[1], "prefix", "pantherPrefix2/", events, topic),
 		}
-		require.Equal(t, expected, topicConfigs)
+		requireEqualSorted(t, expected, topicConfigs)
 		require.Len(t, newManagedConfigIDs, 2)
 	})
 
 	t.Run("remove all Panther-managed configs", func(t *testing.T) {
+		t.Parallel()
 		bucketTopicConfigs := []*s3.TopicConfiguration{
-			topicConfig(events, "prefix", "userPrefixA/", "id1", topic),
-			topicConfig(events, "prefix", "pantherPrefix1/", "panther-managed-1", topic),
-			topicConfig(events, "prefix", "userPrefixB/", "id2", topic),
-			topicConfig(events, "prefix", "pantherPrefix2/", "panther-managed-2", topic),
+			topicConfig("id1", "prefix", "userPrefixA/", events, topic),
+			topicConfig("panther-managed-1", "prefix", "pantherPrefix1/", events, topic),
+			topicConfig("id2", "prefix", "userPrefixB/", events, topic),
+			topicConfig("panther-managed-2", "prefix", "pantherPrefix2/", events, topic),
 		}
-		managedConfigIDs := []string{"panther-managed-1", "panther-managed-2"}
-		prefixes := []string{} // No Panther-managed configs should be kept after the operation
+		var prefixes []string // No Panther-managed configs should be kept after the operation
 
-		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, managedConfigIDs, prefixes, topic)
+		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, prefixes, topic)
 
 		expected := []*s3.TopicConfiguration{
-			topicConfig(events, "prefix", "userPrefixA/", "id1", topic),
-			topicConfig(events, "prefix", "userPrefixB/", "id2", topic),
+			topicConfig("id1", "prefix", "userPrefixA/", events, topic),
+			topicConfig("id2", "prefix", "userPrefixB/", events, topic),
 		}
-		require.Equal(t, expected, topicConfigs)
+		requireEqualSorted(t, expected, topicConfigs)
 		require.Len(t, newManagedConfigIDs, 0)
+	})
+
+	t.Run("override Panther-managed configs", func(t *testing.T) {
+		t.Parallel()
+		bucketTopicConfigs := []*s3.TopicConfiguration{
+			topicConfig("panther-managed-1", "prefix", "aaa", events, topic),
+			topicConfig("panther-managed-2", "prefix", "bbb", events, topic),
+		}
+		// We want to set an empty prefix to the bucket notification. This may happen if a source is updated
+		// or created and has a blank prefix filter.
+		prefixes := []string{""}
+
+		topicConfigs, newManagedConfigIDs := updateTopicConfigs(bucketTopicConfigs, prefixes, topic)
+
+		expected := []*s3.TopicConfiguration{
+			topicConfig(newManagedConfigIDs[0], "prefix", "", events, topic),
+		}
+		requireEqualSorted(t, expected, topicConfigs)
+		require.Len(t, newManagedConfigIDs, 1)
 	})
 }
 
@@ -123,7 +156,7 @@ func Test_reduceNoPrefixes(t *testing.T) {
 	}
 }
 
-func topicConfig(events []*string, filterType, filterValue, id string, topicARN *string) *s3.TopicConfiguration {
+func topicConfig(id, filterType, filterValue string, events []*string, topicARN *string) *s3.TopicConfiguration {
 	return &s3.TopicConfiguration{
 		Events: events,
 		Filter: &s3.NotificationConfigurationFilter{

--- a/internal/core/source_api/api/put_integration.go
+++ b/internal/core/source_api/api/put_integration.go
@@ -96,7 +96,13 @@ func (api *API) PutIntegration(input *models.PutIntegrationInput) (newIntegratio
 }
 
 func (api *API) handleManagedBucketNotifications(source *models.SourceIntegration) {
-	err := ManageBucketNotifications(api.AwsSession, api.Config.AccountID, api.Config.AWSPartition, api.Config.LogProcessorQueueArn, source)
+	panther := pantherDeployment{
+		sess:          api.AwsSession,
+		accountID:     api.Config.AccountID,
+		partition:     api.Config.AWSPartition,
+		inputQueueARN: api.Config.LogProcessorQueueArn,
+	}
+	err := ManageBucketNotifications(api.DdbClient, panther, source)
 	source.NotificationsConfigurationSucceeded = err == nil
 	if err != nil {
 		zap.L().Error("failed to manage bucket notifications", zap.Error(err))

--- a/internal/core/source_api/api/update_integration.go
+++ b/internal/core/source_api/api/update_integration.go
@@ -77,7 +77,7 @@ func (api *API) UpdateIntegrationSettings(input *models.UpdateIntegrationSetting
 		}
 	}
 
-	existingIntegration := itemToIntegration(existingItem)
+	existingIntegration := ddb.ItemToIntegration(existingItem)
 
 	if existingIntegration.IntegrationType == models.IntegrationTypeAWS3 &&
 		existingIntegration.ManagedBucketNotifications {

--- a/internal/core/source_api/api/update_integration_test.go
+++ b/internal/core/source_api/api/update_integration_test.go
@@ -298,7 +298,7 @@ func TestS3PrefixLogTypes_BackwardsCompatibility(t *testing.T) {
 			S3PrefixLogTypes: nil, // new field
 		}
 
-		source := itemToIntegration(sourceItem)
+		source := ddb.ItemToIntegration(sourceItem)
 
 		expected := &models.SourceIntegration{
 			SourceIntegrationMetadata: models.SourceIntegrationMetadata{
@@ -325,7 +325,7 @@ func TestS3PrefixLogTypes_BackwardsCompatibility(t *testing.T) {
 			S3PrefixLogTypes: models.S3PrefixLogtypes{{S3Prefix: "prefix/", LogTypes: []string{"A.LogType"}}},
 		}
 
-		source := itemToIntegration(sourceItem)
+		source := ddb.ItemToIntegration(sourceItem)
 
 		expected := &models.SourceIntegration{
 			SourceIntegrationMetadata: models.SourceIntegrationMetadata{

--- a/internal/core/source_api/api/utils.go
+++ b/internal/core/source_api/api/utils.go
@@ -46,7 +46,6 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		item.StackName = input.StackName
 		item.LogProcessingRole = generateLogProcessingRoleArn(input.AWSAccountID, input.IntegrationLabel)
 		item.ManagedBucketNotifications = input.ManagedBucketNotifications
-		item.ManagedS3Resources = input.ManagedS3Resources
 	case models.IntegrationTypeAWSScan:
 		item.AWSAccountID = input.AWSAccountID
 		item.CWEEnabled = input.CWEEnabled
@@ -75,61 +74,6 @@ func integrationToItem(input *models.SourceIntegration) *ddb.Integration {
 		}
 	}
 	return item
-}
-
-func itemToIntegration(item *ddb.Integration) *models.SourceIntegration {
-	// Initializing the fields common for all integration types
-	integration := &models.SourceIntegration{}
-	integration.IntegrationID = item.IntegrationID
-	integration.IntegrationType = item.IntegrationType
-	integration.IntegrationLabel = item.IntegrationLabel
-	integration.CreatedAtTime = item.CreatedAtTime
-	integration.CreatedBy = item.CreatedBy
-	integration.LastEventReceived = item.LastEventReceived
-	integration.PantherVersion = item.PantherVersion
-	switch item.IntegrationType {
-	case models.IntegrationTypeAWS3:
-		integration.AWSAccountID = item.AWSAccountID
-		integration.S3Bucket = item.S3Bucket
-		integration.S3PrefixLogTypes = item.S3PrefixLogTypes
-		if len(integration.S3PrefixLogTypes) == 0 {
-			// Backwards compatibility: Use the old fields, maybe the info is there.
-			s3prefixLogTypes := models.S3PrefixLogtypesMapping{S3Prefix: item.S3Prefix, LogTypes: item.LogTypes}
-			integration.S3PrefixLogTypes = models.S3PrefixLogtypes{s3prefixLogTypes}
-		}
-		integration.KmsKey = item.KmsKey
-		integration.StackName = item.StackName
-		integration.LogProcessingRole = item.LogProcessingRole
-		integration.ManagedBucketNotifications = item.ManagedBucketNotifications
-		integration.ManagedS3Resources = item.ManagedS3Resources
-	case models.IntegrationTypeAWSScan:
-		integration.AWSAccountID = item.AWSAccountID
-		integration.CWEEnabled = item.CWEEnabled
-		integration.RemediationEnabled = item.RemediationEnabled
-		integration.ScanIntervalMins = item.ScanIntervalMins
-		integration.ScanStatus = item.ScanStatus
-		integration.S3Bucket = item.S3Bucket
-		integration.LogProcessingRole = item.LogProcessingRole
-		integration.EventStatus = item.EventStatus
-		integration.LastScanStartTime = item.LastScanStartTime
-		integration.LastScanEndTime = item.LastScanEndTime
-		integration.LastScanErrorMessage = item.LastScanErrorMessage
-		integration.StackName = item.StackName
-		integration.Enabled = item.Enabled
-		integration.RegionIgnoreList = item.RegionIgnoreList
-		integration.ResourceTypeIgnoreList = item.ResourceTypeIgnoreList
-		integration.ResourceRegexIgnoreList = item.ResourceRegexIgnoreList
-	case models.IntegrationTypeSqs:
-		integration.SqsConfig = &models.SqsConfig{
-			S3Bucket:             item.SqsConfig.S3Bucket,
-			LogProcessingRole:    item.SqsConfig.LogProcessingRole,
-			QueueURL:             item.SqsConfig.QueueURL,
-			LogTypes:             item.SqsConfig.LogTypes,
-			AllowedPrincipalArns: item.SqsConfig.AllowedPrincipalArns,
-			AllowedSourceArns:    item.SqsConfig.AllowedSourceArns,
-		}
-	}
-	return integration
 }
 
 // reduceNoPrefixStrings reduces a list of strings to a list where no string is a prefix of another.

--- a/internal/core/source_api/ddb/items.go
+++ b/internal/core/source_api/ddb/items.go
@@ -54,12 +54,11 @@ type Integration struct {
 	// Deprecated. Use S3PrefixLogTypes. Kept for backwards compatibility. Don't use omitempty to overwrite to empty during writes.
 	S3Prefix string `json:"s3Prefix"`
 	// Deprecated. Use S3PrefixLogTypes. Kept for backwards compatibility.Don't use omitempty to overwrite to empty during writes.
-	LogTypes                   []string                  `json:"logTypes" dynamodbav:",stringset"`
-	KmsKey                     string                    `json:"kmsKey,omitempty"`
-	StackName                  string                    `json:"stackName,omitempty"`
-	LogProcessingRole          string                    `json:"logProcessingRole,omitempty"`
-	ManagedBucketNotifications bool                      `json:"managedBucketNotifications,omitempty"`
-	ManagedS3Resources         models.ManagedS3Resources `json:"managedS3Resources,omitempty"`
+	LogTypes                   []string `json:"logTypes" dynamodbav:",stringset"`
+	KmsKey                     string   `json:"kmsKey,omitempty"`
+	StackName                  string   `json:"stackName,omitempty"`
+	LogProcessingRole          string   `json:"logProcessingRole,omitempty"`
+	ManagedBucketNotifications bool     `json:"managedBucketNotifications,omitempty"`
 
 	SqsConfig *SqsConfig `json:"sqsConfig,omitempty"`
 

--- a/internal/core/source_api/ddb/scan.go
+++ b/internal/core/source_api/ddb/scan.go
@@ -19,10 +19,14 @@ package ddb
  */
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	"github.com/pkg/errors"
+
+	"github.com/panther-labs/panther/api/lambda/source/models"
 )
 
 // ScanIntegrations returns all enabled integrations based on type (if type is specified).
@@ -53,4 +57,93 @@ func (ddb *DDB) ScanIntegrations(integrationType *string) ([]*Integration, error
 	}
 
 	return integrations, nil
+}
+
+func (ddb *DDB) ListS3SourcesWithBucket(ctx context.Context, bucket string) ([]models.SourceIntegration, error) {
+	typeFilter := expression.Name("integrationType").Equal(expression.Value(models.IntegrationTypeAWS3))
+	bucketFilter := expression.Name("s3Bucket").Equal(expression.Value(bucket))
+	expr, err := expression.NewBuilder().WithFilter(typeFilter).WithFilter(bucketFilter).Build()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build filter expression")
+	}
+
+	scanInput := &dynamodb.ScanInput{
+		TableName:                 &ddb.TableName,
+		FilterExpression:          expr.Filter(),
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+	}
+	output, err := ddb.Client.ScanWithContext(ctx, scanInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to scan table")
+	}
+
+	var integrations []*Integration
+	if err := dynamodbattribute.UnmarshalListOfMaps(output.Items, &integrations); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal scan results")
+	}
+
+	result := make([]models.SourceIntegration, 0, len(integrations))
+	for _, item := range integrations {
+		integ := ItemToIntegration(item)
+		result = append(result, *integ)
+	}
+	return result, nil
+}
+
+// Deprecated. This should not be exported but only be used by functions that directly interact with DynamoDB,
+// in the ddb package.
+// These functions should return our domain model `models.SourceIntegration`.
+func ItemToIntegration(item *Integration) *models.SourceIntegration {
+	// Initializing the fields common for all integration types
+	integration := &models.SourceIntegration{}
+	integration.IntegrationID = item.IntegrationID
+	integration.IntegrationType = item.IntegrationType
+	integration.IntegrationLabel = item.IntegrationLabel
+	integration.CreatedAtTime = item.CreatedAtTime
+	integration.CreatedBy = item.CreatedBy
+	integration.LastEventReceived = item.LastEventReceived
+	integration.PantherVersion = item.PantherVersion
+	switch item.IntegrationType {
+	case models.IntegrationTypeAWS3:
+		integration.AWSAccountID = item.AWSAccountID
+		integration.S3Bucket = item.S3Bucket
+		integration.S3PrefixLogTypes = item.S3PrefixLogTypes
+		if len(integration.S3PrefixLogTypes) == 0 {
+			// Backwards compatibility: Use the old fields, maybe the info is there.
+			s3prefixLogTypes := models.S3PrefixLogtypesMapping{S3Prefix: item.S3Prefix, LogTypes: item.LogTypes}
+			integration.S3PrefixLogTypes = models.S3PrefixLogtypes{s3prefixLogTypes}
+		}
+		integration.KmsKey = item.KmsKey
+		integration.StackName = item.StackName
+		integration.LogProcessingRole = item.LogProcessingRole
+		integration.ManagedBucketNotifications = item.ManagedBucketNotifications
+	case models.IntegrationTypeAWSScan:
+		integration.AWSAccountID = item.AWSAccountID
+		integration.CWEEnabled = item.CWEEnabled
+		integration.RemediationEnabled = item.RemediationEnabled
+		integration.ScanIntervalMins = item.ScanIntervalMins
+		integration.ScanStatus = item.ScanStatus
+		integration.S3Bucket = item.S3Bucket
+		integration.LogProcessingRole = item.LogProcessingRole
+		integration.EventStatus = item.EventStatus
+		integration.LastScanStartTime = item.LastScanStartTime
+		integration.LastScanEndTime = item.LastScanEndTime
+		integration.LastScanErrorMessage = item.LastScanErrorMessage
+		integration.StackName = item.StackName
+		integration.Enabled = item.Enabled
+		integration.RegionIgnoreList = item.RegionIgnoreList
+		integration.ResourceTypeIgnoreList = item.ResourceTypeIgnoreList
+		integration.ResourceRegexIgnoreList = item.ResourceRegexIgnoreList
+	case models.IntegrationTypeSqs:
+		integration.SqsConfig = &models.SqsConfig{
+			S3Bucket:             item.SqsConfig.S3Bucket,
+			LogProcessingRole:    item.SqsConfig.LogProcessingRole,
+			QueueURL:             item.SqsConfig.QueueURL,
+			LogTypes:             item.SqsConfig.LogTypes,
+			AllowedPrincipalArns: item.SqsConfig.AllowedPrincipalArns,
+			AllowedSourceArns:    item.SqsConfig.AllowedSourceArns,
+		}
+	}
+	return integration
 }

--- a/web/__generated__/schema.tsx
+++ b/web/__generated__/schema.tsx
@@ -1381,7 +1381,6 @@ export type S3LogIntegration = {
   notificationsConfigurationSucceeded: Scalars['Boolean'];
   health: S3LogIntegrationHealth;
   stackName: Scalars['String'];
-  managedS3Resources?: Maybe<ManagedS3Resources>;
 };
 
 export type S3LogIntegrationHealth = {
@@ -1843,7 +1842,6 @@ export type ResolversTypes = {
   S3LogIntegration: ResolverTypeWrapper<S3LogIntegration>;
   S3PrefixLogTypes: ResolverTypeWrapper<S3PrefixLogTypes>;
   S3LogIntegrationHealth: ResolverTypeWrapper<S3LogIntegrationHealth>;
-  ManagedS3Resources: ResolverTypeWrapper<ManagedS3Resources>;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   SqsLogSourceIntegration: ResolverTypeWrapper<SqsLogSourceIntegration>;
   SqsConfig: ResolverTypeWrapper<SqsConfig>;
@@ -1961,6 +1959,7 @@ export type ResolversTypes = {
   FloatSeries: ResolverTypeWrapper<FloatSeries>;
   Float: ResolverTypeWrapper<Scalars['Float']>;
   FloatSeriesData: ResolverTypeWrapper<FloatSeriesData>;
+  ManagedS3Resources: ResolverTypeWrapper<ManagedS3Resources>;
   ListPoliciesSortFieldsEnum: ListPoliciesSortFieldsEnum;
   ListRulesSortFieldsEnum: ListRulesSortFieldsEnum;
   AccountTypeEnum: AccountTypeEnum;
@@ -2035,7 +2034,6 @@ export type ResolversParentTypes = {
   S3LogIntegration: S3LogIntegration;
   S3PrefixLogTypes: S3PrefixLogTypes;
   S3LogIntegrationHealth: S3LogIntegrationHealth;
-  ManagedS3Resources: ManagedS3Resources;
   GetS3LogIntegrationTemplateInput: GetS3LogIntegrationTemplateInput;
   SqsLogSourceIntegration: SqsLogSourceIntegration;
   SqsConfig: SqsConfig;
@@ -2155,6 +2153,7 @@ export type ResolversParentTypes = {
   FloatSeries: FloatSeries;
   Float: Scalars['Float'];
   FloatSeriesData: FloatSeriesData;
+  ManagedS3Resources: ManagedS3Resources;
   ListPoliciesSortFieldsEnum: ListPoliciesSortFieldsEnum;
   ListRulesSortFieldsEnum: ListRulesSortFieldsEnum;
   AccountTypeEnum: AccountTypeEnum;
@@ -3429,11 +3428,6 @@ export type S3LogIntegrationResolvers<
   >;
   health?: Resolver<ResolversTypes['S3LogIntegrationHealth'], ParentType, ContextType>;
   stackName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  managedS3Resources?: Resolver<
-    Maybe<ResolversTypes['ManagedS3Resources']>,
-    ParentType,
-    ContextType
-  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/web/__tests__/__mocks__/builders.generated.ts
+++ b/web/__tests__/__mocks__/builders.generated.ts
@@ -1589,8 +1589,6 @@ export const buildS3LogIntegration = (
         : true,
     health: 'health' in overrides ? overrides.health : buildS3LogIntegrationHealth(),
     stackName: 'stackName' in overrides ? overrides.stackName : 'River',
-    managedS3Resources:
-      'managedS3Resources' in overrides ? overrides.managedS3Resources : buildManagedS3Resources(),
   };
 };
 

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.generated.ts
@@ -45,7 +45,6 @@ export type S3LogIntegrationDetails = Pick<
     getObjectStatus?: Types.Maybe<IntegrationItemHealthDetails>;
     bucketNotificationsStatus?: Types.Maybe<IntegrationItemHealthDetails>;
   };
-  managedS3Resources?: Types.Maybe<Pick<Types.ManagedS3Resources, 'topicARN'>>;
 };
 
 export const S3LogIntegrationDetails = gql`
@@ -82,9 +81,6 @@ export const S3LogIntegrationDetails = gql`
       bucketNotificationsStatus {
         ...IntegrationItemHealthDetails
       }
-    }
-    managedS3Resources {
-      topicARN
     }
   }
   ${IntegrationItemHealthDetails}

--- a/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
+++ b/web/src/graphql/fragments/S3LogIntegrationDetails.graphql
@@ -32,7 +32,4 @@ fragment S3LogIntegrationDetails on S3LogIntegration {
       ...IntegrationItemHealthDetails
     }
   }
-  managedS3Resources {
-    topicARN
-  }
 }

--- a/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
+++ b/web/src/pages/ListLogSources/LogSourceCards/LogSourceCardOptions.tsx
@@ -46,9 +46,6 @@ const LogSourceCardOptions: React.FC<LogSourceCardOptionsProps> = ({ source }) =
     default:
       castedSource = source as S3LogIntegration;
       description = `Deleting this source will not delete the associated Cloudformation stack. You will need to manually delete the stack ${castedSource.stackName} from the AWS Account ${castedSource.awsAccountId}`;
-      if (castedSource.managedS3Resources?.topicARN) {
-        description += `. The SNS topic created by Panther will also be kept (${castedSource.managedS3Resources.topicARN})`;
-      }
       logSourceEditUrl = urls.integrations.logSources.edit(source.integrationId, 's3');
   }
 


### PR DESCRIPTION
## Background

The Panther notifications feature didn't really account for multiple s3 sources for the same bucket. This scenario
would make the feature unusable if some s3 sources would have the same bucket and overlapping prefixes.

Although this might not seem a common scenario, it is currently allowed and we should support it.

## Changes

- The code that configures bucket notifications now takes into account the s3 prefixes for all the saved sources with the same bucket.
- Don't save the created notifications or the created SNS topic in the db anymore. Assume that a notification is managed by Panther if its name starts with `panther-managed-`
- The healthcheck now becomes green if the prefix defined for a notification is a string prefix of the source's prefix (i.e. we don't require exact equality)

## Testing

- Preexisting unit tests
- Manual QA:
    - Create 3 sources with overlapping prefixes and check bucket notifications
    - Add more prefixes to a source, check bucket notifications
    - Delete the sources one by one, checking bucket notifications in the process

Closes https://app.asana.com/0/1199961111326839/1199961165787232
