### PR TITLE
Fix bug in cloud security scanning when a region ignore list is configured

### DIFF
--- a/internal/compliance/snapshot_poller/pollers/aws/cloudtrail.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/cloudtrail.go
@@ -247,6 +247,11 @@ func PollCloudTrails(pollerInput *awsmodels.ResourcePollerInput) (
 		zap.L().Debug("building CloudTrail snapshots", zap.String("region", *regionID))
 		cloudTrailSvc, err := getCloudTrailClient(pollerInput, *regionID)
 		if err != nil {
+			var e *RegionIgnoreListError
+			if errors.As(err, &e) {
+				zap.L().Debug("Skipping denied region in CloudTrail scan")
+				continue
+			}
 			return nil, nil, err
 		}
 

--- a/internal/compliance/snapshot_poller/pollers/aws/configservice.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/configservice.go
@@ -185,6 +185,11 @@ func PollConfigServices(pollerInput *awsmodels.ResourcePollerInput) ([]apimodels
 		zap.L().Debug("building Config snapshots", zap.String("region", *regionID))
 		configServiceSvc, err := getConfigServiceClient(pollerInput, *regionID)
 		if err != nil {
+			var e *RegionIgnoreListError
+			if errors.As(err, &e) {
+				zap.L().Debug("Skipping denied region in Config scan")
+				continue
+			}
 			return nil, nil, err
 		}
 

--- a/internal/compliance/snapshot_poller/pollers/aws/guardduty_detector.go
+++ b/internal/compliance/snapshot_poller/pollers/aws/guardduty_detector.go
@@ -186,6 +186,11 @@ func PollGuardDutyDetectors(pollerInput *awsmodels.ResourcePollerInput) ([]apimo
 	for _, regionID := range regions {
 		guardDutySvc, err := getGuardDutyClient(pollerInput, *regionID)
 		if err != nil {
+			var e *RegionIgnoreListError
+			if errors.As(err, &e) {
+				zap.L().Debug("Skipping denied region in GuardDuty scan")
+				continue
+			}
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
## Background

@s0l0ist reported a bug found in dogfooding/release testing. We were actually tracking this bug already, but did not realize it would affect the release so strongly.

The bug is that if a user configures a region ignore list for a cloud security scan, we will fail to scan all cloudtrails, guard dutys, and config recorders in the account (and log an error) because we use the same region deny list code for generating generic clients. For the other scanners this situation gets handled higher up in the stack, but these three scanners behave slightly differently because they scan all regions for each scan, not just the region requested.

I'm tagging `sync-to-release` since this will affect every user of cloud security that configures region ignore lists, and @s0l0ist said it should be in 1.16.

## Changes

- Added region denied error handling to cloudtrail, guardduty, and config polllers

## Testing

- Dev deployment going up now
