### PR TITLE
Allow CloudTrail notifications to process

### DIFF
--- a/internal/log_analysis/log_processor/common/common.go
+++ b/internal/log_analysis/log_processor/common/common.go
@@ -86,9 +86,9 @@ func Setup() {
 
 // DataStream represents a data stream for an s3 object read by the processor
 type DataStream struct {
-	Stream       logstream.Stream
-	Closer       io.Closer
-	Source       *models.SourceIntegration
-	S3ObjectKey  string
-	S3Bucket     string
+	Stream      logstream.Stream
+	Closer      io.Closer
+	Source      *models.SourceIntegration
+	S3ObjectKey string
+	S3Bucket    string
 }

--- a/internal/log_analysis/log_processor/common/common.go
+++ b/internal/log_analysis/log_processor/common/common.go
@@ -91,5 +91,4 @@ type DataStream struct {
 	Source       *models.SourceIntegration
 	S3ObjectKey  string
 	S3Bucket     string
-	S3ObjectSize int64
 }

--- a/internal/log_analysis/log_processor/processor/processor.go
+++ b/internal/log_analysis/log_processor/processor/processor.go
@@ -212,7 +212,6 @@ func (p *Processor) run(ctx context.Context, outputChan chan<- *parsers.Result) 
 			// s3 dim info
 			zap.String("bucket", p.input.S3Bucket),
 			zap.String("key", p.input.S3ObjectKey),
-			zap.Int64("size", p.input.S3ObjectSize),
 			zap.String("sourceID", p.input.Source.IntegrationID),
 		)
 	}()

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -226,8 +226,9 @@ func parseCloudTrailNotification(message string) (result []*S3ObjectInfo) {
 
 	for _, s3Key := range cloudTrailNotification.S3ObjectKey {
 		info := &S3ObjectInfo{
-			S3Bucket:    *cloudTrailNotification.S3Bucket,
-			S3ObjectKey: *s3Key,
+			S3Bucket:     *cloudTrailNotification.S3Bucket,
+			S3ObjectKey:  *s3Key,
+			S3ObjectSize: 1,
 		}
 		result = append(result, info)
 	}

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -168,11 +168,11 @@ func buildStream(ctx context.Context, s3Object *S3ObjectInfo) (*common.DataStrea
 	}
 
 	return &common.DataStream{
-		Stream:       stream,
-		Closer:       r,
-		Source:       src,
-		S3Bucket:     s3Object.S3Bucket,
-		S3ObjectKey:  s3Object.S3ObjectKey,
+		Stream:      stream,
+		Closer:      r,
+		Source:      src,
+		S3Bucket:    s3Object.S3Bucket,
+		S3ObjectKey: s3Object.S3ObjectKey,
 	}, nil
 }
 
@@ -290,8 +290,8 @@ type cloudTrailNotification struct {
 
 // S3ObjectInfo contains information about the S3 object
 type S3ObjectInfo struct {
-	S3Bucket     string
-	S3ObjectKey  string
+	S3Bucket    string
+	S3ObjectKey string
 	// In case the size is not known, this will have a negative value
 	S3ObjectSize int64
 }

--- a/internal/log_analysis/log_processor/sources/s3.go
+++ b/internal/log_analysis/log_processor/sources/s3.go
@@ -173,7 +173,6 @@ func buildStream(ctx context.Context, s3Object *S3ObjectInfo) (*common.DataStrea
 		Source:       src,
 		S3Bucket:     s3Object.S3Bucket,
 		S3ObjectKey:  s3Object.S3ObjectKey,
-		S3ObjectSize: s3Object.S3ObjectSize,
 	}, nil
 }
 
@@ -293,6 +292,7 @@ type cloudTrailNotification struct {
 type S3ObjectInfo struct {
 	S3Bucket     string
 	S3ObjectKey  string
+	// In case the size is not known, this will have a negative value
 	S3ObjectSize int64
 }
 

--- a/internal/log_analysis/log_processor/sources/s3_test.go
+++ b/internal/log_analysis/log_processor/sources/s3_test.go
@@ -42,12 +42,14 @@ func TestParseCloudTrailNotification(t *testing.T) {
 	notification := "{\"s3Bucket\": \"testbucket\", \"s3ObjectKey\": [\"key1\",\"key2\"]}"
 	expectedOutput := []*S3ObjectInfo{
 		{
-			S3Bucket:    "testbucket",
-			S3ObjectKey: "key1",
+			S3Bucket:     "testbucket",
+			S3ObjectKey:  "key1",
+			S3ObjectSize: -1,
 		},
 		{
-			S3Bucket:    "testbucket",
-			S3ObjectKey: "key2",
+			S3Bucket:     "testbucket",
+			S3ObjectKey:  "key2",
+			S3ObjectSize: -1,
 		},
 	}
 	s3Objects, err := ParseNotification(notification)


### PR DESCRIPTION
## References

Asana Task URL: https://app.asana.com/0/1199942399745175/1200013141331018

## Background

A recent PR has us ignore s3 event notifications if they have a file size of zero. These files cause us to log errors during processing, and there's no value in processing an empty file anyways so it saves us time and pages.

For CloudTrail logs, instead of configuring S3 event notifications to send to SNS when new objects are written to S3 you can configure the CloudTrail service itself to directly deliver notifications of new data to SNS. This is for some reason I can't remember better than just relying on s3 event notifications directly (more efficient maybe because it groups the s3 keys?). When we process CloudTrail -> SNS notifications, we internally convert them to look like an S3 event notification. When we do this conversion, we don't specify a file size. This was causing all CloudTrail notifications to be discarded as empty files. This PR simply changes the object size to 1 during this conversion so they don't get discarded.

I'm not sure if this will have downstream impacts on processing, where we made certain assumptions if the file size was 0 or if the file size is used in some other calculations somewhere when its non-zero. If so, we could instead add a `IsCloudTrailNotification` flag to our internal s3 event notification struct and use that to not exclude empty s3 objects when set. This would be more explicit, and with less lies. But it would also mean a bigger code change.

## Changes

- Change CloudTrail notification object sizes to 1

## Testing

- Unit tests
- I intend to do a fresh deploy into my dev account without this fix, onboard a CloudTrail s3 source that uses CloudTrail to publish notifications, deploy this update, and verify it's working E2E. This is in progress, I don't want to merge this PR until that's been completed (had to upgrade go to 1.16 so I'm still waiting for that to complete)