### PR TITLE
Fixing integration tests

### DIFF
--- a/internal/core/metrics_api/api/log_processor_metrics.go
+++ b/internal/core/metrics_api/api/log_processor_metrics.go
@@ -37,14 +37,14 @@ func getEventsProcessed(input *models.GetMetricsInput, output *models.GetMetrics
 	// First determine applicable metric dimensions
 	var listMetricsResponse []*cloudwatch.Metric
 	err := cloudwatchClient.ListMetricsPages(&cloudwatch.ListMetricsInput{
-		MetricName: aws.String(logmetrics.MetricLogProcessorEventLatency),
+		MetricName: aws.String(logmetrics.MetricLogProcessorEventsProcessed),
 		Namespace:  aws.String(input.Namespace),
 	}, func(page *cloudwatch.ListMetricsOutput, _ bool) bool {
 		listMetricsResponse = append(listMetricsResponse, page.Metrics...)
 		return true
 	})
 	if err != nil {
-		zap.L().Error("unable to list metrics", zap.String("metric", logmetrics.MetricLogProcessorEventLatency), zap.Error(err))
+		zap.L().Error("unable to list metrics", zap.String("metric", logmetrics.MetricLogProcessorEventsProcessed), zap.Error(err))
 		return metricsInternalError
 	}
 	zap.L().Debug("found applicable metrics", zap.Any("metrics", listMetricsResponse))


### PR DESCRIPTION
## Background

Integration tests were failing - and for a good reason. This PR fixes the issue

## Changes

- Fix metrics issue

## Testing

- mage test:integration

```
]$ mage test:integration
13:30:19	WARN	[test:integration]	Integration tests will erase all Panther data in account 123456789012 (eu-central-1)
Are you sure you want to continue? (yes|no) yes
ok  	github.com/panther-labs/panther/api/lambda/source/models	0.010s [no tests to run]
ok  	github.com/panther-labs/panther/cmd/opstools/requeue	21.992s
ok  	github.com/panther-labs/panther/cmd/opstools/s3queue	3.332s
ok  	github.com/panther-labs/panther/cmd/opstools/s3sns	1.425s
ok  	github.com/panther-labs/panther/internal/compliance/compliance_api/main	1.468s
ok  	github.com/panther-labs/panther/internal/compliance/resources_api/main	1.939s
ok  	github.com/panther-labs/panther/internal/core/analysis_api/main	13.344s
ok  	github.com/panther-labs/panther/internal/core/layer_manager/main	41.377s
ok  	github.com/panther-labs/panther/internal/core/metrics_api/main	61.384s
ok  	github.com/panther-labs/panther/internal/core/organization_api/main	1.898s
ok  	github.com/panther-labs/panther/internal/core/outputs_api/main	1.768s
ok  	github.com/panther-labs/panther/internal/core/source_api/main	0.192s
ok  	github.com/panther-labs/panther/internal/core/users_api/main	3.395s
ok  	github.com/panther-labs/panther/internal/log_analysis/awsglue	7.957s
^[ok  	github.com/panther-labs/panther/pkg/awsathena	66.411s
13:35:25	INFO	[test:integration]	test:integration: python policy engine
.
----------------------------------------------------------------------
Ran 1 test in 1.049s

OK
```