### PR TITLE
Fix resources-table scanning bug

### DIFF
--- a/internal/compliance/resources_api/handlers/dynamo.go
+++ b/internal/compliance/resources_api/handlers/dynamo.go
@@ -143,7 +143,7 @@ func scanPages(inputs []*dynamodb.ScanInput, includeCompliance bool,
 				for _, entry := range items {
 					if !includeCompliance {
 						segmentResources = append(segmentResources, entry.Resource(""))
-						return true
+						continue
 					}
 
 					var status *complianceStatus
@@ -190,6 +190,7 @@ func scanPages(inputs []*dynamodb.ScanInput, includeCompliance bool,
 	var mergedResources []models.Resource
 	for range inputs {
 		result := <-results
+		zap.L().Debug("received scan segment results", zap.Any("results", len(result.resources)), zap.Error(result.err))
 		if result.err != nil {
 			err = result.err
 			continue


### PR DESCRIPTION
## Background

In a recentish [PR](https://github.com/panther-labs/panther/pull/2623) I added parallel scanning of the `panther-resources` table. I had spot checked it to make sure it didn't break any existing functionality, but did not do a thorough enough job as @jacknagz found that in some cases when listing resources only a fraction of the resources were being returned.

It turns out that when moving the serial table scanning to parallel table scanning, I did not convert some of the logic properly and so we ended up only taking the first resource on each page of results returned by dynamo in cases where we did not need to include the compliance status of the resource. As far as I can tell, this only occurs when a user updates a policy and it needs to be evaluated against all current resources.

## Changes

- Return all the results instead of just the first result of each page of resources returned by dynamo
- Refactor just a smidge to save ourselves from doing thousands of uneccessary conditional checks. Basically we had one for loop that had two if statements in it, but those if statements were based on variables that didn't change on each iteration of the loop. So instead of one for loop with with two if statements in it, I made two if statements each with a for loop inside them. A bit of repeated code, but if we're scanning a table with 50,000 resources in it we save 49,999 if statement checks. Now I'm sure the processor is branch predicting that with 100% accuracy so if we prefer the other way I can revert, in which case this PR becomes a one line code change. 

## Testing

- Deployed to dev environment and verified the change by looking at the CloudWatch log groups
- Ran unit tests
- Ran integration tests
